### PR TITLE
Update docs to reflect 3-state colour-mode system

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following changes were made to the free Velocity theme to create Astro Rocke
 | **Blog image gradients** | Plain image containers | Every blog cover and card uses a brand-color gradient background that updates live when the active theme changes |
 | **Icon system** | Basic SVG `Icon` component | Unified `Icon` component powered by Iconify — 350+ Lucide UI icons + 3000+ Simple Icons brand icons |
 | **Typing effect** | Not included | Hero section includes an animated typing effect |
-| **Dark mode storage** | `localStorage` | `sessionStorage` — resets to dark on every new tab/session (see [why](#dark-mode)) |
+| **Colour mode** | Binary `localStorage` toggle | 3-state picker — System / Light / Dark in `localStorage`, with `prefers-color-scheme` live tracking under 'System' (see [Colour Mode](#colour-mode)) |
 | **Target audience** | Developers & agencies | Web designers, developers, bloggers, and portfolio sites |
 | **Ready to launch** | Boilerplate starting point | Fully styled pages — replace the text and your site is live |
 | **Maintained by** | Southwell Media | Hans Martens |
@@ -65,7 +65,7 @@ The following changes were made to the free Velocity theme to create Astro Rocke
 | **Page Animations** | Smooth page transitions via Astro View Transitions, scroll-triggered counter and score animations, scroll-reactive header, card hover effects, and a full suite of UI micro-animations — all with reduced-motion support |
 | **SEO Toolkit** | Meta tags, JSON-LD structured data, sitemap, and robots.txt |
 | **Static OG Image** | A polished default Open Graph image serves as social preview for all pages — no build-time generation required |
-| **Dark Mode** | Dark-first design with `sessionStorage` persistence |
+| **Colour Mode** | 3-state picker — **System / Light / Dark** with `localStorage` persistence and live OS-preference tracking under 'System'; surfaced as a pill dropdown in the header (and inside the mobile menu) |
 | **Content Collections** | Type-safe blog, pages, authors, and FAQs with Zod validation |
 | **API Routes** | Contact form and newsletter endpoints with validation |
 | **React Islands** | Optional client-side interactivity where needed |
@@ -122,7 +122,7 @@ astro-rocket/
 │   │   │   ├── content/     # CodeBlock
 │   │   │   └── marketing/   # Logo, CTA, NpmCopyButton, SocialProof, TerminalDemo
 │   │   ├── patterns/        # Composed patterns (ContactForm, SearchInput, StatCard, etc.)
-│   │   ├── layout/          # Header, Footer, Navigation, ThemeToggle, ThemeSelector
+│   │   ├── layout/          # Header, Footer, Navigation, ThemeModeDropdown, ThemeSelector(Dropdown)
 │   │   ├── seo/             # SEO, JsonLd, Breadcrumbs
 │   │   ├── blog/            # Blog-specific components
 │   │   └── landing/         # Landing page components
@@ -271,23 +271,39 @@ OKLCH values are `oklch(lightness chroma hue)`. To shift your brand to blue, cha
 
 3. Update the import in `src/styles/tokens/colors.css` to point to your new theme file
 
-### Dark Mode
+### Colour Mode
 
-Dark mode toggles via the `.dark` class on `<html>`. The default is **dark** — the design was built dark-first and it looks great for portfolios and creative sites.
+Astro Rocket ships a 3-state colour-mode system — **System / Light / Dark** — instead of a binary toggle. The user's choice is persisted in `localStorage` under the key `theme`, and the resolved appearance is applied via the `.dark` class on `<html>`. Under `'system'`, the page tracks `window.matchMedia('(prefers-color-scheme: dark)')` live, so flipping the OS theme updates the page in real time without a reload.
 
-FOUC is prevented by an inline script that reads `sessionStorage` before first paint. Use the included `ThemeToggle` component:
+State contract:
+
+| Storage / DOM | Values | Role |
+|---|---|---|
+| `localStorage.theme` | `'system' \| 'light' \| 'dark'` | The user's saved choice (default `'system'`) |
+| `<html data-theme-mode="…">` | mirrors the saved mode | Drives the trigger icon (monitor / sun / moon) via CSS |
+| `<html>.dark` | present or absent | Resolved appearance — Tailwind dark variant keys off this |
+
+Defaults are seeded directly on the `<html>` element in `src/layouts/BaseLayout.astro` so JS-disabled visitors still see a sensible state:
+
+```html
+<html lang="en" class="scroll-smooth dark" data-theme="blue" data-theme-mode="system">
+```
+
+Flash-of-wrong-theme is prevented by an inline `<script>` in `<head>` that runs synchronously before body paint, reads `localStorage.theme`, and reconciles `data-theme-mode` + `.dark`. The same script also re-applies on `astro:before-swap` / `astro:after-swap` to handle view transitions, and subscribes once to the OS-preference media query.
+
+The picker is exposed as a pill-shaped dropdown in the header — `ThemeModeDropdown` — and re-rendered inside the mobile menu below the `md` breakpoint, so both desktop and mobile users get the full 3-state picker:
 
 ```astro
 ---
-import ThemeToggle from '@/components/layout/ThemeToggle.astro';
+import ThemeModeDropdown from '@/components/layout/ThemeModeDropdown.astro';
 ---
 
-<ThemeToggle />
+<ThemeModeDropdown />
 ```
 
-To opt out of dark mode, remove the `.dark { ... }` block from your theme file.
+The full design — bootstrap script, dropdown anatomy, the live "Currently dark/light" sub-line under 'System', and how two component instances stay state-synced — is written up in the [System, Light, Dark blog post](https://astrorocket.dev/blog/colour-mode-system).
 
-> **Why `sessionStorage` instead of `localStorage`?** This is a deliberate choice. `sessionStorage` persists the user's preference during their visit but resets when the tab is closed — so every new visit starts with the intended dark design. For a portfolio or marketing site this is the right call. For a product users return to daily (a SaaS dashboard, editor, etc.), switch to `localStorage` so the preference survives across sessions.
+> **Why `localStorage` for colour mode but `sessionStorage` for the colour palette?** They serve different intents. The colour mode is the user's accessibility / preference setting and should survive reloads and new tabs — `localStorage`. The 12-swatch colour palette is a brand-discovery toy that should reset on every new visit so first impressions stay on-brand — `sessionStorage`. Keeping them on different storage tiers is intentional, not accidental.
 
 ### WCAG Contrast Requirements
 
@@ -414,7 +430,7 @@ Astro Rocket includes 57 components across 7 categories. All UI components use [
 | Category | Count | Components |
 |----------|-------|------------|
 | Hero | 1 | Hero section with centered/split layouts, grid pattern, and typing effect |
-| Layout | 6 | Header (with scroll progress bar), Footer, ThemeToggle, ThemeSelector, ThemeSelectorDropdown, Analytics |
+| Layout | 6 | Header (with scroll progress bar), Footer, ThemeModeDropdown, ThemeSelector, ThemeSelectorDropdown, Analytics |
 | Blog | 4 | ArticleHero, BlogCard, ShareButtons, RelatedPosts |
 | Landing | 5 | Credibility, LighthouseScores, TechStack, FeatureTabs, and more |
 | SEO | 3 | SEO, JsonLd, Breadcrumbs |

--- a/src/content/blog/en/astro-rocket-configuration-guide.mdx
+++ b/src/content/blog/en/astro-rocket-configuration-guide.mdx
@@ -68,21 +68,28 @@ blogImageOverlay: true,
 
 When `true`, a translucent brand-colour tint is applied over blog cover images. This helps images blend with your theme if they have neutral or mismatched colours. Set it to `false` if your images are already on-brand or if you prefer photographs to appear unaltered.
 
-### Dark mode default
+### Colour mode default
 
-The default mode is set directly in the HTML element in `src/layouts/BaseLayout.astro`:
-
-```html
-<html lang="en" class="scroll-smooth dark" data-theme="indigo">
-```
-
-The `dark` class is what activates dark mode on first load. Remove it to default to light:
+Astro Rocket uses a 3-state colour-mode system — **System / Light / Dark** — instead of a binary toggle. Defaults are declared on the `<html>` element in `src/layouts/BaseLayout.astro`:
 
 ```html
-<html lang="en" class="scroll-smooth" data-theme="indigo">
+<html lang="en" class="scroll-smooth dark" data-theme="blue" data-theme-mode="system">
 ```
 
-The user's preference during their session is stored in `sessionStorage` — so it persists while the tab is open but resets when they open a new tab. This is intentional for a portfolio or marketing site. If you want it to persist across sessions, swap the `sessionStorage` calls for `localStorage` in the same file.
+Three pieces of state cooperate:
+
+- `class="dark"` is the SSR fallback for visitors with JavaScript disabled — Tailwind's dark variant keys off it.
+- `data-theme-mode="system"` mirrors the user's saved choice and drives the icon shown in the header pill.
+- `data-theme="blue"` is the default colour palette.
+
+For visitors with JavaScript enabled, the inline bootstrap script in `<head>` runs before body paint and reconciles all three values from storage:
+
+- `localStorage.theme` ∈ `'system' | 'light' | 'dark'` — the user's saved colour mode (default `'system'`)
+- `sessionStorage['color-theme']` — the active colour palette (default `'blue'`, resets per tab session)
+
+Under `'system'`, the bootstrap also subscribes to `window.matchMedia('(prefers-color-scheme: dark)')` once and re-applies on every OS flip. The full design — including the no-flash bootstrap, view-transition handling, and the header pill — is written up in [System, Light, Dark — How Astro Rocket's Colour-Mode System Works](/blog/colour-mode-system).
+
+To change the SSR default colour mode, edit the seed attribute. Set `data-theme-mode="light"` (and remove `class="dark"`) to default new visitors to light; set `data-theme-mode="dark"` to default to dark. The user's saved preference always wins once the bootstrap runs.
 
 ### Structured data: schema switches
 
@@ -180,7 +187,7 @@ Available values — all 12 themes:
 
 ### The live theme selector
 
-All 12 themes appear as colour swatches in the header dropdown (desktop) and in the mobile menu when `showThemeSelector` is enabled on the `<Header>` component. The visitor's choice is saved to `sessionStorage` and persists for the duration of the tab session — consistent with how the dark/light mode preference is stored.
+All 12 themes appear as colour swatches in the header dropdown (desktop) and in the mobile menu when `showThemeSelector` is enabled on the `<Header>` component. The visitor's choice is saved to `sessionStorage` and persists for the duration of the tab session — every new tab resets to the configured default. This is intentional for a portfolio or marketing site: first impressions stay on-brand. (The colour mode — System / Light / Dark — is stored separately in `localStorage` and *does* persist across reloads and new tabs; see [the colour-mode post](/blog/colour-mode-system) for that side of the system.)
 
 The `themes` array in `src/components/layout/ThemeSelector.astro` controls which swatches are shown and in what order. The current set:
 
@@ -377,7 +384,7 @@ All Header props and what they do:
 | `variant` | `default` `solid` `transparent` | `solid` | Background fill |
 | `colorScheme` | `default` `invert` | `default` | Use inverted colours — for dark hero backgrounds |
 | `layout` | `default` `centered` `minimal` | `default` | Logo and nav arrangement |
-| `showThemeToggle` | `true` `false` | `true` | Dark/light mode toggle button |
+| `showThemeToggle` | `true` `false` | `true` | Colour-mode pill (System / Light / Dark dropdown) — desktop pill + mobile-menu row |
 | `showThemeSelector` | `true` `false` | `false` | Colour theme swatch picker (desktop dropdown + mobile menu) |
 | `showSocialLinks` | `true` `false` | `false` | Social icon links (desktop only, reads from `siteConfig.socialLinks`) |
 | `showCta` | `true` `false` | `false` | CTA button in the header |

--- a/src/content/blog/en/component-library.mdx
+++ b/src/content/blog/en/component-library.mdx
@@ -168,13 +168,13 @@ These components are fixed parts of the site architecture. They are used once pe
 
 **Hero** — the `Hero` component supports two layouts (`centered`, `split`) and four sizes (`sm`, `md`, `lg`, `xl`). All hero content uses named slots: `badge`, `title`, `description`, `actions`, and optionally `image`.
 
-**Header** — fixed top navigation bar with logo, nav links, dark mode toggle, theme selector, and optional CTA button. Three rendering variants: `solid`, `transparent`, and `default`. The capsule header on the homepage is a separate `shape="floating"` prop — distinct from the variant. Includes the scroll progress bar when enabled.
+**Header** — fixed top navigation bar with logo, nav links, the colour-mode pill (System / Light / Dark dropdown), the colour-theme pill (12-swatch picker), and an optional CTA button. Three rendering variants: `solid`, `transparent`, and `default`. The capsule header on the homepage is a separate `shape="floating"` prop — distinct from the variant. Includes the scroll progress bar when enabled.
 
 **Footer** — bottom navigation with site links, social icons, and copyright text.
 
 **Breadcrumbs** — auto-generated from the current URL path. Used at the top of blog posts and inner pages.
 
-**ThemeToggle / ThemeSelector** — dark/light mode toggle and the live theme switcher with 12-colour swatch picker.
+**ThemeModeDropdown / ThemeSelectorDropdown** — the two pill-shaped dropdowns that live side-by-side in the header. `ThemeModeDropdown` is the 3-state colour-mode picker (System / Light / Dark) backed by `localStorage`; `ThemeSelectorDropdown` is the 12-swatch colour-theme picker backed by `sessionStorage`. Both pills hide below the `md` breakpoint and re-render inside the mobile menu — the colour-mode pill keeps its dropdown, the colour-theme picker becomes the flat `ThemeSelector` swatch row. See [the colour-mode post](/blog/colour-mode-system) for the full design.
 
 **Blog components** — `BlogCard` (post listing card with cover image, tags, and reading time), `ArticleHero` (full-width post header with cover image and metadata), `RelatedPosts` (three-card section at the bottom of every post), `ShareButtons` (Twitter/X, LinkedIn, clipboard copy), and `BlogImageSVG` (the brand-color SVG backgrounds for post covers).
 

--- a/src/content/projects/astro-rocket.mdx
+++ b/src/content/projects/astro-rocket.mdx
@@ -74,9 +74,13 @@ The full setup — what each piece does, how to configure it, and what rich resu
 
 A full technical breakdown of every animation layer — spring curve, stagger logic, observer tuning, and the reason view transitions are intentionally disabled — is in the [Animations in Astro Rocket](/blog/animations-in-astro-rocket) post.
 
-## Dark Mode — Done Right
+## Colour Mode — System, Light, Dark
 
-Dark mode uses `sessionStorage` rather than `localStorage`. The difference: every new tab resets to the intended theme. A visitor who switched modes out of curiosity arrives back in the right one. First impressions are intentional, every time.
+The colour-mode picker is a true 3-state system rather than a binary toggle. The user can pin **Light** or **Dark** explicitly, or pick **System** to delegate to the operating system — and when 'System' is active, the page tracks `prefers-color-scheme` live, flipping the moment the OS does without a reload. The choice persists in `localStorage`, so it survives reloads and new tabs.
+
+The picker lives in the header as a pill-shaped dropdown — a single rounded-full button next to the colour-theme pill. It shows the icon for the *currently chosen mode* (monitor, sun, or moon), so the user can always see what they picked at a glance. Clicking opens a dropdown with three rows, each showing the icon, label, and an active checkmark; the System row carries a small "Currently dark/light" sub-line that updates live when the OS preference flips. Below the `md` breakpoint both pills hide from the header bar and reappear inside the mobile menu — the colour-mode pill keeps its dropdown, and the colour-theme picker becomes a flat row of swatches. Selecting a mode in one instance updates the other instantly.
+
+A small inline bootstrap script in `<head>` runs synchronously before body paint to apply the saved mode and resolve the `.dark` class, so there is never a flash of the wrong theme — even across view transitions. The full implementation, the storage contract, and the no-flash bootstrap are written up in [System, Light, Dark — How Astro Rocket's Colour-Mode System Works](/blog/colour-mode-system).
 
 ## Lighthouse: 100 Across the Board
 


### PR DESCRIPTION
The previous docs described dark mode as a binary toggle persisted to sessionStorage. The implementation has since moved to a 3-state picker (System / Light / Dark) persisted to localStorage, surfaced as a pill-shaped dropdown in the header and inside the mobile menu. This update aligns every doc surface with the current implementation:

- projects/astro-rocket: replace the "Dark Mode — Done Right" section with a "Colour Mode — System, Light, Dark" write-up that describes the 3-state contract, the live OS-preference tracking under 'System', the desktop / mobile pill UX, and links to the new blog post.

- blog/astro-rocket-configuration-guide: rewrite "Dark mode default" as "Colour mode default" describing localStorage.theme and the data-theme-mode seed; fix the showThemeToggle table row; correct the swatch-picker note that wrongly claimed parity with the dark/light storage tier (mode = localStorage, palette = sessionStorage).

- blog/component-library: refresh the Header component description to mention both pills; replace the ThemeToggle/ThemeSelector entry with ThemeModeDropdown/ThemeSelectorDropdown plus their storage tiers and mobile-menu fallbacks.

- README: rewrite the Dark Mode section as Colour Mode with the full state contract table, no-flash bootstrap explanation, the new ThemeModeDropdown usage snippet, and a callout explaining why mode uses localStorage while the palette uses sessionStorage. Update the comparison table, key-features table, file-tree comment, and layout-components table to reference the new component names.

The actual sessionStorage usage in ThemeSelector / ThemeSelectorDropdown / BaseLayout is unchanged and correct — it backs the 12-swatch colour palette, which is intentionally per-session.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
