### PR TITLE
Remove error badge from status indicator row

### DIFF
--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -978,10 +978,6 @@ import EmptyState from '@/components/patterns/EmptyState.astro';
                 <Icon name="alert-triangle" size="xs" />
                 Warning
               </Badge>
-              <Badge variant="error">
-                <Icon name="x-circle" size="xs" />
-                Error
-              </Badge>
               <Badge variant="info">
                 <Icon name="info" size="xs" />
                 Info


### PR DESCRIPTION
Removes the 'Error' badge with x-circle icon from the first row of status badges on the components showcase page.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
