### PR TITLE
add sharp as explicit dependency for image optimisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-dom": "^19.0.0",
     "resend": "^6.9.3",
     "schema-dts": "^1.1.2",
+    "sharp": "^0.34.0",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       schema-dts:
         specifier: ^1.1.2
         version: 1.1.5
+      sharp:
+        specifier: ^0.34.0
+        version: 0.34.5
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -10373,7 +10376,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.0.0
       detect-libc: 2.1.2
-      semver: 7.7.3
+      semver: 7.7.4
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5


### PR DESCRIPTION
sharp was listed in pnpm.onlyBuiltDependencies but not in dependencies, so pnpm never linked it into node_modules, causing MissingSharp at build time.

https://claude.ai/code/session_01RyWMhxWH8tZchZphoWRWT7

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
