### PR TITLE
fix: suppress hero double-animation on mobile nav and fix TypingEffec…

### DIFF
--- a/src/components/ui/TypingEffect.astro
+++ b/src/components/ui/TypingEffect.astro
@@ -24,7 +24,7 @@ const id = `typing-${Math.random().toString(36).slice(2, 8)}`;
 ---
 
 <span id={id} class="typing-effect" aria-label={words.join(', ')}>
-  <span class="typing-text"></span><span class="typing-cursor" aria-hidden="true">|</span>
+  <span class="typing-text">{words[0]}</span><span class="typing-cursor" aria-hidden="true">|</span>
 </span>
 
 <style>
@@ -72,8 +72,8 @@ const id = `typing-${Math.random().toString(36).slice(2, 8)}`;
     root.style.minWidth = maxWidth + 'px';
 
     let wordIndex = 0;
-    let charIndex = 0;
-    let isDeleting = false;
+    let charIndex = words[0].length; // first word is already rendered server-side
+    let isDeleting = true;           // ready to delete after the first pause
     let timer;
 
     function tick() {
@@ -103,8 +103,8 @@ const id = `typing-${Math.random().toString(36).slice(2, 8)}`;
       }
     }
 
-    // Start after a short initial delay so the page paint settles
-    timer = setTimeout(tick, 600);
+    // First word is pre-rendered; pause naturally before beginning the cycle
+    timer = setTimeout(tick, pauseAfterType);
 
     // Clean up pending timer when navigating away
     document.addEventListener('astro:before-swap', () => clearTimeout(timer), { once: true });

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -90,6 +90,22 @@ if (includeProfessionalServiceSchema) {
     <!-- View Transitions (client-side routing with animated page transitions) -->
     <ClientRouter />
 
+    <!-- Mark document during view transitions so entrance animations don't
+         double-fire on top of the page-change cross-fade (most visible on mobile). -->
+    <script is:inline>
+      (function () {
+        if (!window.__navAnimGuardInit) {
+          window.__navAnimGuardInit = true;
+          document.addEventListener('astro:before-swap', function () {
+            document.documentElement.setAttribute('data-navigating', '');
+          });
+          document.addEventListener('astro:page-load', function () {
+            document.documentElement.removeAttribute('data-navigating');
+          });
+        }
+      })();
+    </script>
+
     <!-- Dynamic favicon: syncs letter (first letter of site name) and color (brand-500) with active theme -->
     <script is:inline define:vars={{ _faviconLetter: siteConfig.name.charAt(0).toUpperCase() }}>
       (function () {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -976,6 +976,19 @@
   }
 }
 
+/* During client-side navigation (Astro view transitions) the page-change
+   cross-fade already provides a smooth entrance. Re-running hero-slide-up
+   and data-reveal on top of that cross-fade creates a jarring double-animation
+   that is most visible on mobile. Suppress both while the transition is live. */
+html[data-navigating] .animate-hero-slide-up {
+  animation: none;
+}
+
+html[data-navigating] [data-reveal] {
+  opacity: 1;
+  transition: none;
+}
+
 /* ── Hero / CTA button styles ───────────────────────────────────────────────
    Shared across all pages. Re-enable by applying these classes to buttons.
    hero-btn-brand : brand-coloured primary action


### PR DESCRIPTION
…t layout shift

- Add data-navigating attribute to <html> during Astro view transitions so animate-hero-slide-up and data-reveal do not double-fire on top of the page-change cross-fade (most jarring on mobile)
- Pre-render words[0] in TypingEffect to eliminate the blank-gap and layout reflow that caused a shocking hero on the about/typing page

https://claude.ai/code/session_01FQxbXV2MR1dKnjDuT6k9BE

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
