### PR TITLE
Enable hero grid pattern on the home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,7 +30,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   includeProfessionalServiceSchema={true}
 >
   <!-- Hero -->
-  <Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator>
+  <Hero layout="centered" size="xl" class="hero-dark-gradient" showGrid showScrollIndicator>
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">Available for new projects</Badge>
 
     <h1 slot="title">


### PR DESCRIPTION
Sets showGrid on the home page Hero so the brand-coloured grid overlay actually renders. The overlay still respects the desktop+dark gating (hidden md:dark:block), so it only appears in dark mode at md+.

https://claude.ai/code/session_019ftRrc4upV3fWn92cQhyrC

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
