### PR TITLE
Fix floating header frosted-glass at-rest state

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -813,21 +813,20 @@ const buttonId = `${menuId}-button`;
     }
   }
 
-  .dark [data-header-shape="floating"] {
-    background: color-mix(in oklch, var(--color-background) 65%, transparent);
-    border-color: color-mix(in oklch, var(--color-brand-400) 35%, transparent);
-    box-shadow: none;
-  }
+  /*
+   * NOTE: do NOT add a `.dark [data-header-shape="floating"]` (or
+   * `html:not(.dark) [data-header-shape="floating"]:not([data-scrolled])`)
+   * at-rest rule here. Attribute-selector specificity beats the utility
+   * classes from the compound variant, so any such rule silently shadows
+   * `bg-white/[0.08] backdrop-blur-md border-white/[0.1]` and the frosted
+   * glass collapses to a flat band. Scope theme overrides to [data-scrolled].
+   */
   .dark [data-header-shape="floating"][data-scrolled] {
     background: color-mix(in oklch, var(--color-background) 88%, transparent);
     border-color: rgba(255, 255, 255, 0.14);
     box-shadow: 0 4px 32px rgba(255, 255, 255, 0.07), 0 12px 40px -8px rgba(0, 0, 0, 0.6), 0 2px 8px -2px rgba(0, 0, 0, 0.4);
   }
 
-  html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) {
-    border-color: color-mix(in oklch, var(--color-brand-500) 35%, transparent);
-    box-shadow: none;
-  }
   html:not(.dark) [data-header-shape="floating"][data-scrolled] {
     box-shadow: 0 8px 32px -8px rgba(0, 0, 0, 0.35), 0 2px 8px -2px rgba(0, 0, 0, 0.2);
   }

--- a/src/components/layout/header.variants.ts
+++ b/src/components/layout/header.variants.ts
@@ -24,8 +24,8 @@ export const headerVariants = cva('z-50', {
     { shape: 'floating', position: 'sticky', class: '!top-4 mx-auto max-w-6xl' },
     // Floating + static: centered
     { shape: 'floating', position: 'static', class: 'mx-auto max-w-6xl' },
-    // Floating + transparent: glass effect
-    { shape: 'floating', variant: 'transparent', class: 'bg-white/[0.08] border border-white/[0.1]' },
+    // Floating + transparent: frosted-glass effect (backdrop-blur applied at rest)
+    { shape: 'floating', variant: 'transparent', class: 'bg-white/[0.08] backdrop-blur-md border border-white/[0.1]' },
     // Floating + default: semi-transparent with blur
     { shape: 'floating', variant: 'default', class: '!bg-background/90 backdrop-blur-xl !border border-border/50 !border-b-border/50' },
     // Floating + solid: opaque


### PR DESCRIPTION
Add backdrop-blur-md to the floating + transparent compound variant so the 8% white tint reads as frosted glass at rest, and remove the .dark [data-header-shape="floating"] (and matching light-mode) at-rest overrides whose attribute-selector specificity was silently shadowing the variant's bg/border/blur in dark mode.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
