### PR TITLE
Replace magenta with blue brand colour, swap Instagram for LinkedIn, update hero CTA

### DIFF
--- a/public/og-default.svg
+++ b/public/og-default.svg
@@ -1,10 +1,10 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Background -->
-  <rect width="1200" height="630" fill="#c026d3"/>
+  <rect width="1200" height="630" fill="#2563eb"/>
 
   <!-- Lucide Rocket — scale(5), visual centre at (600, 240) -->
   <g transform="translate(540, 180) scale(5)"
-     stroke="#fae8ff" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
+     stroke="#dbeafe" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
     <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
     <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
     <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
@@ -13,23 +13,23 @@
 
   <!-- Wordmark -->
   <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-4"
-        fill="#fdf4ff"
+        fill="#eff6ff"
         font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
         font-weight="800">Astro Rocket</text>
 
   <!-- Divider -->
-  <line x1="380" y1="436" x2="820" y2="436" stroke="#e879f9" stroke-width="1" stroke-opacity="0.35"/>
+  <line x1="380" y1="436" x2="820" y2="436" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.35"/>
 
   <!-- Domain pill -->
   <rect x="450" y="464" width="300" height="38" rx="19"
-        fill="#d946ef" fill-opacity="0.25" stroke="#f0abfc" stroke-opacity="0.4" stroke-width="1"/>
+        fill="#3b82f6" fill-opacity="0.25" stroke="#93c5fd" stroke-opacity="0.4" stroke-width="1"/>
   <text x="600" y="488" font-size="13" text-anchor="middle" letter-spacing="1.5"
-        fill="#fae8ff"
+        fill="#dbeafe"
         font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">hansmartens.dev</text>
 
   <!-- Corner marks -->
-  <path d="M 36 60 L 36 36 L 60 36"     stroke="#e879f9" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 1140 36 L 1164 36 L 1164 60"   stroke="#e879f9" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 36 570 L 36 594 L 60 594"   stroke="#e879f9" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 1140 594 L 1164 594 L 1164 570" stroke="#e879f9" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 36 60 L 36 36 L 60 36"     stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 1140 36 L 1164 36 L 1164 60"   stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 36 570 L 36 594 L 60 594"   stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 1140 594 L 1164 594 L 1164 570" stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
 </svg>

--- a/public/readme-hero.svg
+++ b/public/readme-hero.svg
@@ -1,10 +1,10 @@
 <svg width="880" height="260" viewBox="0 0 880 260" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Background -->
-  <rect width="880" height="260" fill="#c026d3"/>
+  <rect width="880" height="260" fill="#2563eb"/>
 
   <!-- Lucide Rocket — scale(5), visual centre at (440, 100) -->
   <g transform="translate(379, 41) scale(5)"
-     stroke="#fae8ff" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
+     stroke="#dbeafe" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
     <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
     <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
     <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
@@ -16,11 +16,11 @@
         text-anchor="middle"
         font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
         font-weight="800" font-size="62" letter-spacing="-1.5"
-        fill="#fdf4ff">Astro Rocket</text>
+        fill="#eff6ff">Astro Rocket</text>
 
   <!-- Corner marks -->
-  <path d="M 30 50 L 30 30 L 50 30"     stroke="#e879f9" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 830 30 L 850 30 L 850 50"   stroke="#e879f9" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 30 210 L 30 230 L 50 230"   stroke="#e879f9" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 830 230 L 850 230 L 850 210" stroke="#e879f9" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 30 50 L 30 30 L 50 30"     stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 830 30 L 850 30 L 850 50"   stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 30 210 L 30 230 L 50 230"   stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 830 230 L 850 230 L 850 210" stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
 </svg>

--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -11,6 +11,7 @@ interface Props {
   href: string;
   publishedAt: Date;
   tags?: string[];
+  featured?: boolean;
   author?: string;
   image?: ImageMetadata;
   svgSlug?: string;

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -635,7 +635,7 @@ const buttonId = `${menuId}-button`;
       const scrollTop = window.scrollY;
       const docHeight = document.documentElement.scrollHeight - window.innerHeight;
       const pct = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
-      bar.style.width = `${pct}%`;
+      bar!.style.width = `${pct}%`;
       ticking = false;
     }
 

--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -74,7 +74,7 @@ const siteConfig: SiteConfig = {
   },
   socialLinks: [
     'https://github.com/hansmartens68/Astro-Rocket',
-    'https://instagram.com',
+    'https://linkedin.com',
     'https://x.com',
   ],
   twitter: {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -47,10 +47,10 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         <Icon name="github" size="sm" />
         Get it on GitHub
       </Button>
-      <Button size="lg" variant="outline" href="/about">
+      <Button size="lg" variant="outline" href="/blog/astro-rocket-getting-started">
         <Icon name="rocket" size="sm" />
-        Learn more
-         <Icon name="arrow-right" size="sm" />
+        Get started
+        <Icon name="arrow-right" size="sm" />
       </Button>
     </Fragment>
   </Hero>


### PR DESCRIPTION
## Summary

- **OG image** (`public/og-default.svg`): replace purple/magenta palette with Tailwind blue-600/500/400/300/100 to match the default blue theme
- **README image** (`public/readme-hero.svg`): same blue palette swap for consistency
- **Social links** (`src/config/site.config.ts`): replace `instagram.com` with `linkedin.com` — propagates automatically to contact page, blog index, and all blog post pages
- **Hero CTA** (`src/pages/index.astro`): secondary button reads "Get started" and links to `/blog/astro-rocket-getting-started`
- **Lint/type fixes**: `no-var`/`no-empty` in BaseLayout, `Card` Props extended with `target`/`rel`

## Test plan

- [ ] OG image displays in blue at `/og-default.svg`
- [ ] README hero image displays in blue
- [ ] Contact page shows LinkedIn icon instead of Instagram
- [ ] Blog index "Follow along" section shows LinkedIn
- [ ] Blog post "Follow along" section shows LinkedIn
- [ ] Homepage hero secondary button reads "Get started" and navigates to the getting-started post
- [ ] `pnpm lint`, `pnpm check`, `pnpm build` all pass with 0 errors