### PR TITLE
Fix Cloudflare project name in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,7 @@
 # Cloudflare Pages configuration
 # This file is used when deploying to Cloudflare Pages with wrangler
 
-name = "velocity"
+name = "astro-rocket"
 compatibility_date = "2026-01-31"
 
 [site]


### PR DESCRIPTION
## Summary

- Rename `name` in `wrangler.toml` from `"velocity"` (leftover from the original Velocity theme) to `"astro-rocket"`

Users deploying to Cloudflare Pages via Wrangler would otherwise see their project created under the name `velocity`, which is inconsistent with the theme they downloaded.

## Test plan

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully