### PR TITLE
Bypass View Transitions on project cards

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -189,7 +189,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 
       <div class="grid gap-6 md:grid-cols-2" data-reveal data-reveal-delay="1">
         {featuredProjects.map((project) => (
-          <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col">
+          <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} data-astro-reload class="group flex flex-col">
             <div class="flex flex-1 flex-col">
               <div class="mb-3 flex items-start justify-between gap-4">
                 <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -39,7 +39,7 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
 
         <div class="grid gap-6 md:grid-cols-2" data-reveal>
           {projects.map((project) => (
-            <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col">
+            <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} data-astro-reload class="group flex flex-col">
               <div class="flex flex-1 flex-col">
                 <!-- Header -->
                 <div class="mb-3 flex items-start justify-between gap-4">


### PR DESCRIPTION
View Transitions was intercepting card clicks and navigating to the wrong URL. Adding data-astro-reload forces a full page load, which works correctly (same as right-click + open in new tab).

https://claude.ai/code/session_01UmzuhJ2cr86ZQ1QqR7jA8g