### PR TITLE
Add cover image for scroll-progress-ring blog post

### DIFF
--- a/src/assets/blog/scroll-progress-ring.svg
+++ b/src/assets/blog/scroll-progress-ring.svg
@@ -1,0 +1,42 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .bg  { fill: var(--brand-500); }
+    .txt { fill: var(--brand-50); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; font-weight: 800; }
+    .ln  { stroke: var(--brand-300); stroke-width: 1; stroke-opacity: 0.35; }
+    .pil { fill: var(--brand-400); fill-opacity: 0.25; stroke: var(--brand-200); stroke-opacity: 0.4; stroke-width: 1; }
+    .ptx { fill: var(--brand-100); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; }
+    .cor { stroke: var(--brand-300); stroke-width: 1.5; fill: none; stroke-opacity: 0.45; }
+  </style>
+  <rect width="1200" height="630" class="bg"/>
+
+  <!-- Back-to-top button illustration, centred at (600, 215) -->
+
+  <!-- Outer button face -->
+  <circle cx="600" cy="215" r="100" fill="var(--brand-400)" fill-opacity="0.18" stroke="var(--brand-200)" stroke-width="1" stroke-opacity="0.35"/>
+
+  <!-- Track circle -->
+  <circle cx="600" cy="215" r="85" fill="none" stroke="var(--brand-300)" stroke-width="5" stroke-opacity="0.45"/>
+
+  <!-- Progress arc (~65 % filled); circumference = 2π×85 ≈ 534.07; dashoffset = 534.07×0.35 ≈ 186.92 -->
+  <circle cx="600" cy="215" r="85" fill="none"
+    stroke="var(--brand-100)" stroke-width="7" stroke-linecap="round"
+    stroke-dasharray="534.07" stroke-dashoffset="186.92"
+    transform="rotate(-90 600 215)"/>
+
+  <!-- Inner face -->
+  <circle cx="600" cy="215" r="65" fill="var(--brand-400)" fill-opacity="0.28" stroke="var(--brand-200)" stroke-width="1.5" stroke-opacity="0.45"/>
+
+  <!-- Up-arrow (Lucide ChevronUp, 24×24 → scale 1.333 → 32×32, centred at 600,215) -->
+  <g transform="translate(584, 199) scale(1.333)">
+    <path d="m18 15-6-6-6 6" stroke="var(--brand-100)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  </g>
+
+  <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">progress ring</text>
+  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
+  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
+  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
+  <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
+  <path d="M 36 570 L 36 594 L 60 594" class="cor"/>
+  <path d="M 1140 594 L 1164 594 L 1164 570" class="cor"/>
+</svg>

--- a/src/content/blog/en/scroll-progress-ring.mdx
+++ b/src/content/blog/en/scroll-progress-ring.mdx
@@ -6,8 +6,9 @@ author: "Hans Martens"
 tags: ["astro-rocket", "features", "ux", "animation"]
 featured: false
 locale: en
+image: "../../../assets/blog/scroll-progress-ring.svg"
 svgSlug: "scroll-progress-ring"
-imageAlt: "A circular progress ring surrounding a back-to-top arrow button on a dark background"
+imageAlt: "A circular progress ring surrounding a back-to-top arrow button on a brand-coloured background"
 ---
 
 Astro Rocket's back-to-top button has been upgraded with a circular scroll-progress ring. As you scroll down the page, the ring fills clockwise around the button — giving the reader a visual sense of how far through the page they are. Clicking the button still scrolls back to the top.


### PR DESCRIPTION
SVG follows the same 1200×630 brand-coloured template used by all other post images: track circle, 65%-filled progress arc, inner face circle, and ChevronUp arrow — all using brand CSS custom properties so the image is theme-aware. Also wires up the image field in the post frontmatter.

https://claude.ai/code/session_01R9BjSorrRpuhCbyT2eYkgA

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
