### PR TITLE
feat(header): always-on frosted glass effect for floating header

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -663,10 +663,18 @@ const buttonId = `${menuId}-button`;
     transition: opacity 200ms, filter 200ms;
   }
 
-  /* ===== Floating header: scroll state ===== */
+  /* ===== Floating header: always-on frosted glass ===== */
+  [data-header-shape="floating"] {
+    background: color-mix(in oklch, var(--color-background) 30%, transparent);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-color: color-mix(in oklch, var(--color-border) 40%, transparent);
+  }
+
   [data-header-shape="floating"][data-scrolled] {
-    background: color-mix(in oklch, var(--color-background) 92%, transparent);
+    background: color-mix(in oklch, var(--color-background) 45%, transparent);
     backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
     border-color: var(--color-border);
     box-shadow: 0 4px 20px -6px rgba(0, 0, 0, 0.1);
   }

--- a/src/components/layout/header.variants.ts
+++ b/src/components/layout/header.variants.ts
@@ -14,7 +14,7 @@ export const headerVariants = cva('z-50', {
     },
     shape: {
       bar: 'w-full transition-[background,border-color,box-shadow,backdrop-filter] duration-300',
-      floating: 'rounded-2xl transition-[background,border-color,box-shadow] duration-300',
+      floating: 'rounded-2xl transition-[background,border-color,box-shadow,backdrop-filter] duration-300',
     },
   },
   compoundVariants: [
@@ -27,7 +27,7 @@ export const headerVariants = cva('z-50', {
     // Floating + transparent: glass effect
     { shape: 'floating', variant: 'transparent', class: 'bg-white/[0.06] backdrop-blur-xl border border-white/[0.08]' },
     // Floating + default: semi-transparent with blur
-    { shape: 'floating', variant: 'default', class: '!bg-background/80 backdrop-blur-xl !border border-border/50 !border-b-border/50' },
+    { shape: 'floating', variant: 'default', class: 'border' },
     // Floating + solid: opaque
     { shape: 'floating', variant: 'solid', class: '!bg-background !border border-border !border-b-border' },
   ],


### PR DESCRIPTION
Remove !important Tailwind overrides that blocked CSS from applying, and add a base [data-header-shape="floating"] rule so the glass effect is visible from page load (30% opaque, blur-16) rather than only after scrolling. The scrolled state bumps to 45% opacity and blur-24 with a subtle shadow. Also adds backdrop-filter to the floating transition list.

https://claude.ai/code/session_01NXDESjZfmyC97E9zd6GdWF

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
