### PR TITLE
Update readme hero and OG images to sky theme colors

### DIFF
--- a/public/og-default.svg
+++ b/public/og-default.svg
@@ -1,10 +1,10 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Background -->
-  <rect width="1200" height="630" fill="#2563eb"/>
+  <rect width="1200" height="630" fill="#0284c7"/>
 
   <!-- Lucide Rocket — scale(5), visual centre at (600, 240) -->
   <g transform="translate(540, 180) scale(5)"
-     stroke="#dbeafe" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
+     stroke="#e0f2fe" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
     <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
     <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
     <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
@@ -13,23 +13,23 @@
 
   <!-- Wordmark -->
   <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-4"
-        fill="#eff6ff"
+        fill="#f0f9ff"
         font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
         font-weight="800">Astro Rocket</text>
 
   <!-- Divider -->
-  <line x1="380" y1="436" x2="820" y2="436" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.35"/>
+  <line x1="380" y1="436" x2="820" y2="436" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.35"/>
 
   <!-- Domain pill -->
   <rect x="450" y="464" width="300" height="38" rx="19"
-        fill="#3b82f6" fill-opacity="0.25" stroke="#93c5fd" stroke-opacity="0.4" stroke-width="1"/>
+        fill="#0ea5e9" fill-opacity="0.25" stroke="#7dd3fc" stroke-opacity="0.4" stroke-width="1"/>
   <text x="600" y="488" font-size="13" text-anchor="middle" letter-spacing="1.5"
-        fill="#dbeafe"
+        fill="#e0f2fe"
         font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">hansmartens.dev</text>
 
   <!-- Corner marks -->
-  <path d="M 36 60 L 36 36 L 60 36"     stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 1140 36 L 1164 36 L 1164 60"   stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 36 570 L 36 594 L 60 594"   stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 1140 594 L 1164 594 L 1164 570" stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 36 60 L 36 36 L 60 36"     stroke="#38bdf8" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 1140 36 L 1164 36 L 1164 60"   stroke="#38bdf8" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 36 570 L 36 594 L 60 594"   stroke="#38bdf8" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 1140 594 L 1164 594 L 1164 570" stroke="#38bdf8" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
 </svg>

--- a/public/readme-hero.svg
+++ b/public/readme-hero.svg
@@ -1,10 +1,10 @@
 <svg width="880" height="260" viewBox="0 0 880 260" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Background -->
-  <rect width="880" height="260" fill="#2563eb"/>
+  <rect width="880" height="260" fill="#0284c7"/>
 
   <!-- Lucide Rocket — scale(5), visual centre at (440, 100) -->
   <g transform="translate(379, 41) scale(5)"
-     stroke="#dbeafe" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
+     stroke="#e0f2fe" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
     <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
     <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
     <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
@@ -16,11 +16,11 @@
         text-anchor="middle"
         font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
         font-weight="800" font-size="62" letter-spacing="-1.5"
-        fill="#eff6ff">Astro Rocket</text>
+        fill="#f0f9ff">Astro Rocket</text>
 
   <!-- Corner marks -->
-  <path d="M 30 50 L 30 30 L 50 30"     stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 830 30 L 850 30 L 850 50"   stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 30 210 L 30 230 L 50 230"   stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 830 230 L 850 230 L 850 210" stroke="#60a5fa" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 30 50 L 30 30 L 50 30"     stroke="#38bdf8" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 830 30 L 850 30 L 850 50"   stroke="#38bdf8" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 30 210 L 30 230 L 50 230"   stroke="#38bdf8" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 830 230 L 850 230 L 850 210" stroke="#38bdf8" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
 </svg>


### PR DESCRIPTION
Replaces Tailwind blue palette with Tailwind sky palette to match the site's default sky theme (hue 222°, inspired by Tailwind's sky palette).

https://claude.ai/code/session_01GWaLtrfM89uBr9EDQhZSMw

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
