### PR TITLE
Fix footer copyright HTML rendering in all layouts

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -274,9 +274,7 @@ function getSocialIcon(platform: string): string {
             ) : (
               <>
                 {showCopyright && (
-                  <p class="text-sm text-foreground-muted">
-                    {processedCopyright}
-                  </p>
+                  <p class="text-sm text-foreground-muted" set:html={processedCopyright} />
                 )}
                 {legalLinks.length > 0 && (
                   <div class="flex items-center gap-[var(--space-inline-lg)]">
@@ -300,9 +298,7 @@ function getSocialIcon(platform: string): string {
     {layout === 'minimal' && (
       <div class="text-center">
         {showCopyright && (
-          <p class="text-sm text-foreground-muted">
-            {processedCopyright}
-          </p>
+          <p class="text-sm text-foreground-muted" set:html={processedCopyright} />
         )}
       </div>
     )}
@@ -365,9 +361,7 @@ function getSocialIcon(platform: string): string {
         {(showCopyright || legalLinks.length > 0) && (
           <div class="pt-[var(--space-stack-lg)] border-t border-border w-full flex flex-col items-center gap-[var(--space-stack-md)]">
             {showCopyright && (
-              <p class="text-sm text-foreground-muted">
-                {processedCopyright}
-              </p>
+              <p class="text-sm text-foreground-muted" set:html={processedCopyright} />
             )}
             {legalLinks.length > 0 && (
               <div class="flex items-center gap-[var(--space-inline-lg)]">


### PR DESCRIPTION
## Summary

The `columns`, `minimal`, and `stacked` footer layouts were rendering the copyright string as raw text, causing the "Designed by Hans Martens" anchor tag to appear as visible HTML code on the page. The `simple` layout was already using `set:html` correctly.

Changed all three layouts to use `set:html={processedCopyright}` for consistent rendering across all footer variants.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm check` — 0 errors
- [x] `pnpm build` — complete