### PR TITLE
Fix theme selector: correct color order and green theme persistence

### DIFF
--- a/src/components/layout/ThemeSelector.astro
+++ b/src/components/layout/ThemeSelector.astro
@@ -15,9 +15,9 @@ const { class: className } = Astro.props;
 
 // All 12 themes in Tailwind color order
 const themes = [
-  { id: 'green',   name: 'Green',   color: 'oklch(62.5% 0.22 155)'  },
   { id: 'amber',   name: 'Amber',   color: 'oklch(68%   0.19  75)'  },
   { id: 'lime',    name: 'Lime',    color: 'oklch(64%   0.27 130)'  },
+  { id: 'green',   name: 'Green',   color: 'oklch(62.5% 0.22 155)'  },
   { id: 'emerald', name: 'Emerald', color: 'oklch(62.5% 0.22 160)'  },
   { id: 'teal',    name: 'Teal',    color: 'oklch(62.5% 0.22 190)'  },
   { id: 'cyan',    name: 'Cyan',    color: 'oklch(65%   0.22 200)'  },

--- a/src/components/layout/ThemeSelectorDropdown.astro
+++ b/src/components/layout/ThemeSelectorDropdown.astro
@@ -12,11 +12,11 @@ interface Props {
 
 const { class: className } = Astro.props;
 
-// All 13 themes in Tailwind color order
+// All 12 themes in Tailwind color order
 const themes = [
-  { id: 'green',   name: 'Green',   color: 'oklch(62.5% 0.22 155)'  },
   { id: 'amber',   name: 'Amber',   color: 'oklch(68%   0.19  75)'  },
   { id: 'lime',    name: 'Lime',    color: 'oklch(64%   0.27 130)'  },
+  { id: 'green',   name: 'Green',   color: 'oklch(62.5% 0.22 155)'  },
   { id: 'emerald', name: 'Emerald', color: 'oklch(62.5% 0.22 160)'  },
   { id: 'teal',    name: 'Teal',    color: 'oklch(62.5% 0.22 190)'  },
   { id: 'cyan',    name: 'Cyan',    color: 'oklch(65%   0.22 200)'  },

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -137,7 +137,7 @@ if (includeProfessionalServiceSchema) {
     <!-- Theme script (runs before body paint; <html> starts with class="dark" as default) -->
     <script is:inline>
       (function () {
-        const COLOR_THEMES = ['orange', 'amber', 'lime', 'emerald', 'teal', 'cyan', 'sky', 'blue', 'indigo', 'violet', 'purple', 'magenta'];
+        const COLOR_THEMES = ['amber', 'lime', 'green', 'emerald', 'teal', 'cyan', 'sky', 'blue', 'indigo', 'violet', 'purple', 'magenta'];
 
         function applyTheme(el) {
           try {


### PR DESCRIPTION
- Move green swatch to its correct Tailwind position (after lime, before emerald) in both ThemeSelector and ThemeSelectorDropdown
- Replace 'orange' with 'green' in BaseLayout COLOR_THEMES allowlist so the green theme is recognized as valid during page transitions and not reset to the default indigo theme

https://claude.ai/code/session_01UWNuzioeYVNmVFxnhHwS1H

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
