### PR TITLE
feat: show rocket icon on dark-mode portrait mobile screens

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -62,7 +62,7 @@ const gridClasses = cn(
 <section class={sectionClasses} {...attrs}>
   {showRocketBg && (
     <div
-      class="pointer-events-none absolute inset-0 hidden dark:lg:flex items-center justify-center"
+      class="pointer-events-none absolute inset-0 hidden dark:portrait:flex dark:lg:flex items-center justify-center"
       aria-hidden="true"
     >
       <svg
@@ -73,7 +73,7 @@ const gridClasses = cn(
         stroke-width="0.75"
         stroke-linecap="round"
         stroke-linejoin="round"
-        class="w-[min(55vw,420px)] h-[min(55vw,420px)] text-brand-500 opacity-[0.27]"
+        class="w-[min(55vw,420px)] portrait:w-[min(80vw,420px)] h-[min(55vw,420px)] portrait:h-[min(80vw,420px)] text-brand-500 opacity-[0.27]"
       >
         <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
         <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>


### PR DESCRIPTION
Add dark:portrait:flex to the rocket background wrapper so it appears on portrait-oriented mobile devices in dark mode, alongside the existing dark:lg:flex for large screens. Use portrait: size overrides (min(80vw,420px)) for the wider mobile silhouette.

https://claude.ai/code/session_01HL54vrF15P9Fnb5rhH2gs6

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
