### PR TITLE
feat: add Astro Rocket CTA button to all page headers

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -56,7 +56,7 @@ interface Props extends HTMLAttributes<'header'> {
   nav?: NavItem[];
   extraNav?: NavItem[];
   showCta?: boolean;
-  cta?: { label?: string; href?: string; icon?: string };
+  cta?: { label?: string; href?: string; icon?: string; trailingIcon?: string };
   actions?: HeaderAction[];
   showThemeToggle?: boolean;
   showThemeSelector?: boolean;
@@ -278,6 +278,7 @@ const buttonId = `${menuId}-button`;
                 >
                   {cta.icon && <Icon name={cta.icon} size="sm" />}
                   {cta.label}
+                  {cta.trailingIcon && <Icon name={cta.trailingIcon} size="sm" />}
                 </Button>
               </div>
             )}
@@ -386,7 +387,9 @@ const buttonId = `${menuId}-button`;
             {showCta && (
               <div class="border-border mt-3 border-t pt-3">
                 <Button fullWidth href={ctaHref} target={ctaHref?.startsWith('http') ? '_blank' : undefined}>
+                  {cta.icon && <Icon name={cta.icon} size="sm" />}
                   {cta.label}
+                  {cta.trailingIcon && <Icon name={cta.trailingIcon} size="sm" />}
                 </Button>
               </div>
             )}

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -71,8 +71,8 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     variant="solid"
     size="lg"
     showThemeSelector
-    showCta={false}
-    cta={{ label: 'Get in touch', href: '/contact' }}
+    showCta={true}
+    cta={{ label: 'Astro Rocket', href: 'https://github.com/hansmartens68/Astro-Rocket', icon: 'rocket', trailingIcon: 'download' }}
     showScrollProgress
   />
 

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -56,7 +56,8 @@ const {
     variant="transparent"
     colorScheme="default"
     size="lg"
-    showCta={false}
+    showCta={true}
+    cta={{ label: 'Astro Rocket', href: 'https://github.com/hansmartens68/Astro-Rocket', icon: 'rocket', trailingIcon: 'download' }}
     showThemeSelector
     autoHide={false}
     scrollProgressPosition="top"

--- a/src/layouts/MarketingLayout.astro
+++ b/src/layouts/MarketingLayout.astro
@@ -45,8 +45,8 @@ const {
     position="fixed"
     colorScheme="default"
     showLanguageSwitcher={false}
-    showCta={false}
-    cta={{ label: 'Start a Project', href: '/contact' }}
+    showCta={true}
+    cta={{ label: 'Astro Rocket', href: 'https://github.com/hansmartens68/Astro-Rocket', icon: 'rocket', trailingIcon: 'download' }}
   />
 
   <slot />

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -40,8 +40,8 @@ const { title, description, image, imageAlt, noindex, nofollow, showScrollProgre
     size="lg"
     showActiveState
     showThemeSelector
-    showCta={false}
-    cta={{ label: 'Get in touch', href: '/contact' }}
+    showCta={true}
+    cta={{ label: 'Astro Rocket', href: 'https://github.com/hansmartens68/Astro-Rocket', icon: 'rocket', trailingIcon: 'download' }}
     showScrollProgress={showScrollProgress}
   />
 

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -62,7 +62,8 @@ const breadcrumbs = [
     variant="solid"
     size="lg"
     showThemeSelector
-    showCta={false}
+    showCta={true}
+    cta={{ label: 'Astro Rocket', href: 'https://github.com/hansmartens68/Astro-Rocket', icon: 'rocket', trailingIcon: 'download' }}
     showScrollProgress
   />
 


### PR DESCRIPTION
Adds a branded CTA button with rocket and download icons to every page header, linking to the GitHub repository.

https://claude.ai/code/session_01Edhj4g85FXBLQ66tmjt5w1

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
