### PR TITLE
Fix scroll-reveal not triggering on pages with short heroes

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,6 +25,7 @@ interface Props {
   includeOrgSchema?: boolean;
   includePersonSchema?: boolean;
   includeProfessionalServiceSchema?: boolean;
+  eagerReveal?: boolean;
 }
 
 const {
@@ -38,6 +39,7 @@ const {
   includeOrgSchema = false,
   includePersonSchema = false,
   includeProfessionalServiceSchema = false,
+  eagerReveal = false,
 } = Astro.props;
 
 // Build JSON-LD schemas
@@ -173,7 +175,7 @@ if (includeProfessionalServiceSchema) {
     </script>
   </head>
 
-  <body class="min-h-screen bg-background text-foreground antialiased">
+  <body class="min-h-screen bg-background text-foreground antialiased" data-eager-reveal={eagerReveal ? '' : undefined}>
     <!-- Skip to content link -->
     <a
       href="#main-content"
@@ -268,6 +270,7 @@ if (includeProfessionalServiceSchema) {
         function initReveal() {
           const els = document.querySelectorAll('[data-reveal]:not(.is-visible)');
           if (!els.length) return;
+          var eager = document.body.hasAttribute('data-eager-reveal');
           const observer = new IntersectionObserver(function (entries) {
             entries.forEach(function (entry) {
               if (entry.isIntersecting) {
@@ -275,7 +278,7 @@ if (includeProfessionalServiceSchema) {
                 observer.unobserve(entry.target);
               }
             });
-          }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
+          }, { threshold: 0.12, rootMargin: eager ? '0px 0px 200px 0px' : '0px 0px -40px 0px' });
           els.forEach(function (el) { observer.observe(el); });
         }
 

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -16,9 +16,10 @@ interface Props {
   noindex?: boolean;
   nofollow?: boolean;
   showScrollProgress?: boolean;
+  eagerReveal?: boolean;
 }
 
-const { title, description, image, imageAlt, noindex, nofollow, showScrollProgress = false } = Astro.props;
+const { title, description, image, imageAlt, noindex, nofollow, showScrollProgress = false, eagerReveal = false } = Astro.props;
 
 ---
 
@@ -29,6 +30,7 @@ const { title, description, image, imageAlt, noindex, nofollow, showScrollProgre
   imageAlt={imageAlt}
   noindex={noindex}
   nofollow={nofollow}
+  eagerReveal={eagerReveal}
 >
   <Header
     slot="header"

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -20,6 +20,7 @@ const location = siteConfig.address?.city
 <PageLayout
   title={`About — ${siteConfig.name}`}
   description="Astro Rocket is a production-ready Astro 6 starter with 12 beautiful themes, 57+ components, built-in i18n, dark mode and a fast, modern foundation to build anything on."
+  eagerReveal
 >
   <Hero layout="centered" size="sm">
     <Badge slot="badge" variant="brand" pill>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -37,6 +37,7 @@ const channels = [
 <PageLayout
   title="Contact — Astro Rocket"
   description="Get in touch"
+  eagerReveal
 >
   <Hero layout="centered" size="sm">
     <Badge slot="badge" variant="brand" pill>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -18,6 +18,7 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
 <PageLayout
   title="Projects — Astro Rocket"
   description="Selected work — websites, tools, and open-source projects built by Astro Rocket."
+  eagerReveal
 >
   <Hero layout="centered" size="sm">
     <Badge slot="badge" variant="brand" pill>


### PR DESCRIPTION
Pages with short heroes (about, projects, contact) had content just below the fold that never revealed because the IntersectionObserver negative rootMargin kept it invisible until scroll. Added eagerReveal prop that switches to a positive rootMargin (200px lookahead) so the first content section is revealed on load without requiring scroll.

https://claude.ai/code/session_01Eafdfnv3jH8vg7ZpHyPQVt

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
