### PR TITLE
feat: add rocket watermark to homepage hero background

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -18,6 +18,8 @@ interface Props extends HTMLAttributes<'section'> {
   showScrollIndicator?: boolean;
   /** Max-width class for the description wrapper (default: max-w-xl) */
   descriptionClass?: string;
+  /** Show a large rocket icon watermark in the background */
+  showRocketBg?: boolean;
 }
 
 const {
@@ -27,6 +29,7 @@ const {
   showGlow = false,
   bottomFade = false,
   showScrollIndicator = false,
+  showRocketBg = false,
   descriptionClass = 'max-w-xl',
   class: className,
   ...attrs
@@ -57,6 +60,29 @@ const gridClasses = cn(
 ---
 
 <section class={sectionClasses} {...attrs}>
+  {showRocketBg && (
+    <div
+      class="pointer-events-none absolute inset-0 flex items-center justify-center"
+      aria-hidden="true"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="0.75"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="w-[min(80vw,680px)] h-[min(80vw,680px)] text-brand-500 opacity-[0.04] dark:opacity-[0.08]"
+      >
+        <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
+        <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/>
+      </svg>
+    </div>
+  )}
+
   {showGrid && (
     <div
       class="bg-grid-pattern pointer-events-none absolute inset-x-0 -inset-y-[20%] opacity-30 hidden dark:block"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,7 +30,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   includeProfessionalServiceSchema={true}
 >
   <!-- Hero -->
-  <Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator descriptionClass="max-w-3xl">
+  <Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator showRocketBg descriptionClass="max-w-3xl">
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">Available for new projects</Badge>
 
     <h1 slot="title">


### PR DESCRIPTION
Adds a large, low-opacity Lucide rocket SVG behind the hero content. Uses text-brand-500 so it follows the active color theme automatically, and opacity-[0.04]/dark:opacity-[0.08] for balanced visibility in both light and dark mode. Scales responsively with min(80vw, 680px).

https://claude.ai/code/session_01XMNr4EGXsqPDfwc9hq8B7T

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
