### PR TITLE
fix: scope hero description width to homepage only

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -16,6 +16,8 @@ interface Props extends HTMLAttributes<'section'> {
   bottomFade?: boolean;
   /** Show an animated scroll indicator at the bottom (desktop only, hides on scroll) */
   showScrollIndicator?: boolean;
+  /** Max-width class for the description wrapper (default: max-w-xl) */
+  descriptionClass?: string;
 }
 
 const {
@@ -25,6 +27,7 @@ const {
   showGlow = false,
   bottomFade = false,
   showScrollIndicator = false,
+  descriptionClass = 'max-w-xl',
   class: className,
   ...attrs
 } = Astro.props;
@@ -111,7 +114,8 @@ const gridClasses = cn(
       {/* Description Slot */}
       {hasDescriptionSlot && (
         <div class={cn(
-          'mb-[var(--space-stack-lg)] max-w-3xl text-lg leading-relaxed text-foreground-muted',
+          'mb-[var(--space-stack-lg)] text-lg leading-relaxed text-foreground-muted',
+          descriptionClass,
           '[&>p]:text-lg [&>p]:leading-relaxed [&>p]:text-foreground-muted',
           layout === 'centered' && 'mx-auto'
         )}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,7 +30,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   includeProfessionalServiceSchema={true}
 >
   <!-- Hero -->
-  <Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator>
+  <Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator descriptionClass="max-w-3xl">
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">Available for new projects</Badge>
 
     <h1 slot="title">


### PR DESCRIPTION
Add descriptionClass prop to Hero component (default: max-w-xl) so the wider max-w-3xl is no longer baked in for all pages. Only index.astro explicitly passes descriptionClass="max-w-3xl" to preserve the intended wider homepage hero paragraph.

https://claude.ai/code/session_01UCsyc99W45u6nNny4vUEvx

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
