### PR TITLE
feat: cascading card reveals for premium grid animations

### DIFF
--- a/src/components/landing/TechStack.astro
+++ b/src/components/landing/TechStack.astro
@@ -41,7 +41,7 @@ const stack = items.sort((a, b) => a.data.order - b.data.order);
         )}
       </div>
     )}
-    <div class="grid grid-cols-2 gap-[var(--space-content-gap)] md:grid-cols-4" data-reveal data-reveal-delay="1">
+    <div class="grid grid-cols-2 gap-[var(--space-content-gap)] md:grid-cols-4" data-reveal-children>
       {stack.map((item) => (
         <div
           style={`--tech-color: oklch(${item.data.colorOklch}); --tech-bg: oklch(${item.data.colorOklch} / 0.1);`}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -302,7 +302,7 @@ if (includeProfessionalServiceSchema) {
     <script is:inline>
       (function () {
         function initReveal() {
-          const els = document.querySelectorAll('[data-reveal]:not(.is-visible)');
+          const els = document.querySelectorAll('[data-reveal]:not(.is-visible), [data-reveal-children]:not(.is-visible)');
           if (!els.length) return;
 
           // Above-the-fold elements cascade in after the hero entrance starts.

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -113,7 +113,7 @@ import TechStack from '@/components/landing/TechStack.astro';
           These aren't aspirations — they're the constraints every project is held to, from the first conversation to the final handover.
         </p>
       </div>
-      <div class="grid gap-8 md:grid-cols-3" data-reveal data-reveal-delay="1">
+      <div class="grid gap-8 md:grid-cols-3" data-reveal-children>
         <Card hover>
           <div class="flex items-start gap-4">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -59,7 +59,7 @@ const getPostUrl = (postId: string) => {
             Featured
           </h2>
 
-          <div class="grid gap-6 md:grid-cols-2" data-reveal data-reveal-delay="1">
+          <div class="grid gap-6 md:grid-cols-2" data-reveal-children>
             {featuredPosts.map((post) => (
               <div class="post-card" data-tags={JSON.stringify(post.data.tags)}>
                 <BlogCard
@@ -118,7 +118,7 @@ const getPostUrl = (postId: string) => {
 
       {
         regularPosts.length > 0 ? (
-          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3" data-reveal data-reveal-delay="1">
+          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3" data-reveal-children>
             {regularPosts.map((post) => (
               <div class="post-card" data-tags={JSON.stringify(post.data.tags)}>
                 <BlogCard

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -70,7 +70,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </p>
       </div>
 
-      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3" data-reveal data-reveal-delay="1">
+      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3" data-reveal-children>
         <!-- Web Design -->
         <Card hover>
           <div class="flex items-start gap-4">
@@ -184,7 +184,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </p>
       </div>
 
-      <div class="grid gap-6 md:grid-cols-2" data-reveal data-reveal-delay="1">
+      <div class="grid gap-6 md:grid-cols-2" data-reveal-children>
         {featuredProjects.map((project) => (
           <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col">
             <div class="flex flex-1 flex-col">
@@ -228,7 +228,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </p>
       </div>
 
-      <div class="grid gap-6 md:grid-cols-2" data-reveal data-reveal-delay="1">
+      <div class="grid gap-6 md:grid-cols-2" data-reveal-children>
         <!-- Testimonial 1 -->
         <Card variant="elevated" padding="lg" hover>
           <div class="flex flex-col h-full gap-4">
@@ -298,7 +298,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </a>
       </div>
 
-      <div class="grid gap-6 md:grid-cols-3" data-reveal data-reveal-delay="1">
+      <div class="grid gap-6 md:grid-cols-3" data-reveal-children>
         {posts.map((post) => (
           <BlogCard
             title={post.data.title}

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -38,7 +38,7 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
     <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
       <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
 
-        <div class="grid gap-6 md:grid-cols-2" data-reveal>
+        <div class="grid gap-6 md:grid-cols-2" data-reveal-children>
           {projects.map((project) => (
             <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col">
               <div class="flex flex-1 flex-col">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -956,8 +956,8 @@
 
 [data-reveal] {
   opacity: 0;
-  transform: translateY(16px);
-  transition: opacity 0.6s cubic-bezier(0, 0, 0.2, 1), transform 0.6s cubic-bezier(0, 0, 0.2, 1);
+  transform: translateY(24px);
+  transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 [data-reveal].is-visible {
@@ -969,10 +969,37 @@
 [data-reveal][data-reveal-delay="2"] { transition-delay: 200ms; }
 [data-reveal][data-reveal-delay="3"] { transition-delay: 300ms; }
 
+/* Cascading reveal for grids of cards. The parent grid gets `is-visible`
+   from the IntersectionObserver (or the above-the-fold setTimeout cascade),
+   then each direct child animates in 80ms behind the previous one. Gives
+   a "premium settle" feel on lists of blog posts, projects, features. */
+[data-reveal-children] > * {
+  opacity: 0;
+  transform: translateY(32px) scale(0.96);
+  transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+[data-reveal-children].is-visible > * {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+[data-reveal-children] > *:nth-child(1)    { transition-delay: 0ms;   }
+[data-reveal-children] > *:nth-child(2)    { transition-delay: 80ms;  }
+[data-reveal-children] > *:nth-child(3)    { transition-delay: 160ms; }
+[data-reveal-children] > *:nth-child(4)    { transition-delay: 240ms; }
+[data-reveal-children] > *:nth-child(5)    { transition-delay: 320ms; }
+[data-reveal-children] > *:nth-child(6)    { transition-delay: 400ms; }
+[data-reveal-children] > *:nth-child(7)    { transition-delay: 480ms; }
+[data-reveal-children] > *:nth-child(8)    { transition-delay: 560ms; }
+[data-reveal-children] > *:nth-child(9)    { transition-delay: 640ms; }
+[data-reveal-children] > *:nth-child(n+10) { transition-delay: 720ms; }
+
 @media (prefers-reduced-motion: reduce) {
   .animate-hero-slide-up { animation: none; }
 
-  [data-reveal] {
+  [data-reveal],
+  [data-reveal-children] > * {
     opacity: 1;
     transform: none;
     transition: none;


### PR DESCRIPTION
The previous [data-reveal] system fade+slid the entire grid as one unit, which felt minimalistic - especially on the blog and project pages where visitors expect to see each card animate in.

Adds a [data-reveal-children] attribute that cascades children of the container 80ms apart, with a slightly more dramatic motion (32px slide + 0.96 scale) on a premium ease-out-expo curve. Combined with the existing [data-reveal] for headings and singletons, every section now has a two-step entrance: heading appears, then cards waterfall in behind it.

Also bumps singleton [data-reveal] motion from 16px to 24px and switches to the same ease-out-expo curve, so all reveals feel like one design language.

Converted card grids on:
- index.astro (services, featured projects, testimonials, blog teasers)
- blog/index.astro (featured posts, all posts)
- projects/index.astro (project cards)
- about.astro (process / team grid)
- TechStack.astro (tech logo grid)

https://claude.ai/code/session_019meUzsMNd24bPrPtrWQBu5

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
