### PR TITLE
Replace hero linear gradient with theme-aware radial glow

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -294,13 +294,12 @@
     );
   }
 
-  /* Dark mode hero gradient: brand to black */
+  /* Hero radial gradient — top-center brand glow, theme-aware */
+  .hero-dark-gradient {
+    background: radial-gradient(circle at 50% -20%, oklch(from var(--brand-500) l c h / 0.12), transparent 60%), var(--background);
+  }
   .dark .hero-dark-gradient {
-    background: linear-gradient(
-      to bottom,
-      var(--brand-600) 0%,
-      oklch(0% 0 0) 100%
-    ) !important;
+    background: radial-gradient(circle at 50% -20%, oklch(from var(--brand-500) l c h / 0.38), transparent 60%), var(--background);
   }
 
   /* Gradient border */


### PR DESCRIPTION
Swap the dark-only linear gradient on .hero-dark-gradient for a radial gradient that bleeds in from 50% -20% (above the viewport). Light mode uses 12% brand opacity; dark mode uses 38%. The oklch relative-color syntax pulls the hue directly from --brand-500, so the glow adapts automatically to whichever of the 12 colour themes is active. The !important override is also removed — the new rules sit at the correct cascade weight without it.

No changes to index.astro: the homepage Hero already carries class="hero-dark-gradient".

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
