### PR TITLE
Add dark-mode hero gradient to all non-homepage pages

### DIFF
--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -35,7 +35,7 @@ const estimatedWords = description.split(' ').length * 15;
 const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
 ---
 
-<header class="relative overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section)]">
+<header class="relative overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section)] hero-page-gradient">
 <div class="relative mx-auto max-w-4xl px-6 animate-hero-slide-up">
     <!-- Tags -->
     {tags.length > 0 && (

--- a/src/components/projects/ProjectHero.astro
+++ b/src/components/projects/ProjectHero.astro
@@ -34,7 +34,7 @@ const {
 const hasMeta = year || client || role;
 ---
 
-<header class="relative overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section)]">
+<header class="relative overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section)] hero-page-gradient">
   <div class="relative mx-auto max-w-4xl px-6 animate-hero-slide-up">
 
     <!-- Tags -->

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -16,7 +16,7 @@ import TechStack from '@/components/landing/TechStack.astro';
   title="About Astro Rocket — Web Designer & Developer | Veghel"
   description="Designer & developer — Crafting modern web experiences shaped by clean design, solid structure, and attention to detail."
 >
-  <Hero layout="centered" size="sm">
+  <Hero layout="centered" size="sm" class="hero-page-gradient">
     <Badge slot="badge" variant="brand" pill>
       <Icon name="user" size="sm" />
       About me

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -39,7 +39,7 @@ const getPostUrl = (postId: string) => {
 ---
 
 <PageLayout title="Blog — Astro Rocket" description="Articles on web design, development, and the web by Astro Rocket." showScrollProgress eagerReveal>
-  <Hero layout="centered" size="sm">
+  <Hero layout="centered" size="sm" class="hero-page-gradient">
     <Badge slot="badge" variant="brand" pill>
       <Icon name="book" size="sm" />
       All posts

--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -51,7 +51,7 @@ import EmptyState from '@/components/patterns/EmptyState.astro';
 >
 
   <!-- Hero Section -->
-  <Hero layout="split" size="lg">
+  <Hero layout="split" size="lg" class="hero-page-gradient">
     <Badge slot="badge" variant="brand" pill>50+ production components</Badge>
 
     <h1 slot="title">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -39,7 +39,7 @@ const channels = [
   description="Get in touch"
   eagerReveal
 >
-  <Hero layout="centered" size="sm">
+  <Hero layout="centered" size="sm" class="hero-page-gradient">
     <Badge slot="badge" variant="brand" pill>
       <Icon name="mail" size="sm" />
       Get in touch

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -20,7 +20,7 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
   description="Selected work — websites, tools, and open-source projects built by Astro Rocket."
   eagerReveal
 >
-  <Hero layout="centered" size="sm">
+  <Hero layout="centered" size="sm" class="hero-page-gradient">
     <Badge slot="badge" variant="brand" pill>
       <Icon name="layers" size="sm" />
       Selected work

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -299,6 +299,10 @@
     background: linear-gradient(to bottom, var(--color-brand-600) 0%, #000 100%);
   }
 
+  .dark .hero-page-gradient {
+    background: linear-gradient(to bottom, var(--color-brand-800) 0%, #000 100%);
+  }
+
   /* Gradient border */
   .border-gradient {
     position: relative;


### PR DESCRIPTION
Adds .dark .hero-page-gradient (brand-800 → black) to global.css and applies it to About, Blog, Projects, Contact, Components page heroes, and ArticleHero / ProjectHero components.

https://claude.ai/code/session_01867LuzStkUzD2TBAbgQrq5

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
