### PR TITLE
Update OG and README hero images to blue theme colour; make blue the …

### DIFF
--- a/public/og-default.svg
+++ b/public/og-default.svg
@@ -1,10 +1,10 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Background -->
-  <rect width="1200" height="630" fill="#6366f1"/>
+  <rect width="1200" height="630" fill="#3b82f6"/>
 
   <!-- Lucide Rocket — scale(5), visual centre at (600, 240) -->
   <g transform="translate(540, 180) scale(5)"
-     stroke="#e0e7ff" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
+     stroke="#dbeafe" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
     <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
     <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
     <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
@@ -13,23 +13,23 @@
 
   <!-- Wordmark -->
   <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-4"
-        fill="#eef2ff"
+        fill="#eff6ff"
         font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
         font-weight="800">Astro Rocket</text>
 
   <!-- Divider -->
-  <line x1="380" y1="436" x2="820" y2="436" stroke="#a5b4fc" stroke-width="1" stroke-opacity="0.35"/>
+  <line x1="380" y1="436" x2="820" y2="436" stroke="#93c5fd" stroke-width="1" stroke-opacity="0.35"/>
 
   <!-- Domain pill -->
   <rect x="450" y="464" width="300" height="38" rx="19"
-        fill="#818cf8" fill-opacity="0.25" stroke="#a5b4fc" stroke-opacity="0.4" stroke-width="1"/>
+        fill="#60a5fa" fill-opacity="0.25" stroke="#93c5fd" stroke-opacity="0.4" stroke-width="1"/>
   <text x="600" y="488" font-size="13" text-anchor="middle" letter-spacing="1.5"
-        fill="#e0e7ff"
+        fill="#dbeafe"
         font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">hansmartens.dev</text>
 
   <!-- Corner marks -->
-  <path d="M 36 60 L 36 36 L 60 36"     stroke="#a5b4fc" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 1140 36 L 1164 36 L 1164 60"   stroke="#a5b4fc" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 36 570 L 36 594 L 60 594"   stroke="#a5b4fc" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 1140 594 L 1164 594 L 1164 570" stroke="#a5b4fc" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 36 60 L 36 36 L 60 36"     stroke="#93c5fd" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 1140 36 L 1164 36 L 1164 60"   stroke="#93c5fd" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 36 570 L 36 594 L 60 594"   stroke="#93c5fd" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 1140 594 L 1164 594 L 1164 570" stroke="#93c5fd" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
 </svg>

--- a/public/readme-hero.svg
+++ b/public/readme-hero.svg
@@ -1,10 +1,10 @@
 <svg width="880" height="260" viewBox="0 0 880 260" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Background -->
-  <rect width="880" height="260" fill="#6366f1"/>
+  <rect width="880" height="260" fill="#3b82f6"/>
 
   <!-- Lucide Rocket — scale(5), visual centre at (440, 100) -->
   <g transform="translate(379, 41) scale(5)"
-     stroke="#e0e7ff" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
+     stroke="#dbeafe" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9">
     <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
     <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
     <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
@@ -16,11 +16,11 @@
         text-anchor="middle"
         font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
         font-weight="800" font-size="62" letter-spacing="-1.5"
-        fill="#eef2ff">Astro Rocket</text>
+        fill="#eff6ff">Astro Rocket</text>
 
   <!-- Corner marks -->
-  <path d="M 30 50 L 30 30 L 50 30"     stroke="#a5b4fc" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 830 30 L 850 30 L 850 50"   stroke="#a5b4fc" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 30 210 L 30 230 L 50 230"   stroke="#a5b4fc" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
-  <path d="M 830 230 L 850 230 L 850 210" stroke="#a5b4fc" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 30 50 L 30 30 L 50 30"     stroke="#93c5fd" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 830 30 L 850 30 L 850 50"   stroke="#93c5fd" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 30 210 L 30 230 L 50 230"   stroke="#93c5fd" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
+  <path d="M 830 230 L 850 230 L 850 210" stroke="#93c5fd" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>
 </svg>

--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -97,7 +97,7 @@ const siteConfig: SiteConfig = {
       svg: '/favicon.svg',
     },
     colors: {
-      themeColor: '#6366f1',
+      themeColor: '#3b82f6',
       backgroundColor: '#ffffff',
     },
   },

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -56,7 +56,7 @@ if (includeProfessionalServiceSchema) {
 ---
 
 <!doctype html>
-<html lang="en" class="scroll-smooth dark" data-theme="indigo">
+<html lang="en" class="scroll-smooth dark" data-theme="blue">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
…default theme

- og-default.svg and readme-hero.svg: replace indigo palette (#6366f1, #a5b4fc, #818cf8, #e0e7ff, #eef2ff) with blue equivalents (#3b82f6, #93c5fd, #60a5fa, #dbeafe, #eff6ff) — matches brand-500…50 of the blue theme (OKLCH hue 255)
- BaseLayout.astro: set data-theme="blue" as the server-rendered default (was data-theme="indigo")
- site.config.ts: update themeColor to #3b82f6 (blue-500) for browser toolbar and PWA manifest (was #6366f1, indigo-500)

https://claude.ai/code/session_01X5H7q1iTkNRjGC91sqMS8p

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
