### PR TITLE
feat: per-card reveals and stronger spring on scroll animations

### DIFF
--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -34,7 +34,7 @@ const estimatedWords = description.split(' ').length * 10; // Rough estimate
 const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
 ---
 
-<article class="group rounded-lg border border-brand-500/30 bg-background p-6 ring-1 ring-brand-500/20 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-brand-500 hover:shadow-md">
+<article class="group rounded-lg border border-brand-500/30 bg-background p-6 ring-1 ring-brand-500/20 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-brand-500 hover:shadow-md" data-reveal>
 
   <a href={href} class="block">
     <div

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -305,13 +305,15 @@ if (includeProfessionalServiceSchema) {
           const els = document.querySelectorAll('[data-reveal]:not(.is-visible), [data-reveal-children]:not(.is-visible)');
           if (!els.length) return;
 
-          // Above-the-fold elements cascade in after the hero entrance starts.
-          // Below-the-fold elements wait for the IntersectionObserver.
+          // Above-the-fold = elements whose top is at least 25% inside the
+          // initial viewport. Anything just barely poking above the fold
+          // would otherwise animate while the user can't see it.
+          const fold = window.innerHeight * 0.75;
           const aboveFold = [];
           const belowFold = [];
           els.forEach(function (el) {
             const rect = el.getBoundingClientRect();
-            if (rect.top < window.innerHeight && rect.bottom > 0) {
+            if (rect.top < fold && rect.bottom > 0) {
               aboveFold.push(el);
             } else {
               belowFold.push(el);
@@ -325,6 +327,9 @@ if (includeProfessionalServiceSchema) {
           });
 
           if (!belowFold.length) return;
+          // Negative bottom rootMargin: trigger only when the element is
+          // meaningfully on screen, so the user actually sees the animation
+          // play instead of finding it already finished.
           const eager = document.body.hasAttribute('data-eager-reveal');
           const observer = new IntersectionObserver(function (entries) {
             entries.forEach(function (entry) {
@@ -333,7 +338,7 @@ if (includeProfessionalServiceSchema) {
                 observer.unobserve(entry.target);
               }
             });
-          }, { threshold: 0.12, rootMargin: eager ? '0px 0px 200px 0px' : '0px 0px 120px 0px' });
+          }, { threshold: 0.15, rootMargin: eager ? '0px 0px -5% 0px' : '0px 0px -10% 0px' });
           belowFold.forEach(function (el) { observer.observe(el); });
         }
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -113,8 +113,8 @@ import TechStack from '@/components/landing/TechStack.astro';
           These aren't aspirations — they're the constraints every project is held to, from the first conversation to the final handover.
         </p>
       </div>
-      <div class="grid gap-8 md:grid-cols-3" data-reveal-children>
-        <Card hover>
+      <div class="grid gap-8 md:grid-cols-3">
+        <Card hover data-reveal>
           <div class="flex items-start gap-4">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="zap" size="md" />
@@ -127,7 +127,7 @@ import TechStack from '@/components/landing/TechStack.astro';
             </div>
           </div>
         </Card>
-        <Card hover>
+        <Card hover data-reveal data-reveal-delay="1">
           <div class="flex items-start gap-4">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="award" size="md" />
@@ -140,7 +140,7 @@ import TechStack from '@/components/landing/TechStack.astro';
             </div>
           </div>
         </Card>
-        <Card hover>
+        <Card hover data-reveal data-reveal-delay="2">
           <div class="flex items-start gap-4">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="rocket" size="md" />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -59,7 +59,7 @@ const getPostUrl = (postId: string) => {
             Featured
           </h2>
 
-          <div class="grid gap-6 md:grid-cols-2" data-reveal-children>
+          <div class="grid gap-6 md:grid-cols-2">
             {featuredPosts.map((post) => (
               <div class="post-card" data-tags={JSON.stringify(post.data.tags)}>
                 <BlogCard
@@ -118,7 +118,7 @@ const getPostUrl = (postId: string) => {
 
       {
         regularPosts.length > 0 ? (
-          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3" data-reveal-children>
+          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {regularPosts.map((post) => (
               <div class="post-card" data-tags={JSON.stringify(post.data.tags)}>
                 <BlogCard

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -70,9 +70,9 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </p>
       </div>
 
-      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3" data-reveal-children>
+      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         <!-- Web Design -->
-        <Card hover>
+        <Card hover data-reveal>
           <div class="flex items-start gap-4">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="layout" size="sm" />
@@ -87,7 +87,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </Card>
 
         <!-- Web Development -->
-        <Card hover>
+        <Card hover data-reveal data-reveal-delay="1">
           <div class="flex items-start gap-4">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="code" size="sm" />
@@ -102,7 +102,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </Card>
 
         <!-- Performance -->
-        <Card hover>
+        <Card hover data-reveal data-reveal-delay="2">
           <div class="flex items-start gap-4">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="zap" size="sm" />
@@ -184,9 +184,9 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </p>
       </div>
 
-      <div class="grid gap-6 md:grid-cols-2" data-reveal-children>
+      <div class="grid gap-6 md:grid-cols-2">
         {featuredProjects.map((project) => (
-          <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col">
+          <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col" data-reveal>
             <div class="flex flex-1 flex-col">
               <div class="mb-3 flex items-start justify-between gap-4">
                 <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
@@ -228,9 +228,9 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </p>
       </div>
 
-      <div class="grid gap-6 md:grid-cols-2" data-reveal-children>
+      <div class="grid gap-6 md:grid-cols-2">
         <!-- Testimonial 1 -->
-        <Card variant="elevated" padding="lg" hover>
+        <Card variant="elevated" padding="lg" hover data-reveal>
           <div class="flex flex-col h-full gap-4">
             <div class="flex gap-1 text-brand-500" role="img" aria-label="5 out of 5 stars">
               {[...Array(5)].map(() => (
@@ -255,7 +255,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </Card>
 
         <!-- Testimonial 2 -->
-        <Card variant="elevated" padding="lg" hover>
+        <Card variant="elevated" padding="lg" hover data-reveal data-reveal-delay="1">
           <div class="flex flex-col h-full gap-4">
             <div class="flex gap-1 text-brand-500" role="img" aria-label="5 out of 5 stars">
               {[...Array(5)].map(() => (
@@ -298,7 +298,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </a>
       </div>
 
-      <div class="grid gap-6 md:grid-cols-3" data-reveal-children>
+      <div class="grid gap-6 md:grid-cols-3">
         {posts.map((post) => (
           <BlogCard
             title={post.data.title}

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -38,9 +38,9 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
     <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
       <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
 
-        <div class="grid gap-6 md:grid-cols-2" data-reveal-children>
+        <div class="grid gap-6 md:grid-cols-2">
           {projects.map((project) => (
-            <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col">
+            <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col" data-reveal>
               <div class="flex flex-1 flex-col">
                 <!-- Header -->
                 <div class="mb-3 flex items-start justify-between gap-4">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -946,11 +946,11 @@
    ------------------------------------------------------------------------- */
 
 /* Spring curve approximating Framer Motion's spring(stiffness:100, damping:15).
-   Slight overshoot gives elements a "settle" feel on entrance. */
+   Pronounced overshoot gives elements a "settle" feel on entrance. */
 @keyframes hero-slide-up {
   from {
     opacity: 0;
-    transform: translateY(32px);
+    transform: translateY(40px);
   }
   to {
     opacity: 1;
@@ -959,35 +959,35 @@
 }
 
 .animate-hero-slide-up {
-  animation: hero-slide-up 0.9s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation: hero-slide-up 1s cubic-bezier(0.22, 1.6, 0.36, 1) both;
 }
 
-/* Stagger direct children of a hero container. Each child springs in 80ms
+/* Stagger direct children of a hero container. Each child springs in 90ms
    behind the previous — used on the Hero content column to cascade
    badge → title → description → actions. */
 .animate-hero-stagger > * {
-  animation: hero-slide-up 0.9s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation: hero-slide-up 1s cubic-bezier(0.22, 1.6, 0.36, 1) both;
 }
 .animate-hero-stagger > *:nth-child(1)   { animation-delay: 0ms;   }
-.animate-hero-stagger > *:nth-child(2)   { animation-delay: 80ms;  }
-.animate-hero-stagger > *:nth-child(3)   { animation-delay: 160ms; }
-.animate-hero-stagger > *:nth-child(4)   { animation-delay: 240ms; }
-.animate-hero-stagger > *:nth-child(5)   { animation-delay: 320ms; }
-.animate-hero-stagger > *:nth-child(n+6) { animation-delay: 400ms; }
+.animate-hero-stagger > *:nth-child(2)   { animation-delay: 90ms;  }
+.animate-hero-stagger > *:nth-child(3)   { animation-delay: 180ms; }
+.animate-hero-stagger > *:nth-child(4)   { animation-delay: 270ms; }
+.animate-hero-stagger > *:nth-child(5)   { animation-delay: 360ms; }
+.animate-hero-stagger > *:nth-child(n+6) { animation-delay: 450ms; }
 
 [data-reveal] {
   opacity: 0;
-  transform: translateY(40px);
+  transform: translateY(56px) scale(0.94);
   transition:
-    opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 0.9s cubic-bezier(0.34, 1.56, 0.64, 1);
+    opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 1s cubic-bezier(0.22, 1.6, 0.36, 1);
   will-change: opacity, transform;
 }
 
-[data-reveal="down"]  { transform: translateY(-40px); }
-[data-reveal="left"]  { transform: translateX(40px); }
-[data-reveal="right"] { transform: translateX(-40px); }
-[data-reveal="scale"] { transform: scale(0.92); }
+[data-reveal="down"]  { transform: translateY(-56px) scale(0.94); }
+[data-reveal="left"]  { transform: translateX(56px) scale(0.94); }
+[data-reveal="right"] { transform: translateX(-56px) scale(0.94); }
+[data-reveal="scale"] { transform: scale(0.88); }
 
 [data-reveal].is-visible {
   opacity: 1;
@@ -999,21 +999,20 @@
 [data-reveal][data-reveal-delay="3"] { transition-delay: 300ms; }
 [data-reveal][data-reveal-delay="4"] { transition-delay: 400ms; }
 
-/* Cascading reveal for grids of cards. The parent grid gets `is-visible`
-   from the IntersectionObserver (or the above-the-fold setTimeout cascade),
-   then each direct child animates in behind the previous one. Stagger and
-   distance are tunable per-instance via custom properties. */
+/* Cascading reveal for grids of cards. Each direct child stages in behind
+   the previous when the parent intersects. Stagger and travel distance are
+   tunable per-instance via custom properties. */
 [data-reveal-children] {
-  --reveal-stagger: 90ms;
-  --reveal-distance: 32px;
+  --reveal-stagger: 100ms;
+  --reveal-distance: 48px;
 }
 
 [data-reveal-children] > * {
   opacity: 0;
-  transform: translateY(var(--reveal-distance)) scale(0.96);
+  transform: translateY(var(--reveal-distance)) scale(0.94);
   transition:
-    opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 0.9s cubic-bezier(0.34, 1.56, 0.64, 1);
+    opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 1s cubic-bezier(0.22, 1.6, 0.36, 1);
 }
 
 [data-reveal-children].is-visible > * {


### PR DESCRIPTION
Three fixes:

1. Punchier spring. Bumped translate distance 40px → 56px, scale 0.96 → 0.94, duration 0.9s → 1.0s, and curve to cubic-bezier(0.22, 1.6, 0.36, 1) for a more pronounced overshoot on settle.

2. Per-card reveals. BlogCard's <article> root now carries data-reveal so every blog card individually triggers as it scrolls into view. Project Card map() loops on the homepage and projects index do the same. Drops the parent data-reveal-children grid wrapper on long lists where some cards were below the visible fold when their parent intersected. Inline service / testimonial / "what I do" cards on home and about pages now also use per-card data-reveal with cascading delays for consistency.

3. Animations only fire when visible. IntersectionObserver rootMargin flipped from positive +120px / +200px (eager) to negative -10% / -5% so reveals trigger when the element is actually on screen, not before. Above-the-fold detection tightened from "any pixel showing" to "top is at least 25% inside viewport" so cards barely poking above the fold no longer animate while the user can't see them.

https://claude.ai/code/session_01Reapjk723LB2qy4UpPnD3M

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
