### PR TITLE
fix: change animation-fill-mode from both to backwards on .scroll-ind…

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -145,7 +145,7 @@ const gridClasses = cn(
 <style>
   /* Fade in after the hero slide-up animation completes */
   .scroll-indicator {
-    animation: si-fade-in 0.6s ease-out 1.4s both;
+    animation: si-fade-in 0.6s ease-out 1.4s backwards;
     transition: opacity 0.5s ease, transform 0.5s ease;
   }
 


### PR DESCRIPTION
…icator

fill-mode: both (forwards) was holding the animation's final opacity/transform values after the animation ended, overriding any subsequent class-based changes via .is-hidden in the CSS cascade. Switching to backwards preserves the from-keyframe during the 1.4s delay (preventing a flash) without locking the post-animation state — so the transition and .is-hidden class now work correctly.

https://claude.ai/code/session_01YatkgUXyQXZprhUk7rHN4u

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
