### PR TITLE
fix: replace var with const to satisfy no-var lint rule

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -270,7 +270,7 @@ if (includeProfessionalServiceSchema) {
         function initReveal() {
           const els = document.querySelectorAll('[data-reveal]:not(.is-visible)');
           if (!els.length) return;
-          var eager = document.body.hasAttribute('data-eager-reveal');
+          const eager = document.body.hasAttribute('data-eager-reveal');
           const observer = new IntersectionObserver(function (entries) {
             entries.forEach(function (entry) {
               if (entry.isIntersecting) {


### PR DESCRIPTION
BaseLayout.astro line 273 used var for the eager flag, causing the ESLint no-var error that broke the GitHub Actions build job.

https://claude.ai/code/session_01QwvhUMjEpxArcjTF4NTC5w

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
