### PR TITLE
fix: disable Astro view transitions to restore reliable animations

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -239,5 +239,5 @@ const gridClasses = cn(
     window.addEventListener('scroll', onScroll, { passive: true });
   }
 
-  document.addEventListener('astro:page-load', initScrollIndicator);
+  initScrollIndicator();
 </script>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -620,7 +620,7 @@ const buttonId = `${menuId}-button`;
     });
   }
 
-  document.addEventListener('astro:page-load', initScrollWatcher);
+  initScrollWatcher();
 </script>
 
 <script>

--- a/src/components/ui/TypingEffect.astro
+++ b/src/components/ui/TypingEffect.astro
@@ -74,7 +74,6 @@ const id = `typing-${Math.random().toString(36).slice(2, 8)}`;
     let wordIndex = 0;
     let charIndex = 0;       // start empty — cursor only, then type the first word
     let isDeleting = false;
-    let timer;
 
     function tick() {
       const current = words[wordIndex];
@@ -86,30 +85,26 @@ const id = `typing-${Math.random().toString(36).slice(2, 8)}`;
         if (charIndex === 0) {
           isDeleting = false;
           wordIndex = (wordIndex + 1) % words.length;
-          timer = setTimeout(tick, pauseAfterDelete);
+          setTimeout(tick, pauseAfterDelete);
           return;
         }
-        timer = setTimeout(tick, deleteSpeed);
+        setTimeout(tick, deleteSpeed);
       } else {
         charIndex++;
         textEl.textContent = current.slice(0, charIndex);
 
         if (charIndex === current.length) {
           isDeleting = true;
-          timer = setTimeout(tick, pauseAfterType);
+          setTimeout(tick, pauseAfterType);
           return;
         }
-        timer = setTimeout(tick, typeSpeed);
+        setTimeout(tick, typeSpeed);
       }
     }
 
     // Show the blinking cursor briefly, then begin typing the first word
-    timer = setTimeout(tick, pauseAfterDelete);
-
-    // Clean up pending timer when navigating away
-    document.addEventListener('astro:before-swap', () => clearTimeout(timer), { once: true });
+    setTimeout(tick, pauseAfterDelete);
   }
 
-  // Run on initial load and on every client-side navigation back to this page
-  document.addEventListener('astro:page-load', startTyping);
+  startTyping();
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,7 +4,6 @@ import SEO from '@/components/seo/SEO.astro';
 import JsonLd from '@/components/seo/JsonLd.astro';
 import Analytics from '@/components/layout/Analytics.astro';
 import ConsentBanner from '@/components/ui/overlay/ConsentBanner';
-import { ClientRouter } from 'astro:transitions';
 import { createWebsiteSchema, createOrganizationSchema, createPersonSchema, createProfessionalServiceSchema } from '@/lib/schema';
 import type { WebSite, Organization, Person, WithContext } from 'schema-dts';
 import siteConfig from '@/config/site.config';
@@ -87,33 +86,12 @@ if (includeProfessionalServiceSchema) {
     <!-- Analytics (loads if PUBLIC_GA_MEASUREMENT_ID or PUBLIC_GTM_ID is set) -->
     <Analytics />
 
-    <!-- View Transitions (client-side routing with animated page transitions) -->
-    <ClientRouter />
+    <!-- Client-side view transitions are intentionally disabled. They composed
+         poorly with the theme's CSS keyframe animations (hero slide-up,
+         data-reveal fades) and produced a visible post-fade "aftershake" on
+         mobile. Each navigation now does a normal page load, so animations
+         run cleanly from frame 0 every time. -->
 
-    <!-- For pages reached via Astro view transitions, swap the dramatic 0.7s
-         hero entrance for a shorter variant that finishes with the cross-fade.
-         The original animation visibly continued for ~450ms after the fade
-         ended, producing a post-fade "aftershake" on mobile. Initial full
-         page loads keep the original 0.7s slide-up. -->
-    <script is:inline>
-      (function () {
-        if (window.__navAnimGuardInit) return;
-        window.__navAnimGuardInit = true;
-        document.addEventListener('astro:before-swap', function (e) {
-          const doc = e.newDocument;
-          if (!doc) return;
-          const heroes = doc.querySelectorAll('.animate-hero-slide-up');
-          for (let i = 0; i < heroes.length; i++) {
-            heroes[i].classList.remove('animate-hero-slide-up');
-            heroes[i].classList.add('animate-hero-slide-up-nav');
-          }
-          const reveals = doc.querySelectorAll('[data-reveal]');
-          for (let j = 0; j < reveals.length; j++) {
-            reveals[j].classList.add('is-visible');
-          }
-        });
-      })();
-    </script>
 
     <!-- Dynamic favicon: syncs letter (first letter of site name) and color (brand-500) with active theme -->
     <script is:inline define:vars={{ _faviconLetter: siteConfig.name.charAt(0).toUpperCase() }}>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -245,5 +245,5 @@ const getPostUrl = (postId: string) => {
     });
   }
 
-  document.addEventListener('astro:page-load', initTagFilter);
+  initTagFilter();
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -372,7 +372,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
     });
   }
 
-  document.addEventListener('astro:page-load', initCountup);
+  initCountup();
 </script>
 
 </LandingLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -954,19 +954,6 @@
   animation: hero-slide-up 0.7s cubic-bezier(0, 0, 0.2, 1) both;
 }
 
-/* Shorter entrance used for pages reached via Astro view transitions.
-   The 0.7s slide-up above visibly continues for ~450ms after Astro's
-   cross-fade ends — this 220ms variant finishes with the cross-fade
-   so there's no post-fade "aftershake" on mobile. */
-@keyframes hero-slide-up-nav {
-  from { transform: translateY(8px); opacity: 0.85; }
-  to   { transform: translateY(0); opacity: 1; }
-}
-
-.animate-hero-slide-up-nav {
-  animation: hero-slide-up-nav 0.22s cubic-bezier(0, 0, 0.2, 1) both;
-}
-
 [data-reveal] {
   opacity: 0;
   transition: opacity 0.6s cubic-bezier(0, 0, 0.2, 1);
@@ -981,8 +968,7 @@
 [data-reveal][data-reveal-delay="3"] { transition-delay: 300ms; }
 
 @media (prefers-reduced-motion: reduce) {
-  .animate-hero-slide-up,
-  .animate-hero-slide-up-nav { animation: none; }
+  .animate-hero-slide-up { animation: none; }
 
   [data-reveal] {
     opacity: 1;


### PR DESCRIPTION
The view-transition cross-fade composed poorly with the theme's CSS keyframe animations. Hero slide-up either started during the cross-fade (invisible, then "aftershake" tail after the fade ended) or was suppressed-then-restored mid-flight (causing the keyframe to restart on a fully-mounted element — the same aftershake by a different path).

Removing <ClientRouter /> means each navigation is a normal page load, so:

- Hero slide-up runs cleanly from frame 0 every time, no aftershake.
- Reveal observers, scroll watchers, and other init code run once per page via their existing bare init calls.
- Components that only had astro:page-load listeners (Hero scroll indicator, TypingEffect, Header scroll watcher, home countup, blog tag filter) get a bare init call so they still fire on every load.

Trade-off: navigation no longer cross-fades; each click is a normal page load. For a marketing/portfolio site this is the right choice — animation reliability matters more than a 150ms perceived speed-up.

Also drops the now-unused .animate-hero-slide-up-nav variant, the data-navigating guard script, and the unused timer var in TypingEffect.

https://claude.ai/code/session_019meUzsMNd24bPrPtrWQBu5

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
