### PR TITLE
feat: floating header drops in from above on page load

### DIFF
--- a/src/components/layout/header.variants.ts
+++ b/src/components/layout/header.variants.ts
@@ -19,7 +19,7 @@ export const headerVariants = cva('z-50', {
   },
   compoundVariants: [
     // Floating + fixed: centered with gap
-    { shape: 'floating', position: 'fixed', class: '!left-1/2 !right-auto -translate-x-1/2 w-[calc(100%-3rem)] max-w-6xl mt-4' },
+    { shape: 'floating', position: 'fixed', class: '!left-1/2 !right-auto -translate-x-1/2 w-[calc(100%-3rem)] max-w-6xl mt-4 animate-header-drop' },
     // Floating + sticky: centered with gap
     { shape: 'floating', position: 'sticky', class: '!top-4 mx-auto max-w-6xl' },
     // Floating + static: centered

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -975,6 +975,24 @@
 .animate-hero-stagger > *:nth-child(5)   { animation-delay: 360ms; }
 .animate-hero-stagger > *:nth-child(n+6) { animation-delay: 450ms; }
 
+/* Floating header drop-in: lands from above as the hero rises from below.
+   The translate values mirror the auto-hide hidden state so the entrance
+   plays cleanly with the existing transition system. */
+@keyframes header-drop-in {
+  from {
+    translate: -50% calc(-100% - 1.5rem);
+    opacity: 0;
+  }
+  to {
+    translate: -50% 0;
+    opacity: 1;
+  }
+}
+
+.animate-header-drop {
+  animation: header-drop-in 0.8s cubic-bezier(0.22, 1.6, 0.36, 1) 150ms both;
+}
+
 [data-reveal] {
   opacity: 0;
   transform: translateY(56px) scale(0.94);
@@ -1054,7 +1072,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .animate-hero-slide-up,
-  .animate-hero-stagger > * {
+  .animate-hero-stagger > *,
+  .animate-header-drop {
     animation: none;
   }
 


### PR DESCRIPTION
The floating header (homepage) used to slide horizontally into place because of the global translate transition kicking in on first paint — which read as awkward against the hero rising upward. Replaced with an intentional vertical drop-in: a keyframe animates translate from above the viewport down to the centered position, with the same spring curve the rest of the site uses and a 150ms delay so the hero begins lifting first. Header arrives, hero rises to meet it.

Reduced-motion users skip the animation.

https://claude.ai/code/session_01Reapjk723LB2qy4UpPnD3M

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
