### PR TITLE
Fix TypeScript null check error in Hero scroll indicator

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -258,7 +258,7 @@ const gridClasses = cn(
 
     function onScroll() {
       if (window.scrollY > 50) {
-        indicator.classList.add('is-hidden');
+        indicator?.classList.add('is-hidden');
         window.removeEventListener('scroll', onScroll);
       }
     }


### PR DESCRIPTION
Use optional chaining on `indicator` inside the nested `onScroll` closure so TypeScript's control flow narrowing doesn't flag it as possibly null, fixing the CI type-check failure (ts18047).

https://claude.ai/code/session_01MG2F8xZCtGdWESTJzRptUN

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
