### PR TITLE
fix: hide scroll indicator on mobile landscape via min-height media q…

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -75,7 +75,7 @@ const gridClasses = cn(
   )}
 
   {showScrollIndicator && (
-    <div class="hidden md:block absolute bottom-14 left-1/2 -translate-x-1/2 z-10" aria-hidden="true">
+    <div class="scroll-indicator-wrapper absolute bottom-14 left-1/2 -translate-x-1/2 z-10" aria-hidden="true">
       <div class="scroll-indicator flex flex-col items-center gap-0.5">
         <svg class="scroll-indicator-chevron w-7 h-7 text-brand-500/70" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <polyline points="6 9 12 15 18 9" />
@@ -143,6 +143,18 @@ const gridClasses = cn(
 </section>
 
 <style>
+  /* Desktop-only: require both a minimum width and minimum height so phones
+     in landscape mode (wide but short) are excluded. */
+  .scroll-indicator-wrapper {
+    display: none;
+  }
+
+  @media (min-width: 1024px) and (min-height: 500px) {
+    .scroll-indicator-wrapper {
+      display: block;
+    }
+  }
+
   /* Fade in after the hero slide-up animation completes */
   .scroll-indicator {
     animation: si-fade-in 0.6s ease-out 1.4s backwards;


### PR DESCRIPTION
…uery

Replaced hidden md:block with a scroll-indicator-wrapper CSS class that requires both min-width: 1024px and min-height: 500px. The width-only breakpoint was insufficient because phones in landscape mode can reach ~930px wide while remaining under 430px tall — the height guard excludes them while still showing the indicator on all genuine desktop screens.

https://claude.ai/code/session_01YatkgUXyQXZprhUk7rHN4u

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
