### PR TITLE
feat(blog): replace component-library CTA link with primary button

### DIFF
--- a/src/content/blog/en/component-library.mdx
+++ b/src/content/blog/en/component-library.mdx
@@ -11,9 +11,12 @@ svgSlug: "component-library"
 imageAlt: "Dashboard layout icon above the word 'components' with a large faint '57' in the background"
 ---
 
+import Button from '@/components/ui/form/Button/Button.astro';
+import Icon from '@/components/ui/primitives/Icon/Icon.astro';
+
 Astro Rocket inherits a complete UI component library from [Velocity](https://github.com/southwellmedia/velocity) by Southwell Media. That means 57 production-ready components are available the moment you install the theme — no npm packages to install, no extra setup. Every component is already styled with the design system's color tokens, so they adapt automatically when you switch themes or toggle dark mode.
 
-**See every component live:** [/components](/components)
+<Button href="/components"><Icon name="component" />See every component live</Button>
 
 The library is organized in three layers: 31 UI primitives that form the building blocks, 7 higher-level pattern components, and a set of page-structure components for the Hero, Header, Footer, Blog, and SEO layers.
 


### PR DESCRIPTION
Changes "See every component live: /components" text link to a styled primary Button with a component icon, matching the site's UI patterns.

https://claude.ai/code/session_01Fckzhze9nV2iUkA5msGwiT

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
