### PR TITLE
Apply homepage hero, floating header, and footer layout refinements

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -684,6 +684,19 @@ const buttonId = `${menuId}-button`;
     box-shadow: 0 4px 20px -6px rgba(0, 0, 0, 0.1);
   }
 
+  /* Dark mode: lighten the floating header background */
+  .dark [data-header-shape="floating"] {
+    background: color-mix(in oklch, var(--color-background) 50%, transparent);
+  }
+  .dark [data-header-shape="floating"][data-scrolled] {
+    background: color-mix(in oklch, var(--color-background) 75%, transparent);
+  }
+
+  /* Light mode: subtle brand-tinted border before scrolling */
+  html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) {
+    border-color: color-mix(in oklch, var(--color-brand-300), transparent 50%);
+  }
+
   /* ===== Floating header: color flip (invert → normal on scroll) ===== */
 
   /* Text elements: on-invert → foreground */
@@ -695,22 +708,33 @@ const buttonId = `${menuId}-button`;
     color: var(--color-foreground);
   }
 
-  /* Logo text: on-invert → brand-500 */
+  /* Logo text: on-invert → brand-400 */
   [data-header-shape="floating"][data-header-color-scheme="invert"] .hdr-logo-text {
     color: var(--color-on-invert);
     transition: color 300ms;
   }
   [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-brand-400);
+  }
+  .dark [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
+    color: var(--color-brand-400);
   }
 
-  /* Non-invert floating: use normal colors */
+  /* Non-invert floating: brand-400 in all modes */
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-brand-400);
   }
+  .dark [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
+    color: var(--color-brand-400);
+  }
+
+  /* Nav links: foreground-muted light / foreground-subtle dark */
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text {
     color: var(--color-foreground-muted);
     transition: color 300ms;
+  }
+  .dark [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text {
+    color: var(--color-foreground-subtle);
   }
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text:hover {
     color: var(--color-foreground);
@@ -764,42 +788,4 @@ const buttonId = `${menuId}-button`;
     }
   }
 
-  /* Dark mode: lighten floating header background */
-  .dark [data-header-shape="floating"] {
-    background: color-mix(in oklch, var(--color-background) 50%, transparent);
-  }
-  .dark [data-header-shape="floating"][data-scrolled] {
-    background: color-mix(in oklch, var(--color-background) 75%, transparent);
-  }
-
-  /* Light mode: subtle brand-tinted border before scrolling */
-  html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) {
-    border-color: color-mix(in oklch, var(--color-brand-300), transparent 50%);
-  }
-
-  /* Logo text: brand-400 for all floating states */
-  [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
-    color: var(--color-brand-400);
-  }
-  .dark [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
-    color: var(--color-brand-400);
-  }
-  [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
-    color: var(--color-brand-400);
-  }
-  .dark [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
-    color: var(--color-brand-400);
-  }
-
-  /* Nav links: foreground-muted in light, foreground-subtle in dark */
-  [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text {
-    color: var(--color-foreground-muted);
-    transition: color 300ms;
-  }
-  .dark [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text {
-    color: var(--color-foreground-subtle);
-  }
-  [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text:hover {
-    color: var(--color-foreground);
-  }
 </style>

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -57,6 +57,7 @@ const isHomePage = Astro.url.pathname === '/';
     colorScheme="default"
     size="md"
     showCta={false}
+    cta={{ label: 'Get in touch', href: '/contact' }}
     showThemeSelector
     showScrollProgress={isHomePage}
     scrollProgressPosition="top"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -294,7 +294,7 @@
     );
   }
 
-  /* Hero gradient — theme-aware */
+  /* Hero gradient — mode-specific */
   .hero-dark-gradient {
     background: radial-gradient(ellipse 80% 40% at 50% 0%, color-mix(in oklch, var(--color-brand-400), transparent 94%), transparent);
   }


### PR DESCRIPTION
- global.css: update hero-dark-gradient comment to 'mode-specific'
- LandingLayout.astro: add cta prop to floating Header
- Header.astro: move dark/light mode float rules immediately after scroll-state rule; consolidate hdr-logo-text and hdr-invert-text rules (brand-400 in all modes, dark-mode foreground-subtle for nav links); remove duplicate override blocks at end of style block

https://claude.ai/code/session_01XQqfMwQ8M34MG5nYu6HZSM

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
