### PR TITLE
Animate hero rocket background with fade-in and float

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -73,7 +73,8 @@ const gridClasses = cn(
         stroke-width="0.75"
         stroke-linecap="round"
         stroke-linejoin="round"
-        class="w-[min(55vw,420px)] portrait:w-[min(80vw,420px)] h-[min(55vw,420px)] portrait:h-[min(80vw,420px)] text-brand-500 opacity-[0.27]"
+        class="rocket-bg w-[min(55vw,420px)] portrait:w-[min(80vw,420px)] h-[min(55vw,420px)] portrait:h-[min(80vw,420px)] text-brand-500"
+        style="opacity: 0;"
       >
         <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
         <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
@@ -216,10 +217,27 @@ const gridClasses = cn(
     50%       { transform: translateY(5px); }
   }
 
+  .rocket-bg {
+    animation:
+      rocket-fade-in 0.9s cubic-bezier(0, 0, 0.2, 1) 0.4s forwards,
+      rocket-float 4.5s ease-in-out 1.3s infinite;
+  }
+
+  @keyframes rocket-fade-in {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 0.27; transform: translateY(0); }
+  }
+
+  @keyframes rocket-float {
+    0%, 100% { transform: translateY(0); }
+    50%      { transform: translateY(-10px); }
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .scroll-indicator              { animation: none; opacity: 1; }
     .scroll-indicator-chevron,
     .scroll-indicator-chevron-2    { animation: none; }
+    .rocket-bg                     { animation: none; opacity: 0.27; }
   }
 </style>
 


### PR DESCRIPTION
Adds rocket-bg class and two chained CSS animations: a 0.9s fade-in slide-up (delay 0.4s) that settles at opacity 0.27, followed by an infinite 4.5s gentle float (delay 1.3s). Reduced-motion users get a static rocket at opacity 0.27 with no animation.

https://claude.ai/code/session_01Am2qzPdEWPjshjUs4UtPMT

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
