### PR TITLE
feat: show project image thumbnail in index page cards

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -3,6 +3,7 @@
  * Projects page
  * URL: /projects
  */
+import { Image } from 'astro:assets';
 import PageLayout from '@/layouts/PageLayout.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
@@ -40,14 +41,28 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
 
         <div class="grid gap-6 md:grid-cols-2">
           {projects.map((project) => (
-            <Card variant="elevated" hover padding="lg" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col" data-reveal>
-              <div class="flex flex-1 flex-col">
+            <Card variant="elevated" hover padding="none" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col overflow-hidden" data-reveal>
+              {project.data.image && (
+                <div class="overflow-hidden">
+                  <Image
+                    src={project.data.image}
+                    alt={project.data.imageAlt || project.data.title}
+                    widths={[640, 960]}
+                    sizes="(max-width: 768px) 640px, 960px"
+                    class="aspect-video w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                    loading="lazy"
+                  />
+                </div>
+              )}
+              <div class="flex flex-1 flex-col p-6">
                 <!-- Header -->
                 <div class="mb-3 flex items-start justify-between gap-4">
-                  <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
-                    <Icon name="layers" size="sm" />
-                  </div>
-                  <Icon name="arrow-up-right" size="sm" class="text-foreground-muted group-hover:text-brand-500 transition-colors shrink-0" />
+                  {!project.data.image && (
+                    <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
+                      <Icon name="layers" size="sm" />
+                    </div>
+                  )}
+                  <Icon name="arrow-up-right" size="sm" class="text-foreground-muted group-hover:text-brand-500 transition-colors shrink-0 ml-auto" />
                 </div>
 
                 <!-- Title + year -->


### PR DESCRIPTION
When a project has an image, display it as an aspect-video cover photo at the top of its card. Cards without an image fall back to the existing icon layout.

https://claude.ai/code/session_01RyWMhxWH8tZchZphoWRWT7

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
