### PR TITLE
Implement 3-state colour-mode system (system/light/dark)

### DIFF
--- a/src/components/layout/ThemeToggle.astro
+++ b/src/components/layout/ThemeToggle.astro
@@ -64,15 +64,13 @@ const { class: className } = Astro.props;
     toggle.dataset.themeInit = 'true';
 
     toggle.addEventListener('click', () => {
-      const isDark = document.documentElement.classList.contains('dark');
+      const root = document.documentElement;
+      const nextMode = root.classList.contains('dark') ? 'light' : 'dark';
 
-      if (isDark) {
-        document.documentElement.classList.remove('dark');
-        sessionStorage.setItem('theme', 'light');
-      } else {
-        document.documentElement.classList.add('dark');
-        sessionStorage.removeItem('theme');
-      }
+      try { localStorage.setItem('theme', nextMode); } catch { /* private mode */ }
+      root.setAttribute('data-theme-mode', nextMode);
+      if (nextMode === 'dark') root.classList.add('dark');
+      else root.classList.remove('dark');
     });
   }
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -60,7 +60,7 @@ schemas.push(...extraSchemas);
 ---
 
 <!doctype html>
-<html lang="en" class="scroll-smooth dark" data-theme="blue">
+<html lang="en" class="scroll-smooth dark" data-theme="blue" data-theme-mode="system">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -146,23 +146,38 @@ schemas.push(...extraSchemas);
       })();
     </script>
 
-    <!-- Theme script (runs before body paint; <html> starts with class="dark" as default) -->
+    <!-- Theme bootstrap (runs before body paint; no flash of wrong theme).
+         Implements a 3-state colour-mode contract:
+           localStorage.theme ∈ {'system','light','dark'}  (default 'system')
+           <html data-theme-mode="…">                      (mirrors saved mode)
+           <html class="dark">                              (resolved appearance)
+         When mode === 'system', <html>.dark tracks prefers-color-scheme live. -->
     <script is:inline>
       (function () {
         const COLOR_THEMES = ['orange', 'amber', 'lime', 'emerald', 'teal', 'cyan', 'sky', 'blue', 'indigo', 'violet', 'purple', 'magenta'];
+        const VALID_MODES = ['system', 'light', 'dark'];
 
-        function applyTheme(el) {
+        function getMode() {
           try {
-            // Dark / light mode
-            if (sessionStorage.getItem('theme') === 'light') {
-              el.classList.remove('dark');
-            } else {
-              el.classList.add('dark');
-            }
-          } catch { /* ignored */ }
+            const stored = localStorage.getItem('theme');
+            if (VALID_MODES.indexOf(stored) !== -1) return stored;
+          } catch { /* private mode / disabled storage */ }
+          return 'system';
+        }
 
+        function applyMode(el) {
+          const mode = getMode();
+          el.setAttribute('data-theme-mode', mode);
+          const isDark =
+            mode === 'dark' ||
+            (mode === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          if (isDark) el.classList.add('dark');
+          else el.classList.remove('dark');
+        }
+
+        function applyColorTheme(el) {
           try {
-            // Color theme — persisted in sessionStorage so it resets to sky on every new visit
+            // Color palette — sessionStorage so it resets to default on each new visit
             const saved = sessionStorage.getItem('color-theme');
             if (saved && COLOR_THEMES.indexOf(saved) !== -1) {
               el.setAttribute('data-theme', saved);
@@ -170,15 +185,28 @@ schemas.push(...extraSchemas);
           } catch { /* ignored */ }
         }
 
+        function applyTheme(el) {
+          applyMode(el);
+          applyColorTheme(el);
+        }
+
         applyTheme(document.documentElement);
 
         if (!window.__themeListenersInit) {
           window.__themeListenersInit = true;
 
+          // Live-update when the OS flips colour scheme AND the user is on 'system'.
+          const mql = window.matchMedia('(prefers-color-scheme: dark)');
+          const onSchemeChange = function () {
+            if (getMode() === 'system') applyMode(document.documentElement);
+          };
+          if (mql.addEventListener) mql.addEventListener('change', onSchemeChange);
+          else if (mql.addListener) mql.addListener(onSchemeChange); // Safari < 14
+
+          // Re-apply across Astro view transitions (no flash on swap).
           document.addEventListener('astro:before-swap', function (e) {
             applyTheme(e.newDocument.documentElement);
           });
-
           document.addEventListener('astro:after-swap', function () {
             applyTheme(document.documentElement);
           });


### PR DESCRIPTION
Replace the previous 2-state sessionStorage toggle with a persistent 3-state contract so users can pin Light or Dark while still letting the OS drive the appearance under 'System':

- localStorage.theme ∈ {'system','light','dark'} (default 'system')
- <html data-theme-mode="..."> mirrors the saved mode for icon-state UI
- <html>.dark resolves the active appearance; under 'system' it tracks prefers-color-scheme live (no reload required when the OS flips)
- Inline bootstrap runs before body paint to prevent flash, and rebinds on astro:before-swap / after-swap for view transitions
- Listeners are attached once via window.__themeListenersInit

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
