### PR TITLE
Fix contact card display: strip www. prefix from social links

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -26,7 +26,7 @@ const channels = [
   ...socialLinks.map((link) => ({
     icon: link.icon,
     label: link.label,
-    value: link.href.replace(/^https?:\/\//, ''),
+    value: link.href.replace(/^https?:\/\/(www\.)?/, ''),
     note: 'Follow along',
     href: link.href,
     external: true,


### PR DESCRIPTION
## Summary

The contact page was displaying `www.linkedin.com` instead of `linkedin.com` on the social link card. The regex that strips the protocol prefix (`https://`) was updated to also strip an optional `www.` prefix.

**Before:** `www.linkedin.com`
**After:** `linkedin.com`

GitHub (`github.com/...`) and X (`x.com/...`) are unaffected — they don't have a `www.` prefix.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm check` — 0 errors
- [x] `pnpm build` — complete