### PR TITLE
Keep "Web Designer" in brand colour in dark mode

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 
     <h1 slot="title">
       <span class="text-foreground [-webkit-text-fill-color:currentColor]">Astro Rocket —</span><br />
-      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)] dark:text-foreground dark:[-webkit-text-fill-color:currentColor]">Web Designer</span><span class="text-foreground [-webkit-text-fill-color:currentColor]"> &amp; Developer</span>
+      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)]">Web Designer</span><span class="text-foreground [-webkit-text-fill-color:currentColor]"> &amp; Developer</span>
     </h1>
 
     <p slot="description">


### PR DESCRIPTION
The span had dark:text-foreground and dark:[-webkit-text-fill-color:currentColor] overrides that switched the text to white in dark mode. Removing those overrides lets text-brand-500 and the explicit -webkit-text-fill-color apply in both modes, matching the light-mode appearance.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
