### PR TITLE
Add circular scroll-progress ring to back-to-top button

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -196,21 +196,38 @@ if (includeProfessionalServiceSchema) {
     <button
       id="back-to-top"
       aria-label="Back to top"
-      class="fixed bottom-6 right-6 z-50 flex h-10 w-10 items-center justify-center rounded-full bg-background border border-border-strong text-foreground-muted shadow-md opacity-0 translate-y-2 pointer-events-none transition-[opacity,transform] duration-200"
+      class="fixed bottom-6 right-6 z-50 h-12 w-12 opacity-0 translate-y-2 pointer-events-none transition-[opacity,transform] duration-200"
     >
-      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m18 15-6-6-6 6"/></svg>
+      <!-- Scroll-progress ring -->
+      <svg class="absolute inset-0 h-full w-full -rotate-90" viewBox="0 0 48 48" aria-hidden="true">
+        <circle cx="24" cy="24" r="21" fill="none" stroke="currentColor" class="text-border" stroke-width="2" opacity="0.5" />
+        <circle id="back-to-top-ring" cx="24" cy="24" r="21" fill="none" stroke="currentColor" class="text-brand-500" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="131.95" stroke-dashoffset="131.95" />
+      </svg>
+      <!-- Inner face -->
+      <span class="absolute inset-[5px] flex items-center justify-center rounded-full bg-background border border-border-strong text-foreground-muted shadow-md" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m18 15-6-6-6 6"/></svg>
+      </span>
     </button>
 
     <script is:inline>
       (function () {
-        const THRESHOLD = 400;
+        var THRESHOLD = 400;
+        var CIRCUMFERENCE = 131.95;
 
         function initBackToTop() {
-          const btn = document.getElementById('back-to-top');
+          var btn = document.getElementById('back-to-top');
           if (!btn || btn.dataset.bttInit) return;
           btn.dataset.bttInit = 'true';
 
-          function update() {
+          var ring = document.getElementById('back-to-top-ring');
+          var ticking = false;
+
+          function updateFrame() {
+            var scrollable = document.documentElement.scrollHeight - window.innerHeight;
+            var pct = scrollable > 0 ? window.scrollY / scrollable : 0;
+            if (ring) {
+              ring.style.strokeDashoffset = String(CIRCUMFERENCE * (1 - pct));
+            }
             if (window.scrollY > THRESHOLD) {
               btn.classList.remove('opacity-0', 'translate-y-2', 'pointer-events-none');
               btn.classList.add('opacity-100', 'translate-y-0');
@@ -218,18 +235,30 @@ if (includeProfessionalServiceSchema) {
               btn.classList.add('opacity-0', 'translate-y-2', 'pointer-events-none');
               btn.classList.remove('opacity-100', 'translate-y-0');
             }
+            ticking = false;
           }
 
-          window.addEventListener('scroll', update, { passive: true });
+          function onScroll() {
+            if (!ticking) {
+              ticking = true;
+              requestAnimationFrame(updateFrame);
+            }
+          }
+
+          window.addEventListener('scroll', onScroll, { passive: true });
           btn.addEventListener('click', function () {
             window.scrollTo({ top: 0, behavior: 'smooth' });
           });
-          update();
+
+          document.addEventListener('astro:before-swap', function () {
+            window.removeEventListener('scroll', onScroll);
+          }, { once: true });
+
+          updateFrame();
         }
 
-        initBackToTop();
         document.addEventListener('astro:page-load', initBackToTop);
-        document.addEventListener('astro:after-swap', initBackToTop);
+        initBackToTop();
       })();
     </script>
 


### PR DESCRIPTION
Replace the flat back-to-top button with a three-layer structure: an outer 48×48 button, an SVG ring overlay that fills as the user scrolls (track circle + brand-coloured progress arc using stroke-dashoffset), and an inner face span with the up-arrow icon.

The JS is rewritten with requestAnimationFrame throttling, a astro:before-swap cleanup listener, and var-style IIFE to match the existing is:inline script convention.

https://claude.ai/code/session_01R9BjSorrRpuhCbyT2eYkgA

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
