### PR TITLE
List all 12 colorschemes by name on the Astro Rocket project page

### DIFF
--- a/src/content/projects/astro-rocket.mdx
+++ b/src/content/projects/astro-rocket.mdx
@@ -21,7 +21,7 @@ It's built for designers, freelancers, and developers who want a site that genui
 
 ## 12 Themes. Switch in Seconds.
 
-The theme switcher is one of Astro Rocket's most satisfying details. Twelve colour themes — Indigo, Orange, Emerald, Violet, Rose, and seven others — toggle instantly in the header. Click a colour, and every button, link, badge, progress bar, and accent on the page updates in a single frame. No waiting, no code changes, no deploy.
+The theme switcher is one of Astro Rocket's most satisfying details. Twelve colour themes — **Orange, Amber, Lime, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, Purple, and Magenta** — toggle instantly in the header. Click a colour, and every button, link, badge, progress bar, and accent on the page updates in a single frame. No waiting, no code changes, no deploy.
 
 The secret is CSS custom properties scoped to `data-theme` attributes on `<html>`. The browser does all the work — the server never needs to know.
 


### PR DESCRIPTION
Replaces the vague "Indigo, Orange, Emerald, Violet, Rose, and seven others" (which also incorrectly included Rose) with the full list: Orange, Amber, Lime, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, Purple, and Magenta.

https://claude.ai/code/session_01N4kxnwPVtGrVPbLsmRq2CV

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
