### PR TITLE
perf: defer layout reads to rAF to eliminate forced reflow

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -297,7 +297,11 @@ if (includeProfessionalServiceSchema) {
             window.removeEventListener('scroll', onScroll);
           }, { once: true });
 
-          updateFrame();
+          // Defer initial layout read to the next frame so it doesn't force
+          // a sync reflow during page load (the JS style writes above
+          // invalidate layout; reading scrollHeight immediately would force
+          // the browser to recompute before returning).
+          requestAnimationFrame(updateFrame);
         }
 
         document.addEventListener('astro:page-load', initBackToTop);
@@ -359,10 +363,17 @@ if (includeProfessionalServiceSchema) {
           belowFold.forEach(function (el) { observer.observe(el); });
         }
 
+        // Defer to the next frame so getBoundingClientRect reads happen
+        // after the browser has computed initial layout, turning a forced
+        // sync reflow into a cheap cached read.
+        function deferredInitReveal() {
+          requestAnimationFrame(initReveal);
+        }
+
         if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', initReveal);
+          document.addEventListener('DOMContentLoaded', deferredInitReveal);
         } else {
-          initReveal();
+          deferredInitReveal();
         }
       })();
     </script>


### PR DESCRIPTION
Lighthouse mobile flagged a 205 ms forced reflow during page load caused by two scripts that read geometric properties immediately after writing styles:

1. Back-to-top init writes opacity/translate/pointer-events on the button, then calls updateFrame() which reads scrollHeight and innerHeight. Browser must flush layout sync to satisfy the read.

2. Reveal init runs on DOMContentLoaded and calls getBoundingClientRect() on every [data-reveal] element before the browser has finished initial layout, forcing a sync layout pass.

Both reads are now wrapped in requestAnimationFrame, so they execute one frame later — after the browser has computed initial layout — and become cheap cached reads instead of forced reflows.

Visual impact: above-fold reveals delayed by ~16 ms (one frame) on top of the existing 250 ms timer; back-to-top initial state computed one frame later. Both imperceptible.

https://claude.ai/code/session_01UpAJL86TefngTdgwvjwD98

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
