### PR TITLE
feat: unify section reveal animation with hero slide-up

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -328,7 +328,7 @@ if (includeProfessionalServiceSchema) {
                 observer.unobserve(entry.target);
               }
             });
-          }, { threshold: 0.12, rootMargin: eager ? '0px 0px 200px 0px' : '0px 0px -40px 0px' });
+          }, { threshold: 0.12, rootMargin: eager ? '0px 0px 200px 0px' : '0px 0px 80px 0px' });
           remaining.forEach(function (el) { observer.observe(el); });
         }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -956,11 +956,13 @@
 
 [data-reveal] {
   opacity: 0;
-  transition: opacity 0.6s cubic-bezier(0, 0, 0.2, 1);
+  transform: translateY(16px);
+  transition: opacity 0.6s cubic-bezier(0, 0, 0.2, 1), transform 0.6s cubic-bezier(0, 0, 0.2, 1);
 }
 
 [data-reveal].is-visible {
   opacity: 1;
+  transform: translateY(0);
 }
 
 [data-reveal][data-reveal-delay="1"] { transition-delay: 100ms; }
@@ -972,6 +974,7 @@
 
   [data-reveal] {
     opacity: 1;
+    transform: none;
     transition: none;
   }
 }


### PR DESCRIPTION
[data-reveal] now slides up 16px while fading in, matching the hero's entrance motion at a smaller scale. Previously it was opacity-only, which made the hero feel disconnected from everything below it.

Also bumps the IntersectionObserver rootMargin from -40px to +80px so reveals trigger 80px before the element enters the viewport. On mobile this removes the "scroll, pause, then content appears" delay.

Reduced-motion users still get static content (transform: none).

https://claude.ai/code/session_019meUzsMNd24bPrPtrWQBu5

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
