### PR TITLE
perf: inline CSS bundles and preload Manrope body font

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,6 +14,10 @@ export default defineConfig({
   adapter: isNetlify ? netlify() : vercel(),
   site: process.env.SITE_URL || 'https://example.com',
 
+  build: {
+    inlineStylesheets: 'always',
+  },
+
   env: {
     schema: {
       SITE_URL: envField.string({ context: 'server', access: 'public', optional: true }),

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '@/styles/global.css';
 import outfitFont from '@fontsource-variable/outfit/files/outfit-latin-wght-normal.woff2?url';
+import manropeFont from '@fontsource-variable/manrope/files/manrope-latin-wght-normal.woff2?url';
 import SEO from '@/components/seo/SEO.astro';
 import JsonLd from '@/components/seo/JsonLd.astro';
 import Analytics from '@/components/layout/Analytics.astro';
@@ -62,7 +63,8 @@ if (includeProfessionalServiceSchema) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content={Astro.generator} />
 
-    <!-- Preload display font (used by hero h1) so it's ready for first paint -->
+    <!-- Preload display + body fonts so they're ready for first paint -->
+    <link rel="preload" as="font" type="font/woff2" href={manropeFont} crossorigin="anonymous" />
     <link rel="preload" as="font" type="font/woff2" href={outfitFont} crossorigin="anonymous" />
 
     <!-- Favicon -->


### PR DESCRIPTION
Lighthouse flagged a 31.6 KiB CSS chunk as render-blocking with 440 ms LCP impact. Setting inlineStylesheets: 'always' inlines the CSS into each HTML response, eliminating the extra round-trip and unblocking first paint. The hero h1 already preloaded Outfit; Manrope (the body font) was discovered only after CSS parsed at ~300 ms, so it's now preloaded the same way.

The forced-reflow diagnostic was a downstream effect of scripts reading geometry while CSS was still loading; with CSS inline, layout is already resolved when scripts execute.

https://claude.ai/code/session_01UpAJL86TefngTdgwvjwD98

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
