### PR TITLE
fix: eliminate hero aftershake on mobile navigation

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -64,7 +64,6 @@ const gridClasses = cn(
     <div
       class="bg-grid-pattern pointer-events-none absolute inset-x-0 -inset-y-[20%] opacity-30 hidden dark:block"
       style="mask-image: radial-gradient(ellipse 50% 50% at 50% 40%, black 0%, transparent 70%);"
-      data-parallax="0.2"
       aria-hidden="true"
     />
   )}
@@ -216,58 +215,28 @@ const gridClasses = cn(
 </style>
 
 <script>
-  // Parallax: move [data-parallax] layers at a fraction of scroll speed.
-  // Elements with -inset-y-[20%] have extra room to move without clipping.
-  // Skipped entirely when the user prefers reduced motion.
-  if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-    function initParallax() {
-      const layers = document.querySelectorAll<HTMLElement>('[data-parallax]');
-      if (!layers.length) return;
-
-      function applyParallax() {
-        layers.forEach((el) => {
-          const section = el.closest('section');
-          if (!section) return;
-
-          const rect = section.getBoundingClientRect();
-          // Skip sections fully outside the viewport
-          if (rect.bottom < 0 || rect.top > window.innerHeight) return;
-
-          const speed = parseFloat(el.dataset.parallax ?? '0.3');
-          // Offset relative to how far the section top is from the viewport top
-          const offset = -rect.top * speed;
-          el.style.transform = `translateY(${offset.toFixed(2)}px)`;
-        });
-      }
-
-      window.addEventListener('scroll', applyParallax, { passive: true });
-      applyParallax();
-
-      document.addEventListener('astro:before-swap', () => {
-        window.removeEventListener('scroll', applyParallax);
-      }, { once: true });
-    }
-
-    document.addEventListener('astro:page-load', initParallax);
-  }
-
   // Scroll indicator: fade out once the user starts scrolling.
+  // Stored on window so re-init across navigations replaces the previous
+  // listener instead of stacking handlers.
   function initScrollIndicator() {
     const indicator = document.querySelector<HTMLElement>('.scroll-indicator');
     if (!indicator) return;
+
+    const w = window as Window & { __scrollIndicatorHandler?: () => void };
+    if (w.__scrollIndicatorHandler) {
+      window.removeEventListener('scroll', w.__scrollIndicatorHandler);
+    }
 
     function onScroll() {
       if (window.scrollY > 50) {
         indicator?.classList.add('is-hidden');
         window.removeEventListener('scroll', onScroll);
+        delete w.__scrollIndicatorHandler;
       }
     }
 
+    w.__scrollIndicatorHandler = onScroll;
     window.addEventListener('scroll', onScroll, { passive: true });
-
-    document.addEventListener('astro:before-swap', () => {
-      window.removeEventListener('scroll', onScroll);
-    }, { once: true });
   }
 
   document.addEventListener('astro:page-load', initScrollIndicator);

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -157,7 +157,6 @@ const buttonId = `${menuId}-button`;
   data-header-auto-hide={autoHide ? 'true' : 'false'}
   data-header-invert-on-return={invertOnReturn ? 'true' : 'false'}
   data-morph-to-bar={morphToBar ? 'true' : 'false'}
-  transition:name="site-header"
   {...attrs}
 >
   <div class={cn(innerClasses, 'hdr-inner')}>
@@ -621,9 +620,7 @@ const buttonId = `${menuId}-button`;
     });
   }
 
-  initScrollWatcher();
   document.addEventListener('astro:page-load', initScrollWatcher);
-  document.addEventListener('astro:after-swap', initScrollWatcher);
 </script>
 
 <script>
@@ -912,33 +909,6 @@ const buttonId = `${menuId}-button`;
   }
   html:not(.dark) [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .theme-dropdown-wrapper button {
     border-color: rgba(255, 255, 255, 0.2);
-  }
-
-  /* ===== View Transition: header morph across page navigation ===== */
-
-  ::view-transition-group(site-header) {
-    animation-duration: 350ms;
-    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  }
-
-  ::view-transition-old(site-header) {
-    animation-duration: 180ms;
-    animation-timing-function: ease-in;
-  }
-
-  ::view-transition-new(site-header) {
-    animation-duration: 280ms;
-    animation-timing-function: ease-out;
-    animation-delay: 80ms;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    ::view-transition-group(site-header),
-    ::view-transition-old(site-header),
-    ::view-transition-new(site-header) {
-      animation-duration: 0ms !important;
-      animation-delay: 0ms !important;
-    }
   }
 
   /* ===== Returned state: fix button hover backgrounds ===== */


### PR DESCRIPTION
Mobile address-bar collapse fired scroll events that re-applied the hero's parallax transform after each navigation, producing a visible shake. The header's view-transition morph compounded the effect.

- Remove the parallax script and data-parallax attribute from Hero (the only target was the optional grid layer, which is decorative).
- Remove transition:name="site-header" and the matching dead ::view-transition-* CSS so the floating header no longer morphs across page swaps.
- Drop the duplicate astro:after-swap registration on the scroll watcher; the per-header dataset guard already prevents duplicate init on astro:page-load.
- Track the scroll-indicator handler on window so repeated navigation replaces it rather than stacking listeners.

https://claude.ai/code/session_019meUzsMNd24bPrPtrWQBu5

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
