### PR TITLE
fix: stop hero entrance animation from re-firing after view transition

### DIFF
--- a/src/components/ui/TypingEffect.astro
+++ b/src/components/ui/TypingEffect.astro
@@ -24,7 +24,7 @@ const id = `typing-${Math.random().toString(36).slice(2, 8)}`;
 ---
 
 <span id={id} class="typing-effect" aria-label={words.join(', ')}>
-  <span class="typing-text">{words[0]}</span><span class="typing-cursor" aria-hidden="true">|</span>
+  <span class="typing-text"></span><span class="typing-cursor" aria-hidden="true">|</span>
 </span>
 
 <style>
@@ -72,8 +72,8 @@ const id = `typing-${Math.random().toString(36).slice(2, 8)}`;
     root.style.minWidth = maxWidth + 'px';
 
     let wordIndex = 0;
-    let charIndex = words[0].length; // first word is already rendered server-side
-    let isDeleting = true;           // ready to delete after the first pause
+    let charIndex = 0;       // start empty — cursor only, then type the first word
+    let isDeleting = false;
     let timer;
 
     function tick() {
@@ -103,8 +103,8 @@ const id = `typing-${Math.random().toString(36).slice(2, 8)}`;
       }
     }
 
-    // First word is pre-rendered; pause naturally before beginning the cycle
-    timer = setTimeout(tick, pauseAfterType);
+    // Show the blinking cursor briefly, then begin typing the first word
+    timer = setTimeout(tick, pauseAfterDelete);
 
     // Clean up pending timer when navigating away
     document.addEventListener('astro:before-swap', () => clearTimeout(timer), { once: true });

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -90,19 +90,27 @@ if (includeProfessionalServiceSchema) {
     <!-- View Transitions (client-side routing with animated page transitions) -->
     <ClientRouter />
 
-    <!-- Mark document during view transitions so entrance animations don't
-         double-fire on top of the page-change cross-fade (most visible on mobile). -->
+    <!-- Strip first-paint entrance animations from pages reached via client-side
+         navigation. The view-transition cross-fade is already the entrance, so
+         re-running hero-slide-up / data-reveal on top of it produced a visible
+         "aftershake" once the cross-fade ended (most noticeable on mobile).
+         Initial full page loads are unaffected and animate normally. -->
     <script is:inline>
       (function () {
-        if (!window.__navAnimGuardInit) {
-          window.__navAnimGuardInit = true;
-          document.addEventListener('astro:before-swap', function () {
-            document.documentElement.setAttribute('data-navigating', '');
-          });
-          document.addEventListener('astro:page-load', function () {
-            document.documentElement.removeAttribute('data-navigating');
-          });
-        }
+        if (window.__navAnimGuardInit) return;
+        window.__navAnimGuardInit = true;
+        document.addEventListener('astro:before-swap', function (e) {
+          const doc = e.newDocument;
+          if (!doc) return;
+          const heroes = doc.querySelectorAll('.animate-hero-slide-up');
+          for (let i = 0; i < heroes.length; i++) {
+            heroes[i].classList.remove('animate-hero-slide-up');
+          }
+          const reveals = doc.querySelectorAll('[data-reveal]');
+          for (let j = 0; j < reveals.length; j++) {
+            reveals[j].classList.add('is-visible');
+          }
+        });
       })();
     </script>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -976,19 +976,6 @@
   }
 }
 
-/* During client-side navigation (Astro view transitions) the page-change
-   cross-fade already provides a smooth entrance. Re-running hero-slide-up
-   and data-reveal on top of that cross-fade creates a jarring double-animation
-   that is most visible on mobile. Suppress both while the transition is live. */
-html[data-navigating] .animate-hero-slide-up {
-  animation: none;
-}
-
-html[data-navigating] [data-reveal] {
-  opacity: 1;
-  transition: none;
-}
-
 /* ── Hero / CTA button styles ───────────────────────────────────────────────
    Shared across all pages. Re-enable by applying these classes to buttons.
    hero-btn-brand : brand-coloured primary action


### PR DESCRIPTION
The previous data-navigating guard suppressed .animate-hero-slide-up during navigation by overriding the keyframe with animation: none, then removed the attribute on astro:page-load. Removing the override restarted the keyframe from frame 0 on an element that was already mounted and visible, producing the post-cross-fade "aftershake" (translateY(28px) -> 0 over 0.7s) that users reported on mobile.

Replace the suppress-then-restore pattern with a one-shot mutation of the incoming document on astro:before-swap: strip the entrance class entirely so the animation never fires on swapped pages, and mark [data-reveal] elements as already revealed. Initial full page loads still animate normally; client-side navigations rely on the view-transition cross-fade alone.

Also drops the now-unused html[data-navigating] CSS overrides.

https://claude.ai/code/session_019meUzsMNd24bPrPtrWQBu5

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
