### PR TITLE
Add Astro themes directory listing to launch blog post

### DIFF
--- a/src/content/blog/en/astro-rocket-is-live.mdx
+++ b/src/content/blog/en/astro-rocket-is-live.mdx
@@ -63,6 +63,10 @@ Everything from Velocity is still there, and it's all fully integrated:
 
 **Lighthouse 95+** across Performance, Accessibility, Best Practices, and SEO.
 
+## Now on the official Astro themes directory
+
+Astro Rocket is listed on the official Astro website. You can find it in the [Astro themes directory](https://portal.astro.build/themes/astro-rocket) at astro.build — alongside the other themes the Astro team curates and recommends. If you're browsing themes on astro.build, that's where you'll find it.
+
 ## Give it a star on GitHub
 
 It's open source, MIT-licensed, and ready to use.


### PR DESCRIPTION
Astro Rocket is now listed on the official Astro themes directory at astro.build. Added a dedicated section with the link before the GitHub CTA.

https://claude.ai/code/session_01LAmsbCED4ez3ohYmTaXmUf

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
