### PR TITLE
Fix ProjectShowcase: use plain img tags to avoid Sharp pipeline

### DIFF
--- a/src/components/projects/ProjectShowcase.astro
+++ b/src/components/projects/ProjectShowcase.astro
@@ -1,5 +1,4 @@
 ---
-import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
@@ -24,21 +23,27 @@ const {
 <div class="not-prose my-12 space-y-6">
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
     <div class="rounded-xl border border-border shadow-xl overflow-hidden">
-      <Image
-        src={lightImage}
+      <img
+        src={lightImage.src}
         alt={lightAlt}
+        width={lightImage.width}
+        height={lightImage.height}
         class="aspect-video w-full object-cover"
         loading="lazy"
+        decoding="async"
       />
       <p class="text-xs text-foreground-subtle text-center py-2 bg-background-secondary">Light mode</p>
     </div>
 
     <div class="rounded-xl border border-border shadow-xl overflow-hidden">
-      <Image
-        src={darkImage}
+      <img
+        src={darkImage.src}
         alt={darkAlt}
+        width={darkImage.width}
+        height={darkImage.height}
         class="aspect-video w-full object-cover"
         loading="lazy"
+        decoding="async"
       />
       <p class="text-xs text-foreground-subtle text-center py-2 bg-background-secondary">Dark mode</p>
     </div>


### PR DESCRIPTION
Replacing Astro's <Image> component with plain <img> tags so the component works with SVG placeholders and on hosts where Sharp is not installed. The .src, .width, and .height properties of ImageMetadata are used directly.

https://claude.ai/code/session_01CjRnBRzAUCuWUPFrz2STiu

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
