### PR TITLE
fix(header): increase floating header opacity for darker appearance

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -678,7 +678,7 @@ const buttonId = `${menuId}-button`;
 
   /* ===== Floating header: scroll state ===== */
   [data-header-shape="floating"][data-scrolled] {
-    background: color-mix(in oklch, var(--color-background) 92%, transparent);
+    background: color-mix(in oklch, var(--color-background) 96%, transparent);
     backdrop-filter: blur(24px);
     border-color: var(--color-border);
     box-shadow: 0 4px 20px -6px rgba(0, 0, 0, 0.1);
@@ -766,10 +766,10 @@ const buttonId = `${menuId}-button`;
 
   /* Dark mode: lighten floating header background */
   .dark [data-header-shape="floating"] {
-    background: color-mix(in oklch, var(--color-background) 50%, transparent);
+    background: color-mix(in oklch, var(--color-background) 65%, transparent);
   }
   .dark [data-header-shape="floating"][data-scrolled] {
-    background: color-mix(in oklch, var(--color-background) 75%, transparent);
+    background: color-mix(in oklch, var(--color-background) 88%, transparent);
   }
 
   /* Light mode: subtle brand-tinted border before scrolling */

--- a/src/components/layout/header.variants.ts
+++ b/src/components/layout/header.variants.ts
@@ -27,7 +27,7 @@ export const headerVariants = cva('z-50', {
     // Floating + transparent: glass effect
     { shape: 'floating', variant: 'transparent', class: 'bg-white/[0.06] backdrop-blur-xl border border-white/[0.08]' },
     // Floating + default: semi-transparent with blur
-    { shape: 'floating', variant: 'default', class: '!bg-background/80 backdrop-blur-xl !border border-border/50 !border-b-border/50' },
+    { shape: 'floating', variant: 'default', class: '!bg-background/90 backdrop-blur-xl !border border-border/50 !border-b-border/50' },
     // Floating + solid: opaque
     { shape: 'floating', variant: 'solid', class: '!bg-background !border border-border !border-b-border' },
   ],


### PR DESCRIPTION
Bump background opacity on the floating header across all states:
- Base (light): bg-background/80 → /90
- Scrolled (light): 92% → 96%
- Unscrolled (dark): 50% → 65%
- Scrolled (dark): 75% → 88%

https://claude.ai/code/session_01QWdsXwFZiFRFagZU5wmzbP

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
