### PR TITLE
feat: subtle entrance animation on navigated pages

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -90,11 +90,11 @@ if (includeProfessionalServiceSchema) {
     <!-- View Transitions (client-side routing with animated page transitions) -->
     <ClientRouter />
 
-    <!-- Strip first-paint entrance animations from pages reached via client-side
-         navigation. The view-transition cross-fade is already the entrance, so
-         re-running hero-slide-up / data-reveal on top of it produced a visible
-         "aftershake" once the cross-fade ended (most noticeable on mobile).
-         Initial full page loads are unaffected and animate normally. -->
+    <!-- For pages reached via Astro view transitions, swap the dramatic 0.7s
+         hero entrance for a shorter variant that finishes with the cross-fade.
+         The original animation visibly continued for ~450ms after the fade
+         ended, producing a post-fade "aftershake" on mobile. Initial full
+         page loads keep the original 0.7s slide-up. -->
     <script is:inline>
       (function () {
         if (window.__navAnimGuardInit) return;
@@ -105,6 +105,7 @@ if (includeProfessionalServiceSchema) {
           const heroes = doc.querySelectorAll('.animate-hero-slide-up');
           for (let i = 0; i < heroes.length; i++) {
             heroes[i].classList.remove('animate-hero-slide-up');
+            heroes[i].classList.add('animate-hero-slide-up-nav');
           }
           const reveals = doc.querySelectorAll('[data-reveal]');
           for (let j = 0; j < reveals.length; j++) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -954,6 +954,19 @@
   animation: hero-slide-up 0.7s cubic-bezier(0, 0, 0.2, 1) both;
 }
 
+/* Shorter entrance used for pages reached via Astro view transitions.
+   The 0.7s slide-up above visibly continues for ~450ms after Astro's
+   cross-fade ends — this 220ms variant finishes with the cross-fade
+   so there's no post-fade "aftershake" on mobile. */
+@keyframes hero-slide-up-nav {
+  from { transform: translateY(8px); opacity: 0.85; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+
+.animate-hero-slide-up-nav {
+  animation: hero-slide-up-nav 0.22s cubic-bezier(0, 0, 0.2, 1) both;
+}
+
 [data-reveal] {
   opacity: 0;
   transition: opacity 0.6s cubic-bezier(0, 0, 0.2, 1);
@@ -968,7 +981,8 @@
 [data-reveal][data-reveal-delay="3"] { transition-delay: 300ms; }
 
 @media (prefers-reduced-motion: reduce) {
-  .animate-hero-slide-up { animation: none; }
+  .animate-hero-slide-up,
+  .animate-hero-slide-up-nav { animation: none; }
 
   [data-reveal] {
     opacity: 1;


### PR DESCRIPTION
The previous fix stripped the hero entrance animation entirely on swapped pages, leaving a flat cross-fade. Add a 0.22s slide-up-nav variant that finishes with Astro's cross-fade so navigated pages get a subtle "settle" entrance without the post-fade aftershake.

Initial full page loads keep the original 0.7s dramatic slide-up. Reduced-motion users get neither.

https://claude.ai/code/session_019meUzsMNd24bPrPtrWQBu5

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
