### PR TITLE
Strip .mdx extension from project slugs and card hrefs

### DIFF
--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -8,7 +8,7 @@ export async function getStaticPaths() {
   });
 
   return projects.map((project) => ({
-    params: { slug: project.id },
+    params: { slug: project.id.replace(/\.mdx?$/, '') },
     props: { project },
   }));
 }

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -39,7 +39,7 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
 
         <div class="grid gap-6 md:grid-cols-2" data-reveal>
           {projects.map((project) => (
-            <Card variant="elevated" hover padding="lg" href={`/projects/${project.id}`} class="group flex flex-col">
+            <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col">
               <div class="flex flex-1 flex-col">
                 <!-- Header -->
                 <div class="mb-3 flex items-start justify-between gap-4">


### PR DESCRIPTION
Astro's Content Layer API includes file extensions in entry IDs (astro-rocket.mdx, not astro-rocket). Strip the extension so routes generate /projects/astro-rocket and cards link there correctly.

https://claude.ai/code/session_01UmzuhJ2cr86ZQ1QqR7jA8g