### PR TITLE
Increase dark mode hero gradient opacity from 0.38 to 0.55

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -299,7 +299,7 @@
     background: radial-gradient(circle at 50% -20%, oklch(from var(--brand-500) l c h / 0.12), transparent 60%), var(--background);
   }
   .dark .hero-dark-gradient {
-    background: radial-gradient(circle at 50% -20%, oklch(from var(--brand-500) l c h / 0.38), transparent 60%), var(--background);
+    background: radial-gradient(circle at 50% -20%, oklch(from var(--brand-500) l c h / 0.55), transparent 60%), var(--background);
   }
 
   /* Gradient border */


### PR DESCRIPTION
Makes the brand glow more prominent in dark mode. Light mode variant unchanged.

https://claude.ai/code/session_0165DVbeyn2kR8qXz9dxe52p

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
