### PR TITLE
fix: prevent horizontal page scroll on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -136,6 +136,7 @@
     scroll-behavior: smooth;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    overflow-x: clip;
   }
 
   body {
@@ -144,6 +145,7 @@
     font-size: var(--font-size-base);
     line-height: var(--theme-body-leading);
     min-height: 100vh;
+    overflow-x: clip;
   }
 
   /* Typography - headings use explicit foreground color to prevent any


### PR DESCRIPTION
The /components page exposed a long-standing issue: nothing at the document level was preventing horizontal overflow, so any showcase whose contents temporarily exceeded the viewport (toast demos, header demos with many nav items at narrow widths) made the entire page draggable left/right on mobile.

Added overflow-x: clip to html and body. Using clip rather than hidden so position: fixed elements (floating header, toasts) still anchor to the viewport correctly.

https://claude.ai/code/session_01Reapjk723LB2qy4UpPnD3M

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
