### PR TITLE
fix: normalize font sizes in scroll-progress-ring and hero-scroll-ind…

### DIFF
--- a/src/assets/blog/hero-scroll-indicator.svg
+++ b/src/assets/blog/hero-scroll-indicator.svg
@@ -17,10 +17,10 @@
   <g transform="translate(552, 220) scale(4)" class="ico" opacity="0.4">
     <polyline points="6 9 12 15 18 9" />
   </g>
-  <text x="600" y="412" font-size="80" text-anchor="middle" letter-spacing="-1" class="txt">scroll indicator</text>
+  <text x="600" y="412" font-size="96" text-anchor="middle" letter-spacing="-1" class="txt">scroll indicator</text>
   <line x1="360" y1="438" x2="840" y2="438" class="ln"/>
   <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="488" font-size="13" text-anchor="middle" letter-spacing="1.5" class="ptx">hansmartens.dev</text>
+  <text x="600" y="488" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/scroll-progress-ring.svg
+++ b/src/assets/blog/scroll-progress-ring.svg
@@ -31,10 +31,10 @@
     <path d="m18 15-6-6-6 6" stroke="var(--brand-100)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
   </g>
 
-  <text x="600" y="410" font-size="80" text-anchor="middle" letter-spacing="-2" class="txt">progress ring</text>
+  <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">progress ring</text>
   <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
   <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="488" font-size="13" text-anchor="middle" letter-spacing="1.5" class="ptx">hansmartens.dev</text>
+  <text x="600" y="488" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>


### PR DESCRIPTION
…icator SVGs

Title text bumped from 80 to 96 to match other two-word titles; watermark text standardized from 13 to 16 with letter-spacing removed, consistent with all other blog image SVGs.

https://claude.ai/code/session_018JDvjFkFX6zfdNyGyqQ6aq

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
