### PR TITLE
Add BlogPosting JSON-LD to every blog post

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,7 +7,7 @@ import JsonLd from '@/components/seo/JsonLd.astro';
 import Analytics from '@/components/layout/Analytics.astro';
 import ConsentBanner from '@/components/ui/overlay/ConsentBanner';
 import { createWebsiteSchema, createOrganizationSchema, createPersonSchema, createProfessionalServiceSchema } from '@/lib/schema';
-import type { WebSite, Organization, Person, WithContext } from 'schema-dts';
+import type { Thing, WithContext } from 'schema-dts';
 import siteConfig from '@/config/site.config';
 
 interface Props {
@@ -26,6 +26,7 @@ interface Props {
   includeOrgSchema?: boolean;
   includePersonSchema?: boolean;
   includeProfessionalServiceSchema?: boolean;
+  extraSchemas?: WithContext<Thing>[];
   eagerReveal?: boolean;
 }
 
@@ -40,11 +41,12 @@ const {
   includeOrgSchema = false,
   includePersonSchema = false,
   includeProfessionalServiceSchema = false,
+  extraSchemas = [],
   eagerReveal = false,
 } = Astro.props;
 
 // Build JSON-LD schemas
-const schemas: Array<WithContext<WebSite> | WithContext<Organization> | WithContext<Person>> = [createWebsiteSchema()];
+const schemas: WithContext<Thing>[] = [createWebsiteSchema()];
 if (includeOrgSchema) {
   schemas.push(createOrganizationSchema());
 }
@@ -54,6 +56,7 @@ if (includePersonSchema) {
 if (includeProfessionalServiceSchema) {
   schemas.push(createProfessionalServiceSchema());
 }
+schemas.push(...extraSchemas);
 ---
 
 <!doctype html>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -11,6 +11,7 @@ import RelatedPosts from '@/components/blog/RelatedPosts.astro';
 import CTA from '@/components/ui/marketing/CTA/CTA.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import { resolveSocialLinks } from '@/lib/utils';
+import { createBlogPostSchema } from '@/lib/schema';
 
 const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
 
@@ -50,6 +51,16 @@ const breadcrumbs = [
 
 // Get full URL for sharing
 const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
+
+const blogPostingSchema = createBlogPostSchema({
+  title,
+  description,
+  url: fullUrl,
+  image: new URL(ogImage, Astro.site).toString(),
+  datePublished: publishedAt,
+  dateModified: updatedAt,
+  author: { name: author, url: siteConfig.url },
+});
 ---
 
 <BaseLayout
@@ -63,6 +74,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     authors: [author],
     tags,
   }}
+  extraSchemas={[blogPostingSchema]}
 >
   <Header
     slot="header"


### PR DESCRIPTION
The createBlogPostSchema helper existed but was never called, so blog posts shipped without Article structured data. BaseLayout now accepts a generic extraSchemas prop, and BlogLayout builds a BlogPosting schema from its existing props (absolute url + image, dates, author) and passes it through.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
