### PR TITLE
fix: use foreground text color for sitename in dark mode

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -142,7 +142,7 @@ function getSocialIcon(platform: string): string {
             ) : (
               <a href="/" class="flex items-center gap-2">
                 <Logo size="md" />
-                <span class="font-display text-base font-bold text-brand-500 dark:text-brand-400">
+                <span class="font-display text-base font-bold text-brand-500 dark:text-foreground">
                   {siteConfig.name}
                 </span>
               </a>
@@ -209,7 +209,7 @@ function getSocialIcon(platform: string): string {
               ) : (
                 <a href="/" class="flex items-center gap-2">
                   <Logo size="md" />
-                  <span class="font-display text-base font-bold text-brand-500 dark:text-brand-400">
+                  <span class="font-display text-base font-bold text-brand-500 dark:text-foreground">
                     {siteConfig.name}
                   </span>
                 </a>
@@ -312,7 +312,7 @@ function getSocialIcon(platform: string): string {
           ) : (
             <a href="/" class="flex items-center gap-2">
               <Logo size="md" />
-              <span class="font-display text-xl font-bold text-brand-500 dark:text-brand-400">
+              <span class="font-display text-xl font-bold text-brand-500 dark:text-foreground">
                 {siteConfig.name}
               </span>
             </a>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -171,7 +171,7 @@ const buttonId = `${menuId}-button`;
             <span
               class={cn(
                 'font-display text-xl font-bold tracking-tight',
-                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-brand-500 dark:text-brand-500 md:text-on-invert' : 'text-brand-500 dark:text-brand-500')
+                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-brand-500 dark:text-foreground md:text-on-invert' : 'text-brand-500 dark:text-foreground')
               )}
             >
               {logoText || siteConfig.name}
@@ -840,13 +840,13 @@ const buttonId = `${menuId}-button`;
     color: var(--color-brand-500);
   }
   .dark [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-foreground);
   }
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
     color: var(--color-brand-500);
   }
   .dark [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-foreground);
   }
 
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text {


### PR DESCRIPTION
Replace brand color with standard foreground text color for the site name in the header and footer when in dark mode, matching h1 heading color.

https://claude.ai/code/session_01Qqte11BKxmjY7spJri3kaZ

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
