### PR TITLE
feat: floating header — full-width capsule, auto-hide, shadow, color flip on return

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -584,11 +584,13 @@ const buttonId = `${menuId}-button`;
               } else {
                 if (header.hasAttribute('data-header-hidden')) {
                   lastShownAtY = currentScrollY;
+                  header.setAttribute('data-header-returned', '');
                 }
                 header.removeAttribute('data-header-hidden');
               }
             } else {
               header.removeAttribute('data-header-hidden');
+              header.removeAttribute('data-header-returned');
               lastShownAtY = 0;
             }
           }
@@ -802,5 +804,47 @@ const buttonId = `${menuId}-button`;
     html:not(.dark) [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
       color: var(--color-brand-500);
     }
+  }
+
+  /* ===== Returned state: color flip only when header comes back after being hidden ===== */
+
+  /* Dark mode: flip to white capsule */
+  .dark [data-header-shape="floating"][data-header-returned] {
+    background: rgba(255, 255, 255, 0.95);
+    border-color: rgba(0, 0, 0, 0.08);
+    box-shadow: 0 8px 32px -4px rgba(0, 0, 0, 0.45), 0 2px 8px -2px rgba(0, 0, 0, 0.25);
+  }
+  .dark [data-header-shape="floating"][data-header-returned] .hdr-invert-text {
+    color: oklch(20% 0.005 250);
+    transition: color 300ms;
+  }
+  .dark [data-header-shape="floating"][data-header-returned] .hdr-invert-text:hover {
+    color: oklch(8% 0 0);
+  }
+  .dark [data-header-shape="floating"][data-header-returned] .hdr-logo-text {
+    color: var(--color-brand-500);
+  }
+  .dark [data-header-shape="floating"][data-header-returned] .theme-dropdown-wrapper button {
+    border-color: var(--color-border);
+  }
+
+  /* Light mode: flip to dark capsule */
+  html:not(.dark) [data-header-shape="floating"][data-header-returned] {
+    background: oklch(12% 0.005 250 / 0.93);
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 8px 32px -4px rgba(0, 0, 0, 0.45), 0 2px 8px -2px rgba(0, 0, 0, 0.25);
+  }
+  html:not(.dark) [data-header-shape="floating"][data-header-returned] .hdr-invert-text {
+    color: rgba(255, 255, 255, 0.82);
+    transition: color 300ms;
+  }
+  html:not(.dark) [data-header-shape="floating"][data-header-returned] .hdr-invert-text:hover {
+    color: rgba(255, 255, 255, 1);
+  }
+  html:not(.dark) [data-header-shape="floating"][data-header-returned] .hdr-logo-text {
+    color: var(--color-brand-400);
+  }
+  html:not(.dark) [data-header-shape="floating"][data-header-returned] .theme-dropdown-wrapper button {
+    border-color: rgba(255, 255, 255, 0.2);
   }
 </style>


### PR DESCRIPTION
## Summary

- **Full-width floating capsule** — expanded from narrow pill to `max-w-6xl w-[calc(100%-3rem)]`, `px-6` inner padding, glass transparent background
- **Auto-hide on scroll down** — header slides off-screen after 150px of downward scroll; requires the same 150px travel before hiding again after reappearing (prevents accidental hide on small downward bumps)
- **Shadow** — strong drop shadow in light mode; white glow + depth shadow in dark mode to visually lift the capsule off the page
- **Color flip on return** — when the header comes back after being hidden (scroll up), it flips to a high-contrast style so it's always readable over any page section: white capsule with dark text in dark mode, near-black capsule with light text in light mode. Reverts to transparent glass when scrolling back to the top. No color change on initial scroll down.
- **Scroll progress bar disabled** on homepage (back-to-top button already shows scroll progress via its ring)
- **Inactive nav links** — `opacity-80` on floating header, `hover:opacity-100`

## Test plan

- [ ] Hero: header is transparent glass, no color change while scrolling down
- [ ] After scrolling past 150px: header hides smoothly
- [ ] Scrolling back up: header reappears with inverted color (white/dark depending on mode)
- [ ] Scrolling back to very top: header returns to transparent glass
- [ ] Small downward scroll after header reappears does not immediately hide it again
- [ ] Mobile menu open: header does not hide while menu is open
- [ ] Dark mode and light mode both look correct
- [ ] No scroll progress bar on homepage

https://claude.ai/code/session_01AZggxDNW9MP3vGV924r1qT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZggxDNW9MP3vGV924r1qT)_