### PR TITLE
Fix floating header: remove shrink, shift up, brand border, no invert

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -728,10 +728,7 @@ const buttonId = `${menuId}-button`;
     max-width: 72rem;
     margin-left: auto;
     margin-right: auto;
-    transition: height 300ms ease, box-shadow 300ms;
-  }
-  [data-header-shape="floating"][data-scrolled] .hdr-inner {
-    height: 3rem;
+    transition: box-shadow 300ms;
   }
 
   [data-header-shape="floating"][data-header-color-scheme="invert"] .hdr-invert-text {
@@ -818,8 +815,8 @@ const buttonId = `${menuId}-button`;
 
   .dark [data-header-shape="floating"] {
     background: color-mix(in oklch, var(--color-background) 65%, transparent);
-    border-color: rgba(255, 255, 255, 0.18);
-    box-shadow: 0 4px 32px rgba(255, 255, 255, 0.06), 0 8px 24px -4px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    border-color: color-mix(in oklch, var(--color-brand-400) 35%, transparent);
+    box-shadow: none;
   }
   .dark [data-header-shape="floating"][data-scrolled] {
     background: color-mix(in oklch, var(--color-background) 88%, transparent);
@@ -828,8 +825,8 @@ const buttonId = `${menuId}-button`;
   }
 
   html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) {
-    border-color: color-mix(in oklch, var(--color-brand-300), transparent 50%);
-    box-shadow: 0 4px 24px -4px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.9);
+    border-color: color-mix(in oklch, var(--color-brand-500) 35%, transparent);
+    box-shadow: none;
   }
   html:not(.dark) [data-header-shape="floating"][data-scrolled] {
     box-shadow: 0 8px 32px -8px rgba(0, 0, 0, 0.35), 0 2px 8px -2px rgba(0, 0, 0, 0.2);
@@ -873,11 +870,6 @@ const buttonId = `${menuId}-button`;
   }
 
   /* ===== Returned state: color flip only when header comes back after being hidden ===== */
-
-  /* Restore original height — override the scrolled height shrink */
-  [data-header-shape="floating"][data-header-returned] .hdr-inner {
-    height: 3.5rem;
-  }
 
   /* Dark mode: flip to white capsule */
   .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] {

--- a/src/components/layout/header.variants.ts
+++ b/src/components/layout/header.variants.ts
@@ -19,7 +19,7 @@ export const headerVariants = cva('z-50', {
   },
   compoundVariants: [
     // Floating + fixed: centered with gap
-    { shape: 'floating', position: 'fixed', class: '!left-1/2 !right-auto -translate-x-1/2 w-[calc(100%-3rem)] max-w-6xl mt-5' },
+    { shape: 'floating', position: 'fixed', class: '!left-1/2 !right-auto -translate-x-1/2 w-[calc(100%-3rem)] max-w-6xl mt-4' },
     // Floating + sticky: centered with gap
     { shape: 'floating', position: 'sticky', class: '!top-4 mx-auto max-w-6xl' },
     // Floating + static: centered

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -60,7 +60,7 @@ const {
     showThemeSelector
     autoHide={false}
     scrollProgressPosition="top"
-    invertOnReturn={true}
+    invertOnReturn={false}
     morphToBar={morphToBar}
   />
 


### PR DESCRIPTION
- Shift header up from mt-5 to mt-4 to match velocity-marketing position
- Remove height shrink animation on scroll (header stays fixed size)
- Remove shadow in initial (pre-scroll) state for both light and dark mode
- Add brand-tinted border (brand-500/400 at 35% opacity) as visual anchor
- Keep scroll shadow only when data-scrolled is active
- Disable invertOnReturn to remove the dark/white flip effect

https://claude.ai/code/session_01LV5vAvgz6u79VMSWeBnA3U

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
