### PR TITLE
Apply homepage hero, floating header, and footer design changes

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -12,6 +12,8 @@ interface Props extends HTMLAttributes<'section'> {
   showGrid?: boolean;
   /** Show brand-coloured radial glow blobs behind the content */
   showGlow?: boolean;
+  /** Show two asymmetric brand blobs (dark mode only) */
+  showBlob?: boolean;
   /** Fade the bottom of the section into the next section's background */
   bottomFade?: boolean;
   /** Show an animated scroll indicator at the bottom (desktop only, hides on scroll) */
@@ -25,6 +27,7 @@ const {
   size = 'lg',
   showGrid = true,
   showGlow = true,
+  showBlob = false,
   bottomFade = true,
   showScrollIndicator = false,
   descriptionClass = 'max-w-xl',
@@ -70,6 +73,21 @@ const gridClasses = cn(
     <>
       <div class="pointer-events-none absolute left-1/2 top-1/4 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-brand-500/15 blur-[120px] hidden dark:block" aria-hidden="true" />
       <div class="pointer-events-none absolute bottom-1/4 right-1/4 h-[400px] w-[400px] rounded-full bg-brand-600/10 blur-[100px] hidden dark:block" aria-hidden="true" />
+    </>
+  )}
+
+  {showBlob && (
+    <>
+      <div
+        class="pointer-events-none absolute hidden dark:block dark:opacity-[0.20] rounded-full blur-[120px] h-[500px] w-[500px] -left-20 top-0 -translate-y-1/4"
+        style="background: radial-gradient(ellipse at center, var(--color-brand-400) 0%, transparent 70%);"
+        aria-hidden="true"
+      />
+      <div
+        class="pointer-events-none absolute hidden dark:block dark:opacity-[0.20] rounded-full blur-[120px] h-[500px] w-[500px] -right-20 top-0 -translate-y-1/4"
+        style="background: radial-gradient(ellipse at center, var(--color-brand-400) 0%, transparent 70%);"
+        aria-hidden="true"
+      />
     </>
   )}
 

--- a/src/components/hero/hero.variants.ts
+++ b/src/components/hero/hero.variants.ts
@@ -15,3 +15,19 @@ export const heroSectionVariants = cva('relative overflow-hidden bg-background',
 });
 
 export type HeroSectionVariants = VariantProps<typeof heroSectionVariants>;
+
+export const heroBlobVariants = cva(
+  'pointer-events-none absolute rounded-full blur-[120px] hidden dark:block dark:opacity-[0.20]',
+  {
+    variants: {
+      position: {
+        left:   'left-0 top-1/2 h-[500px] w-[500px] -translate-x-1/3 -translate-y-1/2',
+        right:  'right-0 top-1/2 h-[500px] w-[500px] translate-x-1/3 -translate-y-1/2',
+        center: 'left-1/2 top-1/2 h-[600px] w-[700px] -translate-x-1/2 -translate-y-1/2',
+      },
+    },
+    defaultVariants: { position: 'center' },
+  }
+);
+
+export type HeroBlobVariants = VariantProps<typeof heroBlobVariants>;

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -142,7 +142,7 @@ function getSocialIcon(platform: string): string {
             ) : (
               <a href="/" class="flex items-center gap-2">
                 <Logo size="md" />
-                <span class="font-display text-base font-bold text-brand-500">
+                <span class="font-display text-base font-bold text-brand-400">
                   {siteConfig.name}
                 </span>
               </a>
@@ -209,7 +209,7 @@ function getSocialIcon(platform: string): string {
               ) : (
                 <a href="/" class="flex items-center gap-2">
                   <Logo size="md" />
-                  <span class="font-display text-base font-bold text-brand-500">
+                  <span class="font-display text-base font-bold text-brand-400">
                     {siteConfig.name}
                   </span>
                 </a>
@@ -312,7 +312,7 @@ function getSocialIcon(platform: string): string {
           ) : (
             <a href="/" class="flex items-center gap-2">
               <Logo size="md" />
-              <span class="font-display text-xl font-bold text-brand-500">
+              <span class="font-display text-xl font-bold text-brand-400">
                 {siteConfig.name}
               </span>
             </a>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -191,11 +191,12 @@ const buttonId = `${menuId}-button`;
           <slot name="logo" />
         ) : (
           <a href="/" class="flex items-center gap-2">
-            <Logo size={size === 'lg' ? 'lg' : 'md'} forceDark={isInvert} />
+            <Logo size={size === 'sm' ? 'md' : 'lg'} forceDark={isInvert} />
             <span
               class={cn(
                 'font-display text-xl font-bold tracking-tight',
-                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-on-invert' : 'text-brand-500')
+                isFloating && 'md:hidden',
+                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-on-invert' : 'text-brand-400')
               )}
             >
               {logoText || siteConfig.name}
@@ -223,7 +224,7 @@ const buttonId = `${menuId}-button`;
                   isFloating
                     ? (isActive(href)
                         ? 'hdr-nav-active font-semibold'
-                        : 'font-medium opacity-80 hover:opacity-100')
+                        : 'font-medium')
                     : (isActive(href)
                         ? 'nav-link-active font-semibold text-foreground bg-secondary'
                         : 'nav-link-inactive font-medium text-foreground-muted hover:text-foreground hover:bg-secondary/70')
@@ -343,11 +344,23 @@ const buttonId = `${menuId}-button`;
 
   {/* Scroll Progress Bar */}
   {showScrollProgress && (
-    <div
-      id="scroll-progress-bar"
-      class={`absolute left-0 h-[2px] w-0 bg-brand-500 transition-none ${scrollProgressPosition === 'top' ? 'top-0' : 'bottom-0'}`}
-      aria-hidden="true"
-    />
+    isFloating ? (
+      <div
+        class={`absolute inset-x-3 h-[2px] overflow-hidden rounded-full ${scrollProgressPosition === 'top' ? 'top-[2px]' : 'bottom-[2px]'}`}
+        aria-hidden="true"
+      >
+        <div
+          id="scroll-progress-bar"
+          class="absolute left-0 top-0 h-full w-0 bg-brand-500 transition-none"
+        />
+      </div>
+    ) : (
+      <div
+        id="scroll-progress-bar"
+        class={`absolute left-0 h-[2px] w-0 bg-brand-500 transition-none ${scrollProgressPosition === 'top' ? 'top-0' : 'bottom-0'}`}
+        aria-hidden="true"
+      />
+    )
   )}
 
   {/* Mobile Menu */}
@@ -749,5 +762,44 @@ const buttonId = `${menuId}-button`;
     [data-header-shape="floating"] .nav-link::after {
       transition: none !important;
     }
+  }
+
+  /* Dark mode: lighten floating header background */
+  .dark [data-header-shape="floating"] {
+    background: color-mix(in oklch, var(--color-background) 50%, transparent);
+  }
+  .dark [data-header-shape="floating"][data-scrolled] {
+    background: color-mix(in oklch, var(--color-background) 75%, transparent);
+  }
+
+  /* Light mode: subtle brand-tinted border before scrolling */
+  html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) {
+    border-color: color-mix(in oklch, var(--color-brand-300), transparent 50%);
+  }
+
+  /* Logo text: brand-400 for all floating states */
+  [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
+    color: var(--color-brand-400);
+  }
+  .dark [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
+    color: var(--color-brand-400);
+  }
+  [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
+    color: var(--color-brand-400);
+  }
+  .dark [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
+    color: var(--color-brand-400);
+  }
+
+  /* Nav links: foreground-muted in light, foreground-subtle in dark */
+  [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text {
+    color: var(--color-foreground-muted);
+    transition: color 300ms;
+  }
+  .dark [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text {
+    color: var(--color-foreground-subtle);
+  }
+  [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text:hover {
+    color: var(--color-foreground);
   }
 </style>

--- a/src/components/layout/header.variants.ts
+++ b/src/components/layout/header.variants.ts
@@ -19,7 +19,7 @@ export const headerVariants = cva('z-50', {
   },
   compoundVariants: [
     // Floating + fixed: centered with gap
-    { shape: 'floating', position: 'fixed', class: '!left-1/2 !right-auto -translate-x-1/2 w-[calc(100%-2rem)] max-w-6xl mt-4' },
+    { shape: 'floating', position: 'fixed', class: '!left-1/2 !right-auto -translate-x-1/2 w-[calc(100%-2rem)] max-w-2xl mt-4' },
     // Floating + sticky: centered with gap
     { shape: 'floating', position: 'sticky', class: '!top-4 mx-auto max-w-6xl' },
     // Floating + static: centered

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -55,9 +55,8 @@ const isHomePage = Astro.url.pathname === '/';
     shape="floating"
     variant="transparent"
     colorScheme="default"
-    size="lg"
+    size="md"
     showCta={false}
-    cta={{ label: 'Get in touch', href: '/contact' }}
     showThemeSelector
     showScrollProgress={isHomePage}
     scrollProgressPosition="top"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,12 +30,12 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   includeProfessionalServiceSchema={true}
 >
   <!-- Hero -->
-  <Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator descriptionClass="max-w-3xl">
+  <Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator showGrid>
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">Available for new projects</Badge>
 
     <h1 slot="title">
       <span class="text-foreground [-webkit-text-fill-color:currentColor]">Astro Rocket —</span><br />
-      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)] dark:text-foreground dark:[-webkit-text-fill-color:currentColor]">Web Designer</span><span class="text-foreground [-webkit-text-fill-color:currentColor]"> &amp; Developer</span>
+      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)] dark:text-brand-300 dark:[-webkit-text-fill-color:var(--color-brand-300)]">Web Designer</span><span class="text-foreground [-webkit-text-fill-color:currentColor]"> &amp; Developer</span>
     </h1>
 
     <p slot="description">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -296,10 +296,10 @@
 
   /* Hero gradient — theme-aware */
   .hero-dark-gradient {
-    background: var(--background);
+    background: radial-gradient(ellipse 80% 40% at 50% 0%, color-mix(in oklch, var(--color-brand-400), transparent 94%), transparent);
   }
   .dark .hero-dark-gradient {
-    background: linear-gradient(to bottom, var(--brand-600), black);
+    background: radial-gradient(ellipse 100% 60% at 50% 0%, var(--color-brand-800) 0%, var(--color-background) 100%);
   }
 
   /* Gradient border */


### PR DESCRIPTION
- Hero gradient: replace linear dark gradient with radial brand-tinted ellipse (light + dark)
- Hero: add showBlob prop rendering two asymmetric dark-mode brand blobs
- Hero variants: add heroBlobVariants cva export
- index.astro: add showGrid to Hero, update "Web Designer" span to brand-300 in dark
- Header: narrow floating header to max-w-2xl, size to md in LandingLayout
- Header: logo always lg unless sm, hide site name on md+ when floating
- Header: remove opacity-80 from inactive floating nav links
- Header: inset rounded scroll progress bar for floating shape
- Header: add dark-mode bg, brand-tinted border, brand-400 logo, and foreground-subtle nav CSS
- Header: site name text-brand-500 → text-brand-400 for bar layout
- Footer: site name text-brand-500 → text-brand-400 across all three layouts

https://claude.ai/code/session_01KKdNQNgR8kj4yvtogpefGB

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
