### PR TITLE
Fix card links broken by nested <a> elements

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -59,39 +59,11 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
 
                 <p class="text-sm text-foreground-muted leading-relaxed mb-4 flex-1">{project.data.description}</p>
 
-                <!-- Tags + external links -->
-                <div class="flex items-center justify-between gap-4 flex-wrap">
-                  <div class="flex flex-wrap gap-1.5">
-                    {project.data.tags.map((tag) => (
-                      <Badge variant="brand">{tag}</Badge>
-                    ))}
-                  </div>
-                  <div class="flex gap-2 shrink-0">
-                    {project.data.url && (
-                      <a
-                        href={project.data.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-foreground-muted hover:text-brand-500 transition-colors"
-                        aria-label="View live site"
-                        onclick="event.stopPropagation()"
-                      >
-                        <Icon name="external-link" size="sm" />
-                      </a>
-                    )}
-                    {project.data.repo && (
-                      <a
-                        href={project.data.repo}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-foreground-muted hover:text-brand-500 transition-colors"
-                        aria-label="View source"
-                        onclick="event.stopPropagation()"
-                      >
-                        <Icon name="github" size="sm" />
-                      </a>
-                    )}
-                  </div>
+                <!-- Tags -->
+                <div class="flex flex-wrap gap-1.5">
+                  {project.data.tags.map((tag) => (
+                    <Badge variant="brand">{tag}</Badge>
+                  ))}
                 </div>
               </div>
             </Card>


### PR DESCRIPTION
The project cards on /projects were <a> tags (via Card href) that contained nested <a> tags for the live/repo icon links. Nested anchors are invalid HTML and browsers break the outer link. Removed the nested external links — they are accessible from the detail page anyway.

https://claude.ai/code/session_01UmzuhJ2cr86ZQ1QqR7jA8g