### PR TITLE
Scale down scroll-progress-ring SVG illustration and normalize text

### DIFF
--- a/src/assets/blog/scroll-progress-ring.svg
+++ b/src/assets/blog/scroll-progress-ring.svg
@@ -12,29 +12,29 @@
   <!-- Back-to-top button illustration, centred at (600, 215) -->
 
   <!-- Outer button face -->
-  <circle cx="600" cy="215" r="100" fill="var(--brand-400)" fill-opacity="0.18" stroke="var(--brand-200)" stroke-width="1" stroke-opacity="0.35"/>
+  <circle cx="600" cy="215" r="75" fill="var(--brand-400)" fill-opacity="0.18" stroke="var(--brand-200)" stroke-width="1" stroke-opacity="0.35"/>
 
   <!-- Track circle -->
-  <circle cx="600" cy="215" r="85" fill="none" stroke="var(--brand-300)" stroke-width="5" stroke-opacity="0.45"/>
+  <circle cx="600" cy="215" r="64" fill="none" stroke="var(--brand-300)" stroke-width="5" stroke-opacity="0.45"/>
 
-  <!-- Progress arc (~65 % filled); circumference = 2π×85 ≈ 534.07; dashoffset = 534.07×0.35 ≈ 186.92 -->
-  <circle cx="600" cy="215" r="85" fill="none"
+  <!-- Progress arc (~65 % filled); circumference = 2π×64 ≈ 402.12; dashoffset = 402.12×0.35 ≈ 140.74 -->
+  <circle cx="600" cy="215" r="64" fill="none"
     stroke="var(--brand-100)" stroke-width="7" stroke-linecap="round"
-    stroke-dasharray="534.07" stroke-dashoffset="186.92"
+    stroke-dasharray="402.12" stroke-dashoffset="140.74"
     transform="rotate(-90 600 215)"/>
 
   <!-- Inner face -->
-  <circle cx="600" cy="215" r="65" fill="var(--brand-400)" fill-opacity="0.28" stroke="var(--brand-200)" stroke-width="1.5" stroke-opacity="0.45"/>
+  <circle cx="600" cy="215" r="49" fill="var(--brand-400)" fill-opacity="0.28" stroke="var(--brand-200)" stroke-width="1.5" stroke-opacity="0.45"/>
 
   <!-- Up-arrow (Lucide ChevronUp, 24×24 → scale 1.333 → 32×32, centred at 600,215) -->
-  <g transform="translate(584, 199) scale(1.333)">
+  <g transform="translate(588, 204) scale(1)">
     <path d="m18 15-6-6-6 6" stroke="var(--brand-100)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
   </g>
 
-  <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">progress ring</text>
+  <text x="600" y="410" font-size="80" text-anchor="middle" letter-spacing="-2" class="txt">progress ring</text>
   <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
   <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="488" font-size="13" text-anchor="middle" letter-spacing="1.5" class="ptx">hansmartens.dev</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>


### PR DESCRIPTION
- Reduce all ring radii by 0.75× (outer halo 100→75, track/arc 85→64, inner circle 65→49)
- Update progress arc dash values for new circumference (402.12) at ~65% fill (dashoffset 140.74)
- Reposition chevron to fit smaller inner circle (translate 588,204 scale 1)
- Reduce title font-size from 96 to 80 to balance smaller illustration
- Normalize footer text: font-size 16→13, add letter-spacing 1.5, y 487→488

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
