### PR TITLE
fix(mobile): eliminate hero flash on page navigation

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -157,7 +157,6 @@ const buttonId = `${menuId}-button`;
   data-header-auto-hide={autoHide ? 'true' : 'false'}
   data-header-invert-on-return={invertOnReturn ? 'true' : 'false'}
   data-morph-to-bar={morphToBar ? 'true' : 'false'}
-  transition:name="site-header"
   {...attrs}
 >
   <div class={cn(innerClasses, 'hdr-inner')}>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -173,6 +173,21 @@ if (includeProfessionalServiceSchema) {
         }
       })();
     </script>
+
+    <!-- Suppress hero slide-up animation during client-side navigations -->
+    <script is:inline>
+      (function () {
+        if (!window.__heroNavAnimInit) {
+          window.__heroNavAnimInit = true;
+          document.addEventListener('astro:before-swap', function () {
+            document.documentElement.classList.add('is-navigating');
+          });
+          document.addEventListener('astro:page-load', function () {
+            document.documentElement.classList.remove('is-navigating');
+          });
+        }
+      })();
+    </script>
   </head>
 
   <body class="min-h-screen bg-background text-foreground antialiased" data-eager-reveal={eagerReveal ? '' : undefined}>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -44,7 +44,7 @@ const { title, description, image, imageAlt, noindex, nofollow, showScrollProgre
     showScrollProgress={showScrollProgress}
   />
 
-  <main class="min-h-screen pt-16">
+  <main class="min-h-screen">
     <slot />
   </main>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -954,6 +954,11 @@
   animation: hero-slide-up 0.7s cubic-bezier(0, 0, 0.2, 1) both;
 }
 
+/* Skip the entrance animation when arriving via client-side navigation */
+html.is-navigating .animate-hero-slide-up {
+  animation: none;
+}
+
 [data-reveal] {
   opacity: 0;
   transition: opacity 0.6s cubic-bezier(0, 0, 0.2, 1);


### PR DESCRIPTION
Three-part fix for the jarring visual "shock" when navigating between pages on mobile:

A) Suppress animate-hero-slide-up during client-side navigations by
   adding an is-navigating class to <html> via astro:before-swap and
   removing it on astro:page-load. First-load still gets the entrance
   animation; subsequent navigations get an instant reveal.

C) Remove transition:name="site-header" from Header so the header
   swaps instantly instead of morphing between pages. The morph was
   visually identical (same header on every page) but caused a flash
   from scroll-state differences at the moment of swap.

D) Remove the redundant pt-16 (64px) from PageLayout's <main>. The
   Hero component already provides full header clearance via
   --space-page-top-sm / --space-page-top tokens, so the outer
   padding was doubling up and creating excess whitespace on mobile.

https://claude.ai/code/session_01KQkNDurz4aNLgnxRsn5xn7

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
