### PR TITLE
Match new theme-mode pill border to colour-theme pill in dark mode

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -843,7 +843,8 @@ const buttonId = `${menuId}-button`;
     box-shadow: 0 8px 32px -8px rgba(0, 0, 0, 0.35), 0 2px 8px -2px rgba(0, 0, 0, 0.2);
   }
 
-  .dark [data-header-shape="floating"] .theme-dropdown-wrapper button {
+  .dark [data-header-shape="floating"] .theme-dropdown-wrapper button,
+  .dark [data-header-shape="floating"] .ttg-wrapper .ttg-trigger {
     border-color: var(--color-foreground-subtle);
   }
 
@@ -898,7 +899,8 @@ const buttonId = `${menuId}-button`;
   .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .hdr-logo-text {
     color: var(--color-brand-500);
   }
-  .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .theme-dropdown-wrapper button {
+  .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .theme-dropdown-wrapper button,
+  .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .ttg-wrapper .ttg-trigger {
     border-color: rgba(0, 0, 0, 0.15);
   }
 
@@ -918,7 +920,8 @@ const buttonId = `${menuId}-button`;
   html:not(.dark) [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .hdr-logo-text {
     color: var(--color-brand-400);
   }
-  html:not(.dark) [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .theme-dropdown-wrapper button {
+  html:not(.dark) [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .theme-dropdown-wrapper button,
+  html:not(.dark) [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .ttg-wrapper .ttg-trigger {
     border-color: rgba(255, 255, 255, 0.2);
   }
 


### PR DESCRIPTION
Extend the existing dark-mode border-color overrides for the floating header's colour-theme pill (.theme-dropdown-wrapper button) to also target the new theme-mode pill (.ttg-wrapper .ttg-trigger) so the two pills render with the same border treatment side by side, and the mobile-menu instance (still inside a floating header) picks up the same override.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
