### PR TITLE
fix: shorten hero-rocket-background description to fit 200-char limit

### DIFF
--- a/src/content/blog/en/hero-rocket-background.mdx
+++ b/src/content/blog/en/hero-rocket-background.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Hero Rocket Background — Dark Mode on Desktop and Portrait Mobile"
-description: "A large faint rocket icon sits in the background of the homepage hero in dark mode. It shows on desktop at all orientations and on mobile in portrait mode. It follows the active colour theme automatically and can be toggled off with a single prop."
+description: "A large faint rocket icon in the homepage hero background, visible in dark mode on desktop and on portrait mobile. Colour-theme-aware and toggled with a single prop."
 publishedAt: 2026-04-17
 author: "Hans Martens"
 tags: ["astro-rocket", "features", "dark-mode", "hero", "design"]


### PR DESCRIPTION
The content schema enforces z.string().max(200) on description; the previous rewrite was ~247 characters and caused a build failure.

https://claude.ai/code/session_01HL54vrF15P9Fnb5rhH2gs6

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
