### PR TITLE
Correct blog posts to match current theme state

### DIFF
--- a/src/content/blog/en/animations-in-astro-rocket.mdx
+++ b/src/content/blog/en/animations-in-astro-rocket.mdx
@@ -34,21 +34,21 @@ The default transition is `animate-slide-up`, applied to all pages. Astro also s
 
 ## Scroll-triggered counter animation
 
-On the homepage, the stats block — Years Experience, Projects Delivered, Worldwide Clients — doesn't just sit there as static numbers. When the block scrolls into the viewport, each number counts up from zero to its target value.
+Astro Rocket has a built-in countup utility wired into `src/pages/index.astro`. Any element with a `data-countup` attribute will animate its number from zero to the target value when it scrolls into view.
 
-The animation is driven by an `IntersectionObserver` in `src/pages/index.astro`:
+The animation is driven by an `IntersectionObserver`:
 
 - The observer fires once per element, when it first reaches 40% visibility
 - Each counter runs for 1.2 seconds with a cubic ease-out curve (`1 - (1 - progress)³`)
 - After completing, the observer disconnects — so scrolling back up and down doesn't re-trigger it
 
-To add a counter to any element, give it a `data-countup` attribute with the target number and an optional `data-suffix`:
+To add a counter to any element on the homepage, give it a `data-countup` attribute with the target number and an optional `data-suffix`:
 
 ```html
 <p data-countup="50" data-suffix="+">50+</p>
 ```
 
-The script picks up any element with `[data-countup]` on the page, so you can place counter elements anywhere.
+The script picks up any element with `[data-countup]` on the page, so you can place counter elements anywhere in `index.astro`.
 
 ## Scroll-triggered Lighthouse scores
 

--- a/src/content/blog/en/astro-rocket-configuration-guide.mdx
+++ b/src/content/blog/en/astro-rocket-configuration-guide.mdx
@@ -373,14 +373,14 @@ All Header props and what they do:
 |------|---------|---------|-----------------|
 | `position` | `fixed` `sticky` `static` | `fixed` | Whether the header stays at the top while scrolling |
 | `shape` | `bar` `floating` | `bar` | Full-width bar or centred floating capsule |
-| `size` | `sm` `md` `lg` | `md` | Header height |
-| `variant` | `default` `solid` `transparent` | `default` | Background fill |
+| `size` | `sm` `md` `lg` | `lg` | Header height |
+| `variant` | `default` `solid` `transparent` | `solid` | Background fill |
 | `colorScheme` | `default` `invert` | `default` | Use inverted colours — for dark hero backgrounds |
 | `layout` | `default` `centered` `minimal` | `default` | Logo and nav arrangement |
 | `showThemeToggle` | `true` `false` | `true` | Dark/light mode toggle button |
 | `showThemeSelector` | `true` `false` | `false` | Colour theme swatch picker (desktop dropdown + mobile menu) |
 | `showSocialLinks` | `true` `false` | `false` | Social icon links (desktop only, reads from `siteConfig.socialLinks`) |
-| `showCta` | `true` `false` | `true` | CTA button in the header |
+| `showCta` | `true` `false` | `false` | CTA button in the header |
 | `showMobileMenu` | `true` `false` | `true` | Hamburger menu on small screens |
 | `showActiveState` | `true` `false` | `true` | Highlight for the current page link |
 | `hideLogo` | `true` `false` | `false` | Hide the logo entirely |

--- a/src/content/blog/en/astro-rocket-is-live.mdx
+++ b/src/content/blog/en/astro-rocket-is-live.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Astro Rocket Is Live — My New Open Source Astro Theme"
-description: "Astro Rocket is a production-ready Astro 6 theme with a full blog, 59 components, 12 colour themes, dark mode, SEO, and a contact form. Free and open source."
+description: "Astro Rocket is a production-ready Astro 6 theme with a full blog, 57 components, 12 colour themes, dark mode, SEO, and a contact form. Free and open source."
 publishedAt: 2026-03-28
 author: "Hans Martens"
 tags: ["astro-rocket", "open-source", "astro", "launch"]
@@ -41,7 +41,7 @@ All 12 themes are shown as swatches in the header: Orange, Amber, Lime, Emerald,
 
 **Scroll progress ring** — the back-to-top button has a circular SVG ring that fills clockwise as you scroll, giving readers a glanceable sense of progress without taking up any extra space on the page. The ring is built from two SVG circles: a faint track and a brand-coloured arc animated via `stroke-dashoffset`. Because the arc uses `class="text-brand-500"` with `stroke="currentColor"`, its colour is driven entirely by the active colour theme — switch to a different theme in the header selector and the ring changes colour instantly alongside every other brand-coloured element. No extra JavaScript required. [Read the full post](/blog/scroll-progress-ring).
 
-**Hero gradient** — the homepage hero has a gradient in dark mode only. Light mode uses the standard background colour — no gradient. Dark mode gets a bold linear gradient from `--brand-600` down to black — a fully saturated branded background. The hero H1 adapts too: "Web Designer" is highlighted in brand-500 in light mode and blends into the foreground colour in dark mode, keeping the heading legible against the vivid gradient. No JavaScript, no hardcoded colours. The homepage header is a floating capsule that lets the gradient show through behind it. On all other pages the header is a full-width solid bar. [Read the full post](/blog/dark-mode-hero-gradient).
+**Hero gradient** — the homepage hero has a gradient in dark mode only. Light mode uses the standard background colour — no gradient. Dark mode gets a bold linear gradient from `--brand-600` down to black — a fully saturated branded background. The hero H1 adapts too: "Web Designer" is highlighted in brand-500 in light mode and shifts to brand-400 in dark mode, staying a branded colour against the vivid gradient rather than blending into the foreground. No JavaScript, no hardcoded colours. The homepage header is a floating capsule that lets the gradient show through behind it. On all other pages the header is a full-width solid bar. [Read the full post](/blog/dark-mode-hero-gradient).
 
 **sessionStorage for dark mode** — Velocity uses `localStorage`, which stores the user's preference permanently. I deliberately switched this to `sessionStorage`, so every new visitor sees the site the way it was designed: dark. Dark mode is a design choice here, not a user setting. I wrote a [full post explaining why](/blog/dark-mode-sessionstorage).
 
@@ -51,7 +51,7 @@ Everything from Velocity is still there, and it's all fully integrated:
 
 **A full blog** — built on Astro Content Collections with MDX support. Every post has a typed frontmatter schema, tag filtering, a related posts section, a reading time indicator, and automatically generated Open Graph metadata.
 
-**59 components** — 33 UI components (Button, Input, Card, Badge, Avatar, AvatarGroup, GoogleMap, Table, Tabs, Dialog, Accordion, and more), 7 pattern components (ContactForm, NewsletterForm, StatCard, and more), plus Hero, Header, Footer, BlogCard, ShareButtons, and SEO components.
+**57 components** — 33 UI components (Button, Input, Card, Badge, Avatar, AvatarGroup, GoogleMap, Table, Tabs, Dialog, Accordion, and more), 7 pattern components (ContactForm, NewsletterForm, StatCard, and more), plus Hero, Header, Footer, BlogCard, ShareButtons, and SEO components.
 
 **A complete SEO layer** — meta tags, Open Graph, Twitter Cards, JSON-LD structured data (WebSite, Organization, BlogPosting, Breadcrumb, FAQ), an auto-generated sitemap, and robots.txt.
 

--- a/src/content/blog/en/component-library.mdx
+++ b/src/content/blog/en/component-library.mdx
@@ -26,7 +26,7 @@ The library is organized in three layers: 33 UI primitives that form the buildin
 
 ## UI primitives
 
-These 31 components cover every common UI need. They accept variants and sizes through props and are built with accessibility in mind — keyboard navigation, ARIA attributes, and focus management are handled for you.
+These 33 components cover every common UI need. They accept variants and sizes through props and are built with accessibility in mind — keyboard navigation, ARIA attributes, and focus management are handled for you.
 
 ### Form (7 components)
 
@@ -166,9 +166,9 @@ Pattern components compose the UI primitives into specific real-world use cases.
 
 These components are fixed parts of the site architecture. They are used once per page type and are not generally composed with other components — they define the page.
 
-**Hero** — the `Hero` component supports four layouts (`centered`, `split`, `minimal`, `card`) and three sizes. All hero content uses named slots: `badge`, `title`, `description`, `actions`, and optionally `image`.
+**Hero** — the `Hero` component supports two layouts (`centered`, `split`) and four sizes (`sm`, `md`, `lg`, `xl`). All hero content uses named slots: `badge`, `title`, `description`, `actions`, and optionally `image`.
 
-**Header** — fixed top navigation bar with logo, nav links, dark mode toggle, theme selector, and optional CTA button. Three rendering variants: `solid` (solid bar), `transparent` (transparent, used on blog posts), and `floating` (the capsule header on the homepage). Includes the scroll progress bar when enabled.
+**Header** — fixed top navigation bar with logo, nav links, dark mode toggle, theme selector, and optional CTA button. Three rendering variants: `solid`, `transparent`, and `default`. The capsule header on the homepage is a separate `shape="floating"` prop — distinct from the variant. Includes the scroll progress bar when enabled.
 
 **Footer** — bottom navigation with site links, social icons, and copyright text.
 
@@ -285,7 +285,7 @@ import { Counter } from '@/components/ui';
 
 ## Browse the live demo
 
-The fastest way to get a feel for all 59 components is the live component demo. Every component is rendered with live props you can inspect:
+The fastest way to get a feel for all 57 components is the live component demo. Every component is rendered with live props you can inspect:
 
 **[/components](/components)**
 

--- a/src/content/blog/en/dark-mode-hero-gradient.mdx
+++ b/src/content/blog/en/dark-mode-hero-gradient.mdx
@@ -51,12 +51,12 @@ This means the `.dark` class is toggled on the root element based on the user's 
 The class is applied once, directly on the `Hero` component in `src/pages/index.astro`:
 
 ```astro
-<Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator descriptionClass="max-w-3xl">
+<Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator showGrid>
   ...
 </Hero>
 ```
 
-That is the only place it is used. The class exists for this one purpose.
+The `showGrid` prop adds a dot-grid overlay that is `hidden dark:block` — it only appears in dark mode, layering a subtle texture over the gradient. That is the only place this combination is used.
 
 ## The gradient follows the brand colour
 

--- a/src/content/blog/en/hero-scroll-indicator.mdx
+++ b/src/content/blog/en/hero-scroll-indicator.mdx
@@ -127,7 +127,7 @@ function initScrollIndicator() {
 
   function onScroll() {
     if (window.scrollY > 50) {
-      indicator.classList.add('is-hidden');
+      indicator?.classList.add('is-hidden');
       window.removeEventListener('scroll', onScroll);
     }
   }

--- a/src/content/blog/en/hero-typing-effect.mdx
+++ b/src/content/blog/en/hero-typing-effect.mdx
@@ -31,7 +31,7 @@ The component currently lives in the About page hero, inside a brand-coloured `<
 <h1 slot="title">
   <span class="text-foreground [-webkit-text-fill-color:currentColor]">Astro Rocket —</span><br />
   <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)]">
-    <TypingEffect words={["Web Designer", "Web Developer", "Astro Developer", "Blogger", "Coffee lover"]} />
+    <TypingEffect words={["Web Designer", "Web Developer", "Astro Developer", "Claude Code User", "UI / UX Enthusiast", "Blogger", "Coffee lover"]} />
   </span>
 </h1>
 ```
@@ -286,7 +286,7 @@ To change the blink speed, adjust the `0.75s` value. Faster blinking (`0.5s`) re
 The component wraps everything in a `<span>` with an `aria-label` set to all words joined by a comma:
 
 ```html
-<span id="typing-abc123" class="typing-effect" aria-label="Web Designer, Web Developer, Astro Developer, Blogger, Coffee lover">
+<span id="typing-abc123" class="typing-effect" aria-label="Web Designer, Web Developer, Astro Developer, Claude Code User, UI / UX Enthusiast, Blogger, Coffee lover">
 ```
 
 Screen readers announce the full list of words from the `aria-label` and ignore the animated content inside (the cursor has `aria-hidden="true"`). The text is therefore both readable and not disruptive to assistive technology.


### PR DESCRIPTION
Round 1 — known discrepancies:
- astro-rocket-is-live: 59 → 57 components; fix H1 dark mode text (brand-400, not foreground)
- component-library: 31 → 33 UI primitives; 59 → 57 in demo section; Hero layouts 4 → 2; Header floating is a shape not a variant
- dark-mode-hero-gradient: fix Hero code example (showGrid, remove descriptionClass); describe showGrid grid overlay
- hero-scroll-indicator: add optional chaining on indicator?.classList
- hero-typing-effect: add Claude Code User + UI / UX Enthusiast to words array and aria-label

Round 2 — second-pass findings:
- animations-in-astro-rocket: remove false claim of a homepage countup stats block; rewrite as a reusable utility
- astro-rocket-configuration-guide: fix Header prop defaults (size lg, variant solid, showCta false)
- component-library: Header variant description corrected

https://claude.ai/code/session_01MG2F8xZCtGdWESTJzRptUN

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
