### PR TITLE
Install Vercel Speed Insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/manrope": "^5.2.8",
     "@fontsource-variable/outfit": "^5.2.8",
+    "@vercel/speed-insights": "^2.0.0",
     "astro": "6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@fontsource-variable/outfit':
         specifier: ^5.2.8
         version: 5.2.8
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(react@19.2.4)
       astro:
         specifier: 6.0.0
         version: 6.0.0(@netlify/blobs@10.7.2)(@types/node@22.19.7)(@vercel/functions@3.4.3)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(typescript@5.9.3)(yaml@2.8.2)
@@ -1573,6 +1576,32 @@ packages:
 
   '@vercel/routing-utils@5.3.3':
     resolution: {integrity: sha512-KYm2sLNUD48gDScv8ob4ejc3Gww2jcJyW80hTdYlenAPz/5BQar1Gyh38xrUuZ532TUwSb5mV1uRbAuiykq0EQ==}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react@5.1.4':
     resolution: {integrity: sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==}
@@ -6855,6 +6884,10 @@ snapshots:
       path-to-regexp-updated: path-to-regexp@6.3.0
     optionalDependencies:
       ajv: 6.12.6
+
+  '@vercel/speed-insights@2.0.0(react@19.2.4)':
+    optionalDependencies:
+      react: 19.2.4
 
   '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
     dependencies:

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ import JsonLd from '@/components/seo/JsonLd.astro';
 import Analytics from '@/components/layout/Analytics.astro';
 import ConsentBanner from '@/components/ui/overlay/ConsentBanner';
 import { ClientRouter } from 'astro:transitions';
+import SpeedInsights from '@vercel/speed-insights/astro';
 import { createWebsiteSchema, createOrganizationSchema, createPersonSchema, createProfessionalServiceSchema } from '@/lib/schema';
 import type { WebSite, Organization, Person, WithContext } from 'schema-dts';
 import siteConfig from '@/config/site.config';
@@ -84,6 +85,9 @@ if (includeProfessionalServiceSchema) {
 
     <!-- Analytics (loads if PUBLIC_GA_MEASUREMENT_ID or PUBLIC_GTM_ID is set) -->
     <Analytics />
+
+    <!-- Vercel Speed Insights -->
+    <SpeedInsights />
 
     <!-- Client-side routing for view transitions -->
     <ClientRouter />


### PR DESCRIPTION
## Vercel Speed Insights Integration

Successfully installed and configured Vercel Speed Insights for this Astro project.

### Changes Made

**1. Installed Package:**
- Added `@vercel/speed-insights` v2.0.0 to dependencies in package.json
- Updated pnpm-lock.yaml with the new dependency

**2. Configured Integration:**
- Modified `src/layouts/BaseLayout.astro`:
  - Added import: `import SpeedInsights from '@vercel/speed-insights/astro'`
  - Added the `<SpeedInsights />` component in the `<head>` section, right after Analytics and before ClientRouter

### Implementation Details

- **Framework:** Astro 6.0.0
- **Package Manager:** pnpm
- **Integration Method:** Used the official `@vercel/speed-insights/astro` export
- **Placement:** Added to BaseLayout.astro which is the root layout for all pages

The Speed Insights component is now integrated into the base layout, which means it will automatically track performance metrics on all pages that use this layout (which appears to be all pages in the project).

### Verification

- ✅ Package installed successfully
- ✅ Build completed without errors
- ✅ Component properly integrated following Astro best practices
- ✅ Follows the framework-specific integration pattern from Vercel documentation

### Next Steps

After deploying to Vercel:
1. Enable Speed Insights in your Vercel dashboard (Project Settings → Speed Insights)
2. Deploy the project to production
3. Speed Insights data will begin appearing in the Vercel dashboard after user visits

### Notes

The implementation follows the official Vercel Speed Insights pattern for Astro projects, using the dedicated `/astro` export path that provides first-class Astro component support. The component was placed in the base layout's `<head>` section to ensure consistent tracking across all pages while maintaining the existing code structure and patterns.