### PR TITLE
Add showGlow, bottomFade, showScrollIndicator props to Hero component

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -10,6 +10,12 @@ interface Props extends HTMLAttributes<'section'> {
   size?: 'sm' | 'md' | 'lg' | 'xl';
   /** Show background grid pattern */
   showGrid?: boolean;
+  /** Show brand-coloured radial glow blobs behind the content */
+  showGlow?: boolean;
+  /** Fade the bottom of the section into the next section's background */
+  bottomFade?: boolean;
+  /** Show an animated scroll indicator at the bottom (desktop only, hides on scroll) */
+  showScrollIndicator?: boolean;
   /** Apply the dark-mode hero gradient (black → brand). Homepage only. */
   gradient?: boolean;
 }
@@ -18,6 +24,9 @@ const {
   layout = 'centered',
   size = 'lg',
   showGrid = false,
+  showGlow = false,
+  bottomFade = false,
+  showScrollIndicator = false,
   gradient = false,
   class: className,
   ...attrs
@@ -50,11 +59,35 @@ const gridClasses = cn(
 <section class={sectionClasses} {...attrs}>
   {showGrid && (
     <div
-      class="bg-grid-pattern pointer-events-none absolute inset-x-0 -inset-y-[20%] opacity-30"
+      class="bg-grid-pattern pointer-events-none absolute inset-x-0 -inset-y-[20%] opacity-30 hidden dark:block"
       style="mask-image: radial-gradient(ellipse 50% 50% at 50% 40%, black 0%, transparent 70%);"
       data-parallax="0.2"
       aria-hidden="true"
     />
+  )}
+
+  {showGlow && (
+    <>
+      <div class="pointer-events-none absolute left-1/2 top-1/4 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-brand-500/15 blur-[120px] hidden dark:block" aria-hidden="true" />
+      <div class="pointer-events-none absolute bottom-1/4 right-1/4 h-[400px] w-[400px] rounded-full bg-brand-600/10 blur-[100px] hidden dark:block" aria-hidden="true" />
+    </>
+  )}
+
+  {bottomFade && (
+    <div class="pointer-events-none absolute inset-x-0 bottom-0 h-40 bg-gradient-to-b from-transparent to-background-secondary hidden dark:block" aria-hidden="true" />
+  )}
+
+  {showScrollIndicator && (
+    <div class="hidden md:block absolute bottom-14 left-1/2 -translate-x-1/2 z-10" aria-hidden="true">
+      <div class="scroll-indicator flex flex-col items-center gap-0.5">
+        <svg class="scroll-indicator-chevron w-7 h-7 text-brand-500/70" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+        <svg class="scroll-indicator-chevron-2 w-7 h-7 text-brand-500/35" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </div>
+    </div>
   )}
 
   <div class={gridClasses}>
@@ -112,8 +145,58 @@ const gridClasses = cn(
   </div>
 </section>
 
+<style>
+  .scroll-indicator {
+    animation: si-fade-in 0.6s ease-out 1.4s both;
+    transition: opacity 0.5s ease, transform 0.5s ease;
+  }
+  .scroll-indicator.is-hidden {
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(4px);
+  }
+  @keyframes si-fade-in {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  .scroll-indicator-chevron {
+    animation: si-bounce 2s ease-in-out 2s infinite;
+  }
+  .scroll-indicator-chevron-2 {
+    animation: si-bounce 2s ease-in-out 2.15s infinite;
+  }
+  @keyframes si-bounce {
+    0%, 100% { transform: translateY(0); }
+    50%       { transform: translateY(5px); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .scroll-indicator              { animation: none; opacity: 1; }
+    .scroll-indicator-chevron,
+    .scroll-indicator-chevron-2    { animation: none; }
+  }
+</style>
 
 <script>
+  function initScrollIndicator() {
+    const indicator = document.querySelector('.scroll-indicator');
+    if (!indicator) return;
+
+    function onScroll() {
+      if (window.scrollY > 50) {
+        indicator.classList.add('is-hidden');
+        window.removeEventListener('scroll', onScroll);
+      }
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    document.addEventListener('astro:before-swap', () => {
+      window.removeEventListener('scroll', onScroll);
+    }, { once: true });
+  }
+
+  document.addEventListener('astro:page-load', initScrollIndicator);
+
   // Parallax: move [data-parallax] layers at a fraction of scroll speed.
   // Elements with -inset-y-[20%] have extra room to move without clipping.
   // Skipped entirely when the user prefers reduced motion.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,7 +30,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   includeProfessionalServiceSchema={true}
 >
   <!-- Hero -->
-  <Hero layout="centered" size="xl" class="hero-dark-gradient">
+  <Hero layout="centered" size="xl" class="hero-dark-gradient" showGrid showGlow bottomFade showScrollIndicator>
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">Available for new projects</Badge>
 
     <h1 slot="title">


### PR DESCRIPTION
Adds four decorative props (showGrid already existed) to Hero.astro:
- showGrid: dark-mode-only grid background pattern (updated to hidden dark:block)
- showGlow: dark-mode-only radial brand-colour blur blobs
- bottomFade: dark-mode-only gradient fade into the next section
- showScrollIndicator: desktop-only animated chevron that hides on scroll (both modes)

Includes scoped CSS animations (fade-in, bounce, reduced-motion overrides) and a scroll-hide script wired to astro:page-load / astro:before-swap lifecycle events. Enables all four props on the homepage Hero tag.

https://claude.ai/code/session_01QqBNAUDtUKiR1pGqa8cWMh

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
