### PR TITLE
hero: apply dark-mode-only gradient, disable showGrid/showGlow/bottom…

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,7 +30,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   includeProfessionalServiceSchema={true}
 >
   <!-- Hero -->
-  <Hero layout="centered" size="xl" class="hero-dark-gradient" showGrid showGlow bottomFade>
+  <Hero layout="centered" size="xl" class="hero-dark-gradient">
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">Available for new projects</Badge>
 
     <h1 slot="title">


### PR DESCRIPTION
…Fade

In dark mode the hero now renders only the hero-dark-gradient class (brand → black linear gradient). The showGrid, showGlow, and bottomFade props are removed so those decorative layers no longer render.

https://claude.ai/code/session_016P8bPoRgkV7wukKjj6zYAm

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
