### PR TITLE
Add data-reveal attribute to CTA inner content wrapper

### DIFF
--- a/src/components/ui/marketing/CTA/CTA.astro
+++ b/src/components/ui/marketing/CTA/CTA.astro
@@ -60,7 +60,7 @@ const hasActionsSlot = Astro.slots.has('actions');
       aria-hidden="true"
     />
   )}
-    <div class={cn(maxWidths[maxWidth], 'relative z-10 text-center mx-auto')}>
+    <div data-reveal class={cn(maxWidths[maxWidth], 'relative z-10 text-center mx-auto')}>
       {/* Logo Slot - renders before heading */}
       {hasLogoSlot && (
         <div class="mb-[var(--space-stack-lg)]">


### PR DESCRIPTION
Adds data-reveal to the content div so the CTA section participates in the scroll-reveal animation system, consistent with other page sections.

https://claude.ai/code/session_0119W4aZKAxEfi7Fcp3XBdrk

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
