### PR TITLE
Fix ESLint errors, update About me location, rewrite animations post

### DIFF
--- a/src/content/blog/en/animations-in-astro-rocket.mdx
+++ b/src/content/blog/en/animations-in-astro-rocket.mdx
@@ -74,7 +74,7 @@ The delays are defined in `global.css`:
 
 ### Eager reveal mode
 
-Adding `data-eager-reveal` to the `<body>` element expands the observer's root margin to `0px 0px 200px 0px`, triggering reveals 200px before the element enters the viewport. This gives a more "loaded" feel to content-heavy pages where you want sections to be visible before the user reaches them.
+Adding `data-eager-reveal` to the `<body>` element expands the observer's root margin to `0px 0px 200px 0px`, triggering reveals 200px before the element enters the viewport. This gives a more “loaded” feel to content-heavy pages where you want sections to be visible before the user reaches them.
 
 ## Scroll-triggered counter animation
 


### PR DESCRIPTION
## Summary

- **Homepage About me**: location now reads "based in Veghel, the Netherlands" (pulls `country` from `siteConfig.address`)
- **ESLint fixes**: replace `var` with `const` in `BaseLayout.astro` scroll-reveal script, remove unused `heroBlobVariants` import in `Hero.astro`, fix `catch (_)` bindings to `catch`
- **Animations blog post**: full rewrite to reflect current implementation — built-in `data-reveal` system, `data-reveal-delay` staggering, eager reveal mode, hero slide-up animation, scroll indicator, back-to-top progress ring, Lighthouse SVG arc animation, header height shrink and color flip

## Test plan

- [ ] About me section reads "based in Veghel, the Netherlands"
- [ ] Build passes with no ESLint errors
- [ ] Animations blog post shows updated content on `/blog/animations-in-astro-rocket`

https://claude.ai/code/session_01AZggxDNW9MP3vGV924r1qT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZggxDNW9MP3vGV924r1qT)_