### PR TITLE
Fix blog post inaccuracies found during theme audit

### DIFF
--- a/src/components/layout/ThemeSelector.astro
+++ b/src/components/layout/ThemeSelector.astro
@@ -1,8 +1,8 @@
 ---
 /**
  * ThemeSelector
- * A row of five colour swatches that switches the active colour theme at
- * runtime by writing `data-theme` on <html> and persisting to localStorage.
+ * A row of twelve colour swatches that switches the active colour theme at
+ * runtime by writing `data-theme` on <html> and persisting to sessionStorage.
  *
  * Usage in Header:  <ThemeSelector />
  * Pass `class` to tint the label colour for floating / inverted headers.
@@ -13,7 +13,7 @@ interface Props {
 
 const { class: className } = Astro.props;
 
-// All 13 themes in Tailwind color order
+// All 12 themes in Tailwind color order
 const themes = [
   { id: 'orange',  name: 'Orange',  color: 'oklch(62.5% 0.22  38)'  },
   { id: 'amber',   name: 'Amber',   color: 'oklch(68%   0.19  75)'  },

--- a/src/content/blog/en/astro-rocket-configuration-guide.mdx
+++ b/src/content/blog/en/astro-rocket-configuration-guide.mdx
@@ -73,13 +73,13 @@ When `true`, a translucent brand-colour tint is applied over blog cover images. 
 The default mode is set directly in the HTML element in `src/layouts/BaseLayout.astro`:
 
 ```html
-<html lang="en" class="scroll-smooth dark" data-theme="sky">
+<html lang="en" class="scroll-smooth dark" data-theme="blue">
 ```
 
 The `dark` class is what activates dark mode on first load. Remove it to default to light:
 
 ```html
-<html lang="en" class="scroll-smooth" data-theme="sky">
+<html lang="en" class="scroll-smooth" data-theme="blue">
 ```
 
 The user's preference during their session is stored in `sessionStorage` — so it persists while the tab is open but resets when they open a new tab. This is intentional for a portfolio or marketing site. If you want it to persist across sessions, swap the `sessionStorage` calls for `localStorage` in the same file.
@@ -92,7 +92,7 @@ The landing page (`src/pages/index.astro`) passes three boolean props to `Landin
 <LandingLayout
   includePersonSchema={true}
   includeOrgSchema={false}
-  includeProfessionalServiceSchema={false}
+  includeProfessionalServiceSchema={true}
 >
 ```
 
@@ -158,7 +158,7 @@ Astro Rocket ships with **12 colour themes**. All 12 are shown as coloured swatc
 The default theme is set with `data-theme` on the `<html>` element in `src/layouts/BaseLayout.astro`:
 
 ```html
-data-theme="sky"
+data-theme="blue"
 ```
 
 Available values — all 12 themes:
@@ -171,16 +171,16 @@ Available values — all 12 themes:
 | `emerald` | 160° | All-rounder — works for SaaS, portfolios, and organic brands |
 | `teal` | 190° | Developer tooling, modern SaaS, trustworthy services |
 | `cyan` | 200° | Fresh, vibrant tech — more energetic than teal |
-| `sky` | 222° | Clean and airy — between teal and blue, great for services — the default |
-| `blue` | 255° | Studio aesthetic (Linear/Raycast feel), authoritative |
+| `sky` | 222° | Clean and airy — between teal and blue, great for services |
+| `blue` | 255° | Studio aesthetic (Linear/Raycast feel), authoritative — the default |
 | `indigo` | 264° | Enterprise, productivity tools, serious B2B |
 | `violet` | 277° | Creative and premium — sweet spot between indigo and purple |
-| `purple` | 292° | Expressive, personality-forward, vivid |
+| `purple` | 303° | Expressive, personality-forward, vivid |
 | `magenta` | 330° | Creative agencies, bold personal brands — maximum vivid |
 
 ### The live theme selector
 
-All 12 themes appear as colour swatches in the header dropdown (desktop) and in the mobile menu when `showThemeSelector` is enabled on the `<Header>` component. The visitor's choice is saved to `localStorage` and persists across sessions.
+All 12 themes appear as colour swatches in the header dropdown (desktop) and in the mobile menu when `showThemeSelector` is enabled on the `<Header>` component. The visitor's choice is saved to `sessionStorage` and persists for the duration of the tab session — consistent with how the dark/light mode preference is stored.
 
 The `themes` array in `src/components/layout/ThemeSelector.astro` controls which swatches are shown and in what order. The current set:
 
@@ -213,7 +213,7 @@ All colour values in Astro Rocket use the OKLCH colour space: `oklch(lightness% 
 | **Chroma** | 0 (grey) → ~0.37 (maximum vivid) | How saturated the colour is |
 | **Hue** | 0–360° | The colour angle on the wheel |
 
-Common hue landmarks: 0°/360° = red, 38° = orange, 75° = amber, 130° = lime, 155–160° = green, 190–200° = teal/cyan, 222° = sky, 255° = blue, 264° = indigo, 292° = purple, 330° = magenta.
+Common hue landmarks: 0°/360° = red, 38° = orange, 75° = amber, 130° = lime, 155–160° = green, 190–200° = teal/cyan, 222° = sky, 255° = blue, 264° = indigo, 277° = violet, 303° = purple, 330° = magenta.
 
 To shift a theme to a completely different colour, you only need to change the hue number across the `--brand-50` to `--brand-900` scale — keep the lightness and chroma values the same and the whole palette moves together. Use [oklch.com](https://oklch.com) to pick visually.
 
@@ -222,7 +222,7 @@ To shift a theme to a completely different colour, you only need to change the h
 Every theme is a CSS file in `src/styles/themes/`. Each file defines the full set of colour tokens for both light and dark mode. Open the relevant file and adjust the `--brand-*` scale — all ten steps from 50 to 900:
 
 ```css
-html[data-theme="sky"] {
+html[data-theme="blue"] {
   --brand-50:  oklch(97.5% 0.02 255);
   --brand-100: oklch(94.8% 0.04 255);
   --brand-200: oklch(87.5% 0.08 255);
@@ -479,9 +479,10 @@ Edit `src/config/nav.config.ts` to change the header and footer navigation in on
 
 ```ts
 export const navItems: NavItem[] = [
-  { label: 'Blog',    href: '/blog',    order: 1 },
-  { label: 'About',   href: '/about',   order: 2 },
-  { label: 'Contact', href: '/contact', order: 3 },
+  { label: 'Blog',     href: '/blog',     order: 1 },
+  { label: 'Projects', href: '/projects', order: 2 },
+  { label: 'About',    href: '/about',    order: 3 },
+  { label: 'Contact',  href: '/contact',  order: 4 },
 ];
 ```
 
@@ -534,12 +535,12 @@ Remove any URL you don't use. The footer won't render an empty social section. I
 | Twitter card handles | `src/config/site.config.ts` | `twitter.site`, `twitter.creator` |
 | Search console verification | `.env` or `site.config.ts` | `verification.google/bing` |
 | Navigation items | `src/config/nav.config.ts` | `navItems` array |
-| Default colour theme | `src/layouts/BaseLayout.astro` | `data-theme="sky"` |
+| Default colour theme | `src/layouts/BaseLayout.astro` | `data-theme="blue"` |
 | Default dark/light mode | `src/layouts/BaseLayout.astro` | `class="dark"` on `<html>` |
 | JSON-LD schema switches | `src/pages/index.astro` | `includePersonSchema`, `includeOrgSchema` |
 | noindex / nofollow | any layout | `noindex={true}`, `nofollow={true}` |
 | Live theme selector (12 swatches) | `src/components/layout/ThemeSelector.astro` | `themes` array |
-| All 12 theme files | `src/styles/themes/` | One CSS file per theme |
+| All 12 theme files | `src/styles/themes/` | One CSS file per theme (13 files exist — `green.css` is available but not in the picker) |
 | Brand colour scale (light & dark) | `src/styles/themes/*.css` | `--brand-50` → `--brand-900` |
 | Typography (fonts, weight, tracking) | `src/styles/themes/*.css` | `--theme-font-*`, `--theme-heading-*` |
 | Border radius (global roundness) | `src/styles/themes/*.css` | `--theme-radius-sm/md/lg/xl/full` |

--- a/src/content/blog/en/astro-rocket-getting-started.mdx
+++ b/src/content/blog/en/astro-rocket-getting-started.mdx
@@ -50,18 +50,26 @@ Start here. The `name` field populates the logo badge, page titles, footer copyr
 
 ### Brand colour
 
-Set your brand colour in the `branding.colors` section:
+Astro Rocket ships with 12 ready-to-use colour themes. Pick your preferred theme by setting the `data-theme` attribute in `src/layouts/BaseLayout.astro`:
+
+```html
+<html lang="en" class="scroll-smooth dark" data-theme="blue">
+```
+
+Available values: `orange`, `amber`, `lime`, `emerald`, `teal`, `cyan`, `sky`, `blue`, `indigo`, `violet`, `purple`, `magenta`. The theme CSS files live in `src/styles/themes/` — open the active one to fine-tune the `--brand-*` colour scale if needed.
+
+The `branding.colors` section in `site.config.ts` controls two unrelated browser values:
 
 ```ts
 branding: {
   colors: {
-    themeColor: '#F94C10',       // Your primary brand colour
-    backgroundColor: '#ffffff',  // Used in the web app manifest
+    themeColor: '#3b82f6',       // Browser toolbar colour on mobile Chrome/Safari
+    backgroundColor: '#ffffff',  // PWA splash screen background
   },
 },
 ```
 
-The `themeColor` drives every brand-coloured element across the site — buttons, links, the logo badge, highlights, and the favicon — through a single CSS custom property. Change it once and the entire site updates.
+Update `themeColor` to a hex that matches your chosen brand colour so the mobile browser chrome looks polished — it does not affect any on-page colours.
 
 ### Navigation
 
@@ -69,10 +77,10 @@ Open `src/config/nav.config.ts`. This is the only file you need to touch to chan
 
 ```ts
 export const navItems: NavItem[] = [
-  { label: 'Home',    href: '/'        },
-  { label: 'Blog',    href: '/blog'    },
-  { label: 'About',   href: '/about'   },
-  { label: 'Contact', href: '/contact' },
+  { label: 'Blog',     href: '/blog',     order: 1 },
+  { label: 'Projects', href: '/projects', order: 2 },
+  { label: 'About',    href: '/about',    order: 3 },
+  { label: 'Contact',  href: '/contact',  order: 4 },
 ];
 ```
 

--- a/src/content/blog/en/astro-rocket-is-live.mdx
+++ b/src/content/blog/en/astro-rocket-is-live.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Astro Rocket Is Live — My New Open Source Astro Theme"
-description: "Astro Rocket is a production-ready Astro 6 theme with a full blog, 57 components, 12 colour themes, dark mode, SEO, and a contact form. Free and open source."
+description: "Astro Rocket is a production-ready Astro 6 theme with a full blog, 59 components, 12 colour themes, dark mode, SEO, and a contact form. Free and open source."
 publishedAt: 2026-03-28
 author: "Hans Martens"
 tags: ["astro-rocket", "open-source", "astro", "launch"]
@@ -51,7 +51,7 @@ Everything from Velocity is still there, and it's all fully integrated:
 
 **A full blog** — built on Astro Content Collections with MDX support. Every post has a typed frontmatter schema, tag filtering, a related posts section, a reading time indicator, and automatically generated Open Graph metadata.
 
-**57 components** — 31 UI components (Button, Input, Card, Badge, Avatar, Table, Tabs, Dialog, Accordion, and more), 7 pattern components (ContactForm, NewsletterForm, StatCard, and more), plus Hero, Header, Footer, BlogCard, ShareButtons, and SEO components.
+**59 components** — 33 UI components (Button, Input, Card, Badge, Avatar, AvatarGroup, GoogleMap, Table, Tabs, Dialog, Accordion, and more), 7 pattern components (ContactForm, NewsletterForm, StatCard, and more), plus Hero, Header, Footer, BlogCard, ShareButtons, and SEO components.
 
 **A complete SEO layer** — meta tags, Open Graph, Twitter Cards, JSON-LD structured data (WebSite, Organization, BlogPosting, Breadcrumb, FAQ), an auto-generated sitemap, and robots.txt.
 

--- a/src/content/blog/en/component-library.mdx
+++ b/src/content/blog/en/component-library.mdx
@@ -20,7 +20,7 @@ Astro Rocket inherits a complete UI component library from [Velocity](https://gi
   <Button href="/components" class="!bg-brand-500 ![background-image:none] !text-white dark:!border-transparent hover:!bg-brand-600"><Icon name="component" />See every component live<Icon name="arrow-right" /></Button>
 </div>
 
-The library is organized in three layers: 31 UI primitives that form the building blocks, 7 higher-level pattern components, and a set of page-structure components for the Hero, Header, Footer, Blog, and SEO layers.
+The library is organized in three layers: 33 UI primitives that form the building blocks, 7 higher-level pattern components, and a set of page-structure components for the Hero, Header, Footer, Blog, and SEO layers.
 
 ---
 
@@ -54,7 +54,7 @@ import Input from '@/components/ui/form/Input/Input.astro';
 <Input label="Email address" type="email" placeholder="you@example.com" />
 ```
 
-### Data display (8 components)
+### Data display (9 components)
 
 | Component | What it does |
 |-----------|--------------|
@@ -66,6 +66,7 @@ import Input from '@/components/ui/form/Input/Input.astro';
 | `Pagination` | Page navigation with prev/next and numbered page buttons. |
 | `Progress` | Horizontal progress bar that fills to a percentage value. |
 | `Skeleton` | Loading placeholder that pulses in the shape of the content it replaces. |
+| `GoogleMap` | Embeds an interactive Google Map via iframe. Accepts address, zoom, and size props. |
 
 ```astro
 ---
@@ -203,9 +204,9 @@ Place new components in the matching subdirectory under `src/components/`:
 src/components/
 ├── ui/
 │   ├── form/          # Button, Input, Select, Checkbox, Radio, Switch, Textarea
-│   ├── data-display/  # Card, Badge, Avatar, Table, Pagination, Progress, Skeleton
+│   ├── data-display/  # Card, Badge, Avatar, AvatarGroup, GoogleMap, Table, Pagination, Progress, Skeleton
 │   ├── feedback/      # Alert, Toast, Tooltip
-│   ├── overlay/       # Dialog, Dropdown, Tabs, VerticalTabs, Accordion
+│   ├── overlay/       # Dialog, Dropdown, Tabs, VerticalTabs, Accordion, ConsentBanner
 │   ├── layout/        # Separator
 │   ├── primitives/    # Icon
 │   ├── content/       # CodeBlock
@@ -284,7 +285,7 @@ import { Counter } from '@/components/ui';
 
 ## Browse the live demo
 
-The fastest way to get a feel for all 57 components is the live component demo. Every component is rendered with live props you can inspect:
+The fastest way to get a feel for all 59 components is the live component demo. Every component is rendered with live props you can inspect:
 
 **[/components](/components)**
 

--- a/src/content/blog/en/dark-mode-hero-gradient.mdx
+++ b/src/content/blog/en/dark-mode-hero-gradient.mdx
@@ -44,7 +44,7 @@ Dark mode in Astro Rocket is class-based, not media-query-based. The custom vari
 @custom-variant dark (&:where(.dark, .dark *));
 ```
 
-This means the `.dark` class is toggled on the root element based on the user's explicit theme choice, or their system preference on first visit. The `.dark .hero-dark-gradient` rule activates the moment that class is present — no JavaScript is needed for the gradient itself. See [Why Astro Rocket Uses sessionStorage for Dark Mode](/blog/dark-mode-sessionstorage) for how that choice is stored and restored between page loads.
+This means the `.dark` class is toggled on the root element based on the user's explicit theme choice during the current session. The `.dark .hero-dark-gradient` rule activates the moment that class is present — no JavaScript is needed for the gradient itself. See [Why Astro Rocket Uses sessionStorage for Dark Mode](/blog/dark-mode-sessionstorage) for how that choice is stored and restored between page loads.
 
 ## Applying it
 

--- a/src/content/blog/en/seo-in-astro-rocket.mdx
+++ b/src/content/blog/en/seo-in-astro-rocket.mdx
@@ -30,11 +30,11 @@ None of these require per-page setup. They are wired into the base layout and ru
 
 Structured data is the part most themes skip. Astro Rocket outputs [JSON-LD](https://json-ld.org/) schema.org markup on every page.
 
-**Home page** outputs three schemas:
+**Home page** outputs three schemas (exact set depends on which schema props are enabled in `src/pages/index.astro`):
 
-- `WebSite` — site name, URL, and search action
-- `Organization` — your organisation name, logo, and contact details
-- `Person` — the site author
+- `WebSite` — site name, URL, and search action (always included)
+- `Person` — the site author (enabled by default via `includePersonSchema`)
+- `ProfessionalService` — professional service details with address and area served (enabled by default via `includeProfessionalServiceSchema`)
 
 **Blog posts** output `BlogPosting` with full metadata:
 


### PR DESCRIPTION
- ThemeSelector.astro: fix JSDoc (5→12 swatches, localStorage→sessionStorage) and inline comment (13→12 themes)
- astro-rocket-getting-started: rewrite themeColor section (it sets browser toolbar color, not brand colors); fix nav config (add Projects, add order fields, remove non-existent Home)
- astro-rocket-configuration-guide: fix theme selector storage (localStorage→sessionStorage); fix default theme (sky→blue in HTML examples, table, and quick reference); fix purple hue (292°→303°); add violet to OKLCH landmarks; fix brand scale example label (sky→blue); fix schema switches example (includeProfessionalServiceSchema false→true); fix nav config (add Projects); note green.css exists but is not in picker
- seo-in-astro-rocket: fix homepage schemas (Organization→Person+ProfessionalService, which reflects actual index.astro config)
- component-library: fix UI count (31→33); add GoogleMap to data-display table (8→9 components); update directory diagram to include AvatarGroup, GoogleMap, ConsentBanner; update live demo count (57→59)
- astro-rocket-is-live: fix UI count (31→33) and total (57→59) in both frontmatter and body; add AvatarGroup and GoogleMap to component list
- dark-mode-hero-gradient: remove incorrect claim that dark mode respects system preference on first visit

https://claude.ai/code/session_01V57eHRZbHoNVHev94bUvJU

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
