### PR TITLE
fix: clamp scroll progress to [0,1] to prevent ring wrap-around on mo…

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -260,7 +260,7 @@ if (includeProfessionalServiceSchema) {
 
           function updateFrame() {
             const scrollable = document.documentElement.scrollHeight - window.innerHeight;
-            const pct = scrollable > 0 ? window.scrollY / scrollable : 0;
+            const pct = scrollable > 0 ? Math.min(1, Math.max(0, window.scrollY / scrollable)) : 0;
             if (ring) {
               ring.style.strokeDashoffset = String(CIRCUMFERENCE * (1 - pct));
             }


### PR DESCRIPTION
…bile

On mobile, the browser URL bar dynamically resizes window.innerHeight as you scroll, which can make the computed scrollable height smaller and push the scroll percentage above 1.0. This produced a negative strokeDashoffset, causing the progress ring to overshoot and restart from the beginning.

https://claude.ai/code/session_01XMNr4EGXsqPDfwc9hq8B7T

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
