### PR TITLE
fix: add eagerReveal to blog index so cards animate on page load

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -38,7 +38,7 @@ const getPostUrl = (postId: string) => {
 };
 ---
 
-<PageLayout title="Blog — Astro Rocket" description="Articles on web design, development, and the web by Astro Rocket." showScrollProgress>
+<PageLayout title="Blog — Astro Rocket" description="Articles on web design, development, and the web by Astro Rocket." showScrollProgress eagerReveal>
   <Hero layout="centered" size="sm">
     <Badge slot="badge" variant="brand" pill>
       <Icon name="book" size="sm" />


### PR DESCRIPTION
On mobile portrait the small hero fills the viewport, pushing the featured section and blog cards just below the fold. The IntersectionObserver's -40px rootMargin prevented them from triggering without user scroll. Adding eagerReveal extends the rootMargin to +200px so elements reveal automatically on load, matching the fix applied to other short-hero pages (about, contact, projects).

https://claude.ai/code/session_01WzFtTide2V66nxrE86wEqf

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
