### PR TITLE
feat: replace orange with green in theme selector

### DIFF
--- a/src/components/layout/ThemeSelector.astro
+++ b/src/components/layout/ThemeSelector.astro
@@ -15,7 +15,7 @@ const { class: className } = Astro.props;
 
 // All 12 themes in Tailwind color order
 const themes = [
-  { id: 'orange',  name: 'Orange',  color: 'oklch(62.5% 0.22  38)'  },
+  { id: 'green',   name: 'Green',   color: 'oklch(62.5% 0.22 155)'  },
   { id: 'amber',   name: 'Amber',   color: 'oklch(68%   0.19  75)'  },
   { id: 'lime',    name: 'Lime',    color: 'oklch(64%   0.27 130)'  },
   { id: 'emerald', name: 'Emerald', color: 'oklch(62.5% 0.22 160)'  },

--- a/src/components/layout/ThemeSelectorDropdown.astro
+++ b/src/components/layout/ThemeSelectorDropdown.astro
@@ -14,7 +14,7 @@ const { class: className } = Astro.props;
 
 // All 13 themes in Tailwind color order
 const themes = [
-  { id: 'orange',  name: 'Orange',  color: 'oklch(62.5% 0.22  38)'  },
+  { id: 'green',   name: 'Green',   color: 'oklch(62.5% 0.22 155)'  },
   { id: 'amber',   name: 'Amber',   color: 'oklch(68%   0.19  75)'  },
   { id: 'lime',    name: 'Lime',    color: 'oklch(64%   0.27 130)'  },
   { id: 'emerald', name: 'Emerald', color: 'oklch(62.5% 0.22 160)'  },

--- a/src/styles/tokens/colors.css
+++ b/src/styles/tokens/colors.css
@@ -11,10 +11,10 @@
    Theme files
    -----------
    Active in selector (ThemeSelector.astro):
-     orange, lime, emerald, teal, sky, blue, purple
+     green, lime, emerald, teal, sky, blue, purple
 
    Hidden from selector (files kept for re-use):
-     cyan, green, indigo
+     cyan, orange, indigo
 
    Available but not exposed in selector:
      amber, magenta


### PR DESCRIPTION
Swap orange for green in the ThemeSelector and ThemeSelectorDropdown themes arrays; update colors.css selector comment to match.

https://claude.ai/code/session_01GC4DDXkp6MKyJsNXe2kyCE

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
