### PR TITLE
feat: spring-based premium reveal animations

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -110,7 +110,7 @@ const gridClasses = cn(
 
   <div class={gridClasses}>
     {/* Content Column */}
-    <div class={cn(contentClasses, 'order-1 lg:order-none animate-hero-slide-up')}>
+    <div class={cn(contentClasses, 'order-1 lg:order-none animate-hero-stagger')}>
       {/* Badge Slot */}
       {hasBadgeSlot && (
         <div class="mb-[var(--space-heading-gap)]">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -333,7 +333,7 @@ if (includeProfessionalServiceSchema) {
                 observer.unobserve(entry.target);
               }
             });
-          }, { threshold: 0.12, rootMargin: eager ? '0px 0px 200px 0px' : '0px 0px 80px 0px' });
+          }, { threshold: 0.12, rootMargin: eager ? '0px 0px 200px 0px' : '0px 0px 120px 0px' });
           belowFold.forEach(function (el) { observer.observe(el); });
         }
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -38,7 +38,7 @@ import TechStack from '@/components/landing/TechStack.astro';
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-12 lg:grid-cols-2">
         <!-- Left: text -->
-        <div class="flex flex-col gap-4" data-reveal>
+        <div class="flex flex-col gap-4" data-reveal="right">
           <div class="flex flex-col gap-6">
             <Badge variant="brand" pill class="self-start">The partnership</Badge>
             <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
@@ -53,7 +53,7 @@ import TechStack from '@/components/landing/TechStack.astro';
           </p>
         </div>
         <!-- Right: two stacked partner cards -->
-        <div class="flex flex-col gap-4 h-full" data-reveal data-reveal-delay="1">
+        <div class="flex flex-col gap-4 h-full" data-reveal="left" data-reveal-delay="1">
           <Card variant="elevated" hover class="flex-1 flex flex-col justify-center">
             <div class="flex items-start gap-4">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -60,7 +60,7 @@ const channels = [
       <div class="grid grid-cols-1 lg:grid-cols-5 gap-10 lg:gap-16 items-stretch">
 
         <!-- Left column: contact form -->
-        <div class="lg:col-span-3 h-full" data-reveal>
+        <div class="lg:col-span-3 h-full" data-reveal="right">
           <Card padding="lg" class="h-full flex flex-col justify-center">
             <h2 class="font-display text-xl font-bold text-foreground mb-6">Send a message</h2>
             <ContactForm />
@@ -68,7 +68,7 @@ const channels = [
         </div>
 
         <!-- Right column: contact channels -->
-        <div class="lg:col-span-2 space-y-4" data-reveal data-reveal-delay="1">
+        <div class="lg:col-span-2 space-y-4" data-reveal="left" data-reveal-delay="1">
           <div>
             <h2 class="font-display text-lg font-bold text-foreground mb-1">Other channels</h2>
             <p class="text-sm text-foreground-muted">Prefer a direct channel? Pick whichever works best.</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -123,7 +123,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   <section class="relative z-10 py-[var(--space-section-md)] bg-background border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-12 lg:grid-cols-2">
-        <div class="flex flex-col justify-center" data-reveal>
+        <div class="flex flex-col justify-center" data-reveal="right">
           <div class="flex flex-col gap-6 mb-6">
             <Badge variant="brand" pill class="self-start">About me</Badge>
             <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
@@ -141,7 +141,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
             More about me
           </Button>
         </div>
-        <Card variant="elevated" padding="lg" class="h-full flex flex-col" data-reveal data-reveal-delay="1">
+        <Card variant="elevated" padding="lg" class="h-full flex flex-col" data-reveal="left" data-reveal-delay="1">
           <p class="text-sm text-foreground mb-5 text-center">A few things about me.</p>
           <div class="grid grid-cols-2 gap-3 flex-1 auto-rows-fr">
             <div class="bg-background-tertiary rounded-xl p-5 flex flex-col items-center justify-center text-center gap-2 border-t-2 border-brand-500/40 transition-all duration-200 hover:-translate-y-1 hover:shadow-md hover:border-brand-500 cursor-default h-full">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -945,58 +945,101 @@
    transition shorthand is always valid.
    ------------------------------------------------------------------------- */
 
+/* Spring curve approximating Framer Motion's spring(stiffness:100, damping:15).
+   Slight overshoot gives elements a "settle" feel on entrance. */
 @keyframes hero-slide-up {
-  from { transform: translateY(28px); }
-  to   { transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(32px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .animate-hero-slide-up {
-  animation: hero-slide-up 0.7s cubic-bezier(0, 0, 0.2, 1) both;
+  animation: hero-slide-up 0.9s cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
+
+/* Stagger direct children of a hero container. Each child springs in 80ms
+   behind the previous — used on the Hero content column to cascade
+   badge → title → description → actions. */
+.animate-hero-stagger > * {
+  animation: hero-slide-up 0.9s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+.animate-hero-stagger > *:nth-child(1)   { animation-delay: 0ms;   }
+.animate-hero-stagger > *:nth-child(2)   { animation-delay: 80ms;  }
+.animate-hero-stagger > *:nth-child(3)   { animation-delay: 160ms; }
+.animate-hero-stagger > *:nth-child(4)   { animation-delay: 240ms; }
+.animate-hero-stagger > *:nth-child(5)   { animation-delay: 320ms; }
+.animate-hero-stagger > *:nth-child(n+6) { animation-delay: 400ms; }
 
 [data-reveal] {
   opacity: 0;
-  transform: translateY(24px);
-  transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+  transform: translateY(40px);
+  transition:
+    opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.9s cubic-bezier(0.34, 1.56, 0.64, 1);
+  will-change: opacity, transform;
 }
+
+[data-reveal="down"]  { transform: translateY(-40px); }
+[data-reveal="left"]  { transform: translateX(40px); }
+[data-reveal="right"] { transform: translateX(-40px); }
+[data-reveal="scale"] { transform: scale(0.92); }
 
 [data-reveal].is-visible {
   opacity: 1;
-  transform: translateY(0);
+  transform: none;
 }
 
 [data-reveal][data-reveal-delay="1"] { transition-delay: 100ms; }
 [data-reveal][data-reveal-delay="2"] { transition-delay: 200ms; }
 [data-reveal][data-reveal-delay="3"] { transition-delay: 300ms; }
+[data-reveal][data-reveal-delay="4"] { transition-delay: 400ms; }
 
 /* Cascading reveal for grids of cards. The parent grid gets `is-visible`
    from the IntersectionObserver (or the above-the-fold setTimeout cascade),
-   then each direct child animates in 80ms behind the previous one. Gives
-   a "premium settle" feel on lists of blog posts, projects, features. */
+   then each direct child animates in behind the previous one. Stagger and
+   distance are tunable per-instance via custom properties. */
+[data-reveal-children] {
+  --reveal-stagger: 90ms;
+  --reveal-distance: 32px;
+}
+
 [data-reveal-children] > * {
   opacity: 0;
-  transform: translateY(32px) scale(0.96);
-  transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+  transform: translateY(var(--reveal-distance)) scale(0.96);
+  transition:
+    opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.9s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 [data-reveal-children].is-visible > * {
   opacity: 1;
-  transform: translateY(0) scale(1);
+  transform: none;
 }
 
-[data-reveal-children] > *:nth-child(1)    { transition-delay: 0ms;   }
-[data-reveal-children] > *:nth-child(2)    { transition-delay: 80ms;  }
-[data-reveal-children] > *:nth-child(3)    { transition-delay: 160ms; }
-[data-reveal-children] > *:nth-child(4)    { transition-delay: 240ms; }
-[data-reveal-children] > *:nth-child(5)    { transition-delay: 320ms; }
-[data-reveal-children] > *:nth-child(6)    { transition-delay: 400ms; }
-[data-reveal-children] > *:nth-child(7)    { transition-delay: 480ms; }
-[data-reveal-children] > *:nth-child(8)    { transition-delay: 560ms; }
-[data-reveal-children] > *:nth-child(9)    { transition-delay: 640ms; }
-[data-reveal-children] > *:nth-child(n+10) { transition-delay: 720ms; }
+[data-reveal-children] > *:nth-child(1)    { transition-delay: calc(var(--reveal-stagger) * 0);  }
+[data-reveal-children] > *:nth-child(2)    { transition-delay: calc(var(--reveal-stagger) * 1);  }
+[data-reveal-children] > *:nth-child(3)    { transition-delay: calc(var(--reveal-stagger) * 2);  }
+[data-reveal-children] > *:nth-child(4)    { transition-delay: calc(var(--reveal-stagger) * 3);  }
+[data-reveal-children] > *:nth-child(5)    { transition-delay: calc(var(--reveal-stagger) * 4);  }
+[data-reveal-children] > *:nth-child(6)    { transition-delay: calc(var(--reveal-stagger) * 5);  }
+[data-reveal-children] > *:nth-child(7)    { transition-delay: calc(var(--reveal-stagger) * 6);  }
+[data-reveal-children] > *:nth-child(8)    { transition-delay: calc(var(--reveal-stagger) * 7);  }
+[data-reveal-children] > *:nth-child(9)    { transition-delay: calc(var(--reveal-stagger) * 8);  }
+[data-reveal-children] > *:nth-child(10)   { transition-delay: calc(var(--reveal-stagger) * 9);  }
+[data-reveal-children] > *:nth-child(11)   { transition-delay: calc(var(--reveal-stagger) * 10); }
+[data-reveal-children] > *:nth-child(12)   { transition-delay: calc(var(--reveal-stagger) * 11); }
+[data-reveal-children] > *:nth-child(n+13) { transition-delay: calc(var(--reveal-stagger) * 12); }
 
 @media (prefers-reduced-motion: reduce) {
-  .animate-hero-slide-up { animation: none; }
+  .animate-hero-slide-up,
+  .animate-hero-stagger > * {
+    animation: none;
+  }
 
   [data-reveal],
   [data-reveal-children] > * {


### PR DESCRIPTION
Replace ease-out reveals with a spring curve approximating Framer Motion's spring(stiffness:100, damping:15) so elements settle with a slight overshoot instead of landing flat. Adds direction variants (up/down/left/right/scale) for [data-reveal], a configurable stagger via CSS custom properties on [data-reveal-children], and a hero stagger that cascades badge → title → description → actions instead of revealing the whole column at once.

https://claude.ai/code/session_01Reapjk723LB2qy4UpPnD3M

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
