### PR TITLE
Prepare for public release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [1.0.0] — 2026-04-04
+
+Initial public release of Astro Rocket.
+
+### Added
+
+- Production-ready Astro 6 starter theme built on Tailwind CSS v4 and TypeScript
+- 57 UI and pattern components (buttons, forms, cards, badges, inputs, selects, etc.)
+- 12 live colour themes (Orange, Amber, Lime, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, Purple, Magenta) switchable at runtime without a rebuild
+- Full blog with MDX support, syntax highlighting (Shiki), and RSS feed
+- Auto-generated SVG favicon and monogram logo badge from `site.config.ts`
+- Unified `Icon` component via Iconify (350+ Lucide icons + 3000+ Simple Icons)
+- Animated typing effect in hero section
+- Contact form with Zod validation, honeypot bot detection, and Resend integration
+- Newsletter signup form with Resend Audiences integration
+- Cookie consent banner with Google Consent Mode v2 support
+- Google Analytics 4 and Google Tag Manager integration (consent-aware)
+- Built-in SEO layer: JSON-LD structured data, Open Graph, sitemap, robots.txt
+- Dark mode via `sessionStorage` (resets to dark on each new session)
+- Search powered by Pagefind
+- Multiple deployment targets: Vercel, Netlify, Cloudflare Pages
+- Security headers configured for all deployment targets
+- GitHub Actions CI/CD workflow (lint, type-check, build)
+- Vitest unit tests for API endpoint validation schemas
+
+### Changed (from Velocity)
+
+- Forked and extended [Velocity](https://github.com/southwellmedia/velocity) by Southwell Media
+- Added theme switching, 12 colour themes, typed logo badge, auto favicon
+- Replaced localStorage with sessionStorage for dark mode preference
+- Added blog image gradients that update with the active theme
+- Upgraded icon system to Iconify
+- Targeted at complete, ready-to-launch sites rather than a bare boilerplate

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/hansmartens68/Rocket-Theme"
+    "url": "https://github.com/hansmartens68/astro-rocket"
   },
-  "homepage": "https://github.com/hansmartens68/Rocket-Theme#readme",
+  "homepage": "https://github.com/hansmartens68/astro-rocket#readme",
   "bugs": {
-    "url": "https://github.com/hansmartens68/Rocket-Theme/issues"
+    "url": "https://github.com/hansmartens68/astro-rocket/issues"
   },
   "scripts": {
     "dev": "astro dev",
@@ -80,7 +80,8 @@
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.18.0",
-    "vitest": "^3.2.0"
+    "vitest": "^3.2.0",
+    "zod": "^4.0.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       vitest:
         specifier: ^3.2.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
 
 packages:
 

--- a/post_to_bluesky.py
+++ b/post_to_bluesky.py
@@ -1,54 +1,45 @@
 """
-Post 4 blog posts to Bluesky with images and hashtags.
+Post blog posts to Bluesky with images and hashtags.
 Usage: python3 post_to_bluesky.py
 
 Requires:
   pip install cairosvg atproto
 
-Set credentials via environment variables or edit the constants below.
+Set credentials via environment variables:
+  BSKY_HANDLE       — your Bluesky handle (e.g. yourname.bsky.social)
+  BSKY_APP_PASSWORD — your Bluesky app password (create one at bsky.app/settings)
+  SITE_BASE_URL     — your blog's base URL (e.g. https://yoursite.com/blog/en)
+
+Customize the `posts` list below with your own blog posts before running.
 """
 
 import os
+import sys
 import cairosvg
 from atproto import Client, models
 
-HANDLE = os.getenv("BSKY_HANDLE", "hansmartens-online.bsky.social")
-APP_PASSWORD = os.getenv("BSKY_APP_PASSWORD", "YOUR_APP_PASSWORD_HERE")
-BASE_URL = "https://hansmartens.dev/blog/en"
+HANDLE = os.getenv("BSKY_HANDLE")
+APP_PASSWORD = os.getenv("BSKY_APP_PASSWORD")
+BASE_URL = os.getenv("SITE_BASE_URL")
+
+if not HANDLE or not APP_PASSWORD or not BASE_URL:
+    print("Error: BSKY_HANDLE, BSKY_APP_PASSWORD, and SITE_BASE_URL must all be set as environment variables.")
+    sys.exit(1)
 
 # Adjust this path to wherever your project lives
 ASSETS = os.path.join(os.path.dirname(__file__), "src/assets/blog")
 
+# ---- Customize this list with your own blog posts ----
 posts = [
-    {
-        "slug": "using-claude-ai-for-web-design-and-development",
-        "title": "How I Use Claude AI for Web Design and Development",
-        "description": "Discover how I use Claude AI to build faster, better websites — what it can do, which model to pick, and the difference between Claude Sonnet and Opus.",
-        "image": f"{ASSETS}/claude-ai-web-design.svg",
-        "hashtags": ["AI", "Claude", "WebDevelopment", "WebDesign", "Productivity"],
-    },
-    {
-        "slug": "why-i-build-with-astro",
-        "title": "Why I Build Every Website with Astro",
-        "description": "I'm genuinely enthusiastic about Astro — here's why I chose it, how it works, and why I use it for every website I build.",
-        "image": f"{ASSETS}/why-i-build-with-astro-v3.svg",
-        "hashtags": ["Astro", "WebDevelopment", "Performance", "StaticSites"],
-    },
-    {
-        "slug": "domain-email-vercel-setup",
-        "title": "How I Set Up My Domain, Email, and Hosting",
-        "description": "Buying hansmartens.dev at GoDaddy, adding a Microsoft 365 mailbox, pointing the domain to Vercel — a walkthrough of the full setup.",
-        "image": f"{ASSETS}/domain-email-vercel-setup-v2.svg",
-        "hashtags": ["WebDevelopment", "Vercel", "GoDaddy", "Domain", "Tutorial"],
-    },
-    {
-        "slug": "dark-mode-sessionstorage",
-        "title": "Why I Use sessionStorage for Dark Mode (Not localStorage)",
-        "description": "Dark mode is the default on my site — and I store the preference in sessionStorage instead of localStorage. Here's the reasoning.",
-        "image": f"{ASSETS}/dark-mode-sessionstorage.svg",
-        "hashtags": ["WebDevelopment", "DarkMode", "CSS", "Performance"],
-    },
+    # {
+    #     "slug": "your-post-slug",
+    #     "title": "Your Post Title",
+    #     "description": "A short description of your post.",
+    #     "image": f"{ASSETS}/your-post-image.svg",
+    #     "hashtags": ["Tag1", "Tag2", "Tag3"],
+    # },
 ]
+# ------------------------------------------------------
 
 
 def svg_to_png_bytes(path: str) -> bytes:
@@ -99,6 +90,10 @@ def create_facets(text: str, hashtags: list[str], url: str) -> list:
 
 
 def main():
+    if not posts:
+        print("No posts configured. Edit the `posts` list in this script before running.")
+        sys.exit(1)
+
     client = Client()
     client.login(HANDLE, APP_PASSWORD)
     print("Logged in successfully")
@@ -126,7 +121,7 @@ def main():
         response = client.send_post(text=text, facets=facets, embed=embed)
         print(f"  Posted! URI: {response.uri}")
 
-    print("\nAll 4 posts published!")
+    print(f"\nAll {len(posts)} post(s) published!")
 
 
 if __name__ == "__main__":

--- a/src/__tests__/contact.test.ts
+++ b/src/__tests__/contact.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+// Schema mirroring src/pages/api/contact.ts
+const contactSchema = z.object({
+  name: z.string().min(2, 'Name must be at least 2 characters').max(100),
+  email: z.email('Please enter a valid email address'),
+  subject: z.string().max(200).optional(),
+  message: z.string().min(10, 'Message must be at least 10 characters').max(5000),
+  honeypot: z.string().max(0),
+});
+
+describe('Contact form validation', () => {
+  const validData = {
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    subject: 'Hello',
+    message: 'This is a test message that is long enough.',
+    honeypot: '',
+  };
+
+  it('accepts valid form data', () => {
+    const result = contactSchema.safeParse(validData);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts data without optional subject', () => {
+    const { subject: _s, ...data } = validData;
+    const result = contactSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects name shorter than 2 characters', () => {
+    const result = contactSchema.safeParse({ ...validData, name: 'J' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Name must be at least 2 characters');
+    }
+  });
+
+  it('rejects invalid email address', () => {
+    const result = contactSchema.safeParse({ ...validData, email: 'not-an-email' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path[0]).toBe('email');
+    }
+  });
+
+  it('rejects message shorter than 10 characters', () => {
+    const result = contactSchema.safeParse({ ...validData, message: 'Too short' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Message must be at least 10 characters');
+    }
+  });
+
+  it('rejects filled honeypot field (bot detection)', () => {
+    const result = contactSchema.safeParse({ ...validData, honeypot: 'bot-value' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path[0]).toBe('honeypot');
+    }
+  });
+
+  it('rejects subject longer than 200 characters', () => {
+    const result = contactSchema.safeParse({ ...validData, subject: 'a'.repeat(201) });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects message longer than 5000 characters', () => {
+    const result = contactSchema.safeParse({ ...validData, message: 'a'.repeat(5001) });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/__tests__/newsletter.test.ts
+++ b/src/__tests__/newsletter.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+// Schema mirroring src/pages/api/newsletter.ts
+const newsletterSchema = z.object({
+  email: z.email('Please enter a valid email address'),
+  honeypot: z.string().max(0).optional(),
+});
+
+describe('Newsletter form validation', () => {
+  it('accepts a valid email address', () => {
+    const result = newsletterSchema.safeParse({ email: 'user@example.com', honeypot: '' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an invalid email address', () => {
+    const result = newsletterSchema.safeParse({ email: 'not-an-email' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Please enter a valid email address');
+    }
+  });
+
+  it('rejects an empty email field', () => {
+    const result = newsletterSchema.safeParse({ email: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects filled honeypot field (bot detection)', () => {
+    const result = newsletterSchema.safeParse({ email: 'user@example.com', honeypot: 'bot' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path[0]).toBe('honeypot');
+    }
+  });
+
+  it('accepts missing honeypot field (it is optional)', () => {
+    const result = newsletterSchema.safeParse({ email: 'user@example.com' });
+    expect(result.success).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
- Remove hardcoded personal credentials and URLs from post_to_bluesky.py; script now requires BSKY_HANDLE, BSKY_APP_PASSWORD, and SITE_BASE_URL env vars and exits with a clear error if any are missing
- Fix package.json repository/homepage/bugs URLs (Rocket-Theme → astro-rocket)
- Add vitest.config.ts and 13 unit tests for contact and newsletter API validation schemas (zod v4)
- Add zod ^4.0.0 as a devDependency for tests
- Add CHANGELOG.md documenting v1.0.0 initial public release

https://claude.ai/code/session_01PqJvV4vD4uw4Ag2pRdMUT1