### PR TITLE
Add LinkedIn to social links

### DIFF
--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -75,6 +75,7 @@ const siteConfig: SiteConfig = {
   socialLinks: [
     'https://github.com/hansmartens68/Astro-Rocket',
     'https://x.com/hansmartens_dev',
+    'https://www.linkedin.com',
   ],
   twitter: {
     site: 'https://x.com/hansmartens_dev',


### PR DESCRIPTION
## Summary

Adds `https://www.linkedin.com` to `socialLinks` in `site.config.ts`. The `resolveSocialLinks()` utility automatically detects the LinkedIn URL and assigns the correct icon and label.

The LinkedIn icon now appears in all locations that render social links:
- Contact page
- Blog index — "Follow along" section
- Blog post pages — "Follow along" section
- Header social icons
- Footer social icons

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm check` — 0 errors
- [x] `pnpm build` — complete