### PR TITLE
fix: split featured project card horizontally on desktop

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -41,15 +41,18 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
 
         <div class="grid gap-6 md:grid-cols-2">
           {projects.map((project) => (
-            <Card variant="elevated" hover padding="none" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class:list={['group flex flex-col overflow-hidden', project.data.featured && 'md:col-span-2']} data-reveal>
+            <Card variant="elevated" hover padding="none" href={`/projects/${project.id.replace(/\.mdx?$/, '')}`} class:list={['group overflow-hidden flex flex-col', project.data.featured && 'md:col-span-2 md:grid md:grid-cols-2 md:flex-row']} data-reveal>
               {project.data.image && (
                 <div class="overflow-hidden">
                   <Image
                     src={project.data.image}
                     alt={project.data.imageAlt || project.data.title}
                     widths={[640, 960]}
-                    sizes="(max-width: 768px) 640px, 960px"
-                    class="aspect-video w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                    sizes={project.data.featured ? '(max-width: 768px) 640px, 480px' : '(max-width: 768px) 640px, 960px'}
+                    class:list={[
+                      'w-full object-cover transition-transform duration-300 group-hover:scale-105',
+                      project.data.featured ? 'aspect-video md:aspect-auto md:h-full' : 'aspect-video'
+                    ]}
                     loading="lazy"
                   />
                 </div>


### PR DESCRIPTION
The previous full-width-image treatment was too dominant. Featured cards now use an internal 2-column layout on desktop: image takes the left half, content takes the right half, card height stays close to the regular project cards. Mobile is unchanged — image on top, content below in a single stack.

Image sizes attribute is also corrected for the smaller display width when the featured card is split (480px on desktop instead of 960px).

https://claude.ai/code/session_01UpAJL86TefngTdgwvjwD98

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
