### PR TITLE
Add Lighthouse scores section to homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Card from '@/components/ui/data-display/Card/Card.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import BlogCard from '@/components/blog/BlogCard.astro';
+import LighthouseScores from '@/components/landing/LighthouseScores.astro';
 import { getCollection } from 'astro:content';
 import siteConfig from '@/config/site.config';
 
@@ -168,6 +169,9 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
       </div>
     </div>
   </section>
+
+  <!-- Lighthouse scores -->
+  <LighthouseScores />
 
   <!-- Portfolio -->
   <section id="work" class="relative z-10 py-[var(--space-section-md)] bg-background-secondary border-t border-border">


### PR DESCRIPTION
Mirrors the homepage layout from hansmartens68/HansMartens by inserting the existing LighthouseScores landing component between the About Teaser and Portfolio sections.

https://claude.ai/code/session_01Ei5JXyE84Hsk6gZS3pgNYA

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
