### PR TITLE
fix: span featured project card across both columns on desktop

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -41,7 +41,7 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
 
         <div class="grid gap-6 md:grid-cols-2">
           {projects.map((project) => (
-            <Card variant="elevated" hover padding="none" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class="group flex flex-col overflow-hidden" data-reveal>
+            <Card variant="elevated" hover padding="none" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class:list={['group flex flex-col overflow-hidden', project.data.featured && 'md:col-span-2']} data-reveal>
               {project.data.image && (
                 <div class="overflow-hidden">
                   <Image


### PR DESCRIPTION
The /projects grid is 2-col on desktop. Astro Rocket has a hero image while other projects don't, making row 1 visually uneven (one tall card, one short text-only card sitting beside it). Spanning the featured card across both columns gives it a wider, intentional layout and removes the awkward height mismatch.

Mobile is unaffected — the grid is single-column there, so cards stack vertically and there's no side-by-side comparison.

https://claude.ai/code/session_01UpAJL86TefngTdgwvjwD98

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
