### PR TITLE
Align hero grid pattern with desktop-only brand-glow spec

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -62,8 +62,8 @@ const gridClasses = cn(
 <section class={sectionClasses} {...attrs}>
   {showGrid && (
     <div
-      class="bg-grid-pattern pointer-events-none absolute inset-x-0 -inset-y-[20%] opacity-30 hidden dark:block"
-      style="mask-image: radial-gradient(ellipse 50% 50% at 50% 40%, black 0%, transparent 70%);"
+      class="bg-grid-pattern pointer-events-none absolute inset-x-0 -inset-y-[20%] opacity-30 hidden md:dark:block"
+      style="mask-image: radial-gradient(ellipse 50% 50% at 50% 40%, black 0%, transparent 70%); -webkit-mask-image: radial-gradient(ellipse 50% 50% at 50% 40%, black 0%, transparent 70%);"
       aria-hidden="true"
     />
   )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -359,8 +359,8 @@
 
   .dark .bg-grid-pattern {
     background-image:
-      linear-gradient(to right, var(--gray-800) 1px, transparent 1px),
-      linear-gradient(to bottom, var(--gray-800) 1px, transparent 1px);
+      linear-gradient(to right, var(--color-brand-600) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--color-brand-600) 1px, transparent 1px);
   }
 
   /* Animations */


### PR DESCRIPTION
Switches the dark-mode grid lines from --gray-800 to --color-brand-600 so the grid glows subtly behind the hero, gates the overlay to md+ via md:dark:block (so it no longer renders on mobile), and adds the -webkit-mask-image fallback for Safari.

https://claude.ai/code/session_019ftRrc4upV3fWn92cQhyrC

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
