### PR TITLE
Set blue as default theme and use brand-500 for site title everywhere

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -196,7 +196,7 @@ const buttonId = `${menuId}-button`;
               class={cn(
                 'font-display text-xl font-bold tracking-tight',
                 isFloating && 'md:hidden',
-                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-brand-500 dark:text-brand-400 md:text-on-invert' : 'text-brand-500 dark:text-brand-400')
+                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-brand-500 dark:text-brand-500 md:text-on-invert' : 'text-brand-500 dark:text-brand-500')
               )}
             >
               {logoText || siteConfig.name}
@@ -782,13 +782,13 @@ const buttonId = `${menuId}-button`;
     color: var(--color-brand-500);
   }
   .dark [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
-    color: var(--color-brand-400);
+    color: var(--color-brand-500);
   }
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
     color: var(--color-brand-500);
   }
   .dark [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
-    color: var(--color-brand-400);
+    color: var(--color-brand-500);
   }
 
   /* Nav links: foreground-muted in light, foreground-subtle in dark */

--- a/src/components/layout/ThemeSelector.astro
+++ b/src/components/layout/ThemeSelector.astro
@@ -84,7 +84,7 @@ const themes = [
 
 <script>
   const STORAGE_KEY = 'color-theme';
-  const DEFAULT_THEME = 'indigo';
+  const DEFAULT_THEME = 'blue';
 
   function getActiveTheme(): string {
     try {

--- a/src/components/layout/ThemeSelectorDropdown.astro
+++ b/src/components/layout/ThemeSelectorDropdown.astro
@@ -117,7 +117,7 @@ const themes = [
 
 <script>
   const STORAGE_KEY = 'color-theme';
-  const DEFAULT_THEME = 'indigo';
+  const DEFAULT_THEME = 'blue';
 
   function getActiveTheme(): string {
     try {


### PR DESCRIPTION
- Change DEFAULT_THEME from 'indigo' to 'blue' in ThemeSelector and ThemeSelectorDropdown
- Replace dark:text-brand-400 with dark:text-brand-500 on the site title span in Header
- Update floating header CSS dark-mode overrides to use brand-500 instead of brand-400 for .hdr-logo-text

https://claude.ai/code/session_01JNGNXLynpemtKXCDHAV43u

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
