### PR TITLE
Lighten dark mode gradients to brand-600

### DIFF
--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -109,7 +109,7 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
       {svgSlug ? (
         <div
           class="relative overflow-hidden rounded-xl border border-border shadow-2xl
-            bg-gradient-to-br from-brand-100/50 to-brand-50/30 dark:from-brand-900/50 dark:to-brand-800/30"
+            bg-gradient-to-br from-brand-100/50 to-brand-50/30 dark:from-brand-900/50 dark:to-brand-600/30"
           style="color: var(--brand-500);"
         >
           <BlogImageSVG slug={svgSlug} title={imageAlt || title} />

--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -39,7 +39,7 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
   <a href={href} class="block">
     <div
       class="relative mb-4 overflow-hidden rounded-md
-        bg-background-secondary bg-gradient-to-br from-brand-100/65 to-transparent dark:from-brand-900/60 dark:to-brand-800/25"
+        bg-background-secondary bg-gradient-to-br from-brand-100/65 to-transparent dark:from-brand-900/60 dark:to-brand-600/25"
       style="color: var(--brand-500);"
     >
       {svgSlug ? (

--- a/src/components/blog/BlogImageSVG.astro
+++ b/src/components/blog/BlogImageSVG.astro
@@ -44,7 +44,7 @@ const svgContent = svgs[`/src/assets/blog/${slug}.svg`] ?? '';
   /* ── Dark mode ───────────────────────────────────────────────────────────
      Deep background with all brand colors at full opacity — vivid, not faded.
   ── */
-  :global(html.dark) .svg-host :global(.bg)  { fill: var(--brand-800); }
+  :global(html.dark) .svg-host :global(.bg)  { fill: var(--brand-600); }
   :global(html.dark) .svg-host :global(.ico) { stroke: var(--brand-200); }
   :global(html.dark) .svg-host :global(.txt) { fill: var(--brand-50); }
   :global(html.dark) .svg-host :global(.ln)  { stroke: var(--brand-300); stroke-opacity: 0.5; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -298,7 +298,7 @@
   .dark .hero-dark-gradient {
     background: linear-gradient(
       to bottom,
-      var(--brand-700) 0%,
+      var(--brand-600) 0%,
       oklch(0% 0 0) 100%
     ) !important;
   }


### PR DESCRIPTION
## Summary

Adjusts dark mode gradient colours for a richer, more vibrant appearance.

- **Hero gradient** (`global.css`): start colour brand-700 → brand-600
- **Blog SVG images** (`BlogImageSVG.astro`): background fill brand-800 → brand-600
- **Blog card grid** (`BlogCard.astro`): gradient end brand-800 → brand-600
- **Article hero** (`ArticleHero.astro`): gradient end brand-800 → brand-600

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm check` — 0 errors
- [x] `pnpm build` — complete