### PR TITLE
Hide CTA button from all production page headers

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -82,8 +82,7 @@ const blogPostingSchema = createBlogPostSchema({
     shape="bar"
     variant="solid"
     size="lg"
-    showCta={true}
-    cta={{ label: 'Astro Rocket', href: 'https://github.com/hansmartens68/Astro-Rocket', icon: 'rocket', trailingIcon: 'download' }}
+    showCta={false}
     showScrollProgress
   />
 

--- a/src/layouts/MarketingLayout.astro
+++ b/src/layouts/MarketingLayout.astro
@@ -45,8 +45,7 @@ const {
     position="fixed"
     colorScheme="default"
     showLanguageSwitcher={false}
-    showCta={true}
-    cta={{ label: 'Astro Rocket', href: 'https://github.com/hansmartens68/Astro-Rocket', icon: 'rocket', trailingIcon: 'download' }}
+    showCta={false}
   />
 
   <slot />

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -39,8 +39,7 @@ const { title, description, image, imageAlt, noindex, nofollow, showScrollProgre
     variant="solid"
     size="lg"
     showActiveState
-    showCta={true}
-    cta={{ label: 'Astro Rocket', href: 'https://github.com/hansmartens68/Astro-Rocket', icon: 'rocket', trailingIcon: 'download' }}
+    showCta={false}
     showScrollProgress={showScrollProgress}
   />
 

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -61,8 +61,7 @@ const breadcrumbs = [
     shape="bar"
     variant="solid"
     size="lg"
-    showCta={true}
-    cta={{ label: 'Astro Rocket', href: 'https://github.com/hansmartens68/Astro-Rocket', icon: 'rocket', trailingIcon: 'download' }}
+    showCta={false}
     showScrollProgress
   />
 


### PR DESCRIPTION
Set showCta={false} on the Header in BlogLayout, PageLayout, ProjectLayout, and MarketingLayout (LandingLayout already had it disabled). The components-showcase page and the documentation / blog references that explicitly demonstrate the showCta prop are left as-is — they document the API rather than render production header instances.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
