### PR TITLE
Make contact form card match height of channel cards column

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -56,11 +56,11 @@ const channels = [
   <!-- Contact Section -->
   <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
     <div class="mx-auto max-w-5xl px-6">
-      <div class="grid grid-cols-1 lg:grid-cols-5 gap-10 lg:gap-16 items-start">
+      <div class="grid grid-cols-1 lg:grid-cols-5 gap-10 lg:gap-16 items-stretch">
 
         <!-- Left column: contact form -->
-        <div class="lg:col-span-3" data-reveal>
-          <Card padding="lg">
+        <div class="lg:col-span-3 h-full" data-reveal>
+          <Card padding="lg" class="h-full flex flex-col justify-center">
             <h2 class="font-display text-xl font-bold text-foreground mb-6">Send a message</h2>
             <ContactForm />
           </Card>


### PR DESCRIPTION
- Change grid from items-start to items-stretch so both columns reach equal height
- Add h-full to the left column and Card so the form card fills that height
- Add flex flex-col justify-center so form content sits with equal top/bottom padding

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
