### PR TITLE
fix: remove hero brand gradient in light mode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -296,7 +296,7 @@
 
   /* Hero gradient — theme-aware */
   .hero-dark-gradient {
-    background: radial-gradient(circle at 50% -20%, oklch(from var(--brand-500) l c h / 0.12), transparent 60%), var(--background);
+    background: var(--background);
   }
   .dark .hero-dark-gradient {
     background: linear-gradient(to bottom, var(--brand-600), black);


### PR DESCRIPTION
Light mode now uses a plain background on the homepage hero. Dark mode gradient (linear-gradient to black) is untouched.

https://claude.ai/code/session_01UCsyc99W45u6nNny4vUEvx

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
