### PR TITLE
header: override hdr-logo-text to foreground color in dark mode

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -195,7 +195,7 @@ const buttonId = `${menuId}-button`;
             <span
               class={cn(
                 'font-display text-xl font-bold tracking-tight',
-                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-on-invert' : 'text-brand-500 dark:text-foreground')
+                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-on-invert' : 'text-brand-500')
               )}
             >
               {logoText || siteConfig.name}
@@ -694,6 +694,9 @@ const buttonId = `${menuId}-button`;
   /* Non-invert floating: use normal colors */
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
     color: var(--color-brand-500);
+  }
+  .dark [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
+    color: var(--color-foreground);
   }
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text {
     color: var(--color-foreground-muted);


### PR DESCRIPTION
The floating header logo text is styled via CSS (not a Tailwind class), so it needs a dark-mode CSS override. Adds a .dark-prefixed rule with higher specificity (0,4,0 vs 0,3,0) to switch the site name from brand-500 to foreground (near-white) in dark mode only. Also reverts the ineffective template change from the previous commit.

https://claude.ai/code/session_016P8bPoRgkV7wukKjj6zYAm

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
