### PR TITLE
Sync CTA sections with HansMartens repo, add LetterGlitch on desktop

### DIFF
--- a/src/components/effects/LetterGlitch.tsx
+++ b/src/components/effects/LetterGlitch.tsx
@@ -1,0 +1,306 @@
+import { useRef, useEffect } from 'react';
+
+interface LetterGlitchProps {
+  glitchColors?: string[];
+  glitchSpeed?: number;
+  centerVignette?: boolean;
+  outerVignette?: boolean;
+  smooth?: boolean;
+  /**
+   * When true (default), at mount the component reads --brand-300, --brand-600,
+   * and --brand-900 from :root and uses those as the glitch palette so the
+   * effect tracks the active theme. Falls back to `glitchColors` if the
+   * tokens can't be resolved.
+   */
+  useBrandTokens?: boolean;
+}
+
+const FALLBACK_COLORS = ['#5e4491', '#A476FF', '#241a38'];
+const BRAND_VARS = ['--brand-300', '--brand-600', '--brand-900'];
+
+const LetterGlitch = ({
+  glitchColors = FALLBACK_COLORS,
+  glitchSpeed = 33,
+  centerVignette = false,
+  outerVignette = false,
+  smooth = true,
+  useBrandTokens = true,
+}: LetterGlitchProps) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const animationRef = useRef<number | null>(null);
+  const letters = useRef<
+    {
+      char: string;
+      color: string;
+      targetColor: string;
+      colorProgress: number;
+    }[]
+  >([]);
+  const grid = useRef({ columns: 0, rows: 0 });
+  const context = useRef<CanvasRenderingContext2D | null>(null);
+  const lastGlitchTime = useRef(Date.now());
+  const activeColors = useRef<string[]>(glitchColors);
+
+  const fontSize = 16;
+  const charWidth = 10;
+  const charHeight = 20;
+
+  const lettersAndSymbols = [
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    '!', '@', '#', '$', '&', '*', '(', ')', '-', '_', '+', '=', '/',
+    '[', ']', '{', '}', ';', ':', '<', '>', ',',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+  ];
+
+  const getRandomChar = () => {
+    return lettersAndSymbols[Math.floor(Math.random() * lettersAndSymbols.length)];
+  };
+
+  const getRandomColor = () => {
+    const list = activeColors.current;
+    return list[Math.floor(Math.random() * list.length)];
+  };
+
+  const parseColor = (color: string) => {
+    const sixHex = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(color);
+    if (sixHex) {
+      return {
+        r: parseInt(sixHex[1], 16),
+        g: parseInt(sixHex[2], 16),
+        b: parseInt(sixHex[3], 16),
+      };
+    }
+    const threeHex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i.exec(color);
+    if (threeHex) {
+      return {
+        r: parseInt(threeHex[1] + threeHex[1], 16),
+        g: parseInt(threeHex[2] + threeHex[2], 16),
+        b: parseInt(threeHex[3] + threeHex[3], 16),
+      };
+    }
+    const rgb = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(color);
+    if (rgb) {
+      return {
+        r: parseInt(rgb[1], 10),
+        g: parseInt(rgb[2], 10),
+        b: parseInt(rgb[3], 10),
+      };
+    }
+    return null;
+  };
+
+  const interpolateColor = (
+    start: { r: number; g: number; b: number },
+    end: { r: number; g: number; b: number },
+    factor: number,
+  ) => {
+    const result = {
+      r: Math.round(start.r + (end.r - start.r) * factor),
+      g: Math.round(start.g + (end.g - start.g) * factor),
+      b: Math.round(start.b + (end.b - start.b) * factor),
+    };
+    return `rgb(${result.r}, ${result.g}, ${result.b})`;
+  };
+
+  const calculateGrid = (width: number, height: number) => {
+    const columns = Math.ceil(width / charWidth);
+    const rows = Math.ceil(height / charHeight);
+    return { columns, rows };
+  };
+
+  const initializeLetters = (columns: number, rows: number) => {
+    grid.current = { columns, rows };
+    const totalLetters = columns * rows;
+    letters.current = Array.from({ length: totalLetters }, () => ({
+      char: getRandomChar(),
+      color: getRandomColor(),
+      targetColor: getRandomColor(),
+      colorProgress: 1,
+    }));
+  };
+
+  const drawLetters = () => {
+    if (!context.current || letters.current.length === 0) return;
+    const ctx = context.current;
+    const { width, height } = canvasRef.current!.getBoundingClientRect();
+    ctx.clearRect(0, 0, width, height);
+    ctx.font = `${fontSize}px monospace`;
+    ctx.textBaseline = 'top';
+
+    letters.current.forEach((letter, index) => {
+      const x = (index % grid.current.columns) * charWidth;
+      const y = Math.floor(index / grid.current.columns) * charHeight;
+      ctx.fillStyle = letter.color;
+      ctx.fillText(letter.char, x, y);
+    });
+  };
+
+  const resizeCanvas = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const parent = canvas.parentElement;
+    if (!parent) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const rect = parent.getBoundingClientRect();
+
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+
+    if (context.current) {
+      context.current.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    const { columns, rows } = calculateGrid(rect.width, rect.height);
+    initializeLetters(columns, rows);
+    drawLetters();
+  };
+
+  const updateLetters = () => {
+    if (!letters.current || letters.current.length === 0) return;
+
+    const updateCount = Math.max(1, Math.floor(letters.current.length * 0.05));
+
+    for (let i = 0; i < updateCount; i++) {
+      const index = Math.floor(Math.random() * letters.current.length);
+      if (!letters.current[index]) continue;
+
+      letters.current[index].char = getRandomChar();
+      letters.current[index].targetColor = getRandomColor();
+
+      if (!smooth) {
+        letters.current[index].color = letters.current[index].targetColor;
+        letters.current[index].colorProgress = 1;
+      } else {
+        letters.current[index].colorProgress = 0;
+      }
+    }
+  };
+
+  const handleSmoothTransitions = () => {
+    let needsRedraw = false;
+    letters.current.forEach((letter) => {
+      if (letter.colorProgress < 1) {
+        letter.colorProgress += 0.05;
+        if (letter.colorProgress > 1) letter.colorProgress = 1;
+
+        const startRgb = parseColor(letter.color);
+        const endRgb = parseColor(letter.targetColor);
+        if (startRgb && endRgb) {
+          letter.color = interpolateColor(startRgb, endRgb, letter.colorProgress);
+          needsRedraw = true;
+        }
+      }
+    });
+
+    if (needsRedraw) {
+      drawLetters();
+    }
+  };
+
+  const animate = () => {
+    const now = Date.now();
+    if (now - lastGlitchTime.current >= glitchSpeed) {
+      updateLetters();
+      drawLetters();
+      lastGlitchTime.current = now;
+    }
+
+    if (smooth) {
+      handleSmoothTransitions();
+    }
+
+    animationRef.current = requestAnimationFrame(animate);
+  };
+
+  // Resolves brand tokens (e.g. --brand-500: oklch(...)) to plain rgb(r,g,b)
+  // strings via a 1×1 canvas. Works for any CSS colour the browser can paint.
+  const resolveBrandColors = (): string[] => {
+    if (typeof document === 'undefined') return [];
+    const tmp = document.createElement('canvas');
+    tmp.width = 1;
+    tmp.height = 1;
+    const tmpCtx = tmp.getContext('2d');
+    if (!tmpCtx) return [];
+    const root = getComputedStyle(document.documentElement);
+    const resolved: string[] = [];
+    for (const name of BRAND_VARS) {
+      const raw = root.getPropertyValue(name).trim();
+      if (!raw) continue;
+      tmpCtx.clearRect(0, 0, 1, 1);
+      tmpCtx.fillStyle = '#000';
+      tmpCtx.fillStyle = raw;
+      tmpCtx.fillRect(0, 0, 1, 1);
+      const [r, g, b] = tmpCtx.getImageData(0, 0, 1, 1).data;
+      resolved.push(`rgb(${r}, ${g}, ${b})`);
+    }
+    return resolved;
+  };
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    context.current = canvas.getContext('2d');
+
+    if (useBrandTokens) {
+      const brand = resolveBrandColors();
+      if (brand.length > 0) {
+        activeColors.current = brand;
+      }
+    }
+
+    resizeCanvas();
+
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (!prefersReducedMotion) {
+      animate();
+    }
+
+    let resizeTimeout: ReturnType<typeof setTimeout>;
+
+    const handleResize = () => {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(() => {
+        if (animationRef.current !== null) {
+          cancelAnimationFrame(animationRef.current);
+        }
+        resizeCanvas();
+        if (!prefersReducedMotion) {
+          animate();
+        }
+      }, 100);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      if (animationRef.current !== null) {
+        cancelAnimationFrame(animationRef.current);
+      }
+      window.removeEventListener('resize', handleResize);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [glitchSpeed, smooth, useBrandTokens]);
+
+  return (
+    <div className="relative w-full h-full bg-[#101010] overflow-hidden">
+      <canvas ref={canvasRef} className="block w-full h-full" />
+      {outerVignette && (
+        <div className="absolute top-0 left-0 w-full h-full pointer-events-none bg-[radial-gradient(circle,_rgba(16,16,16,0)_60%,_rgba(16,16,16,1)_100%)]"></div>
+      )}
+      {centerVignette && (
+        <div className="absolute top-0 left-0 w-full h-full pointer-events-none bg-[radial-gradient(circle,_rgba(0,0,0,0.8)_0%,_rgba(0,0,0,0)_60%)]"></div>
+      )}
+    </div>
+  );
+};
+
+export default LetterGlitch;

--- a/src/components/patterns/LetterGlitchBand.astro
+++ b/src/components/patterns/LetterGlitchBand.astro
@@ -1,0 +1,16 @@
+---
+import LetterGlitch from '@/components/effects/LetterGlitch';
+---
+
+<div class="hidden glitch:block mx-auto max-w-6xl px-6">
+  <div class="invert-section relative overflow-hidden rounded-3xl border border-white/10">
+    <div class="absolute inset-0" aria-hidden="true">
+      <LetterGlitch client:visible outerVignette />
+    </div>
+    <div class="relative z-10 px-6 py-16 sm:py-24" data-reveal>
+      <div class="mx-auto max-w-2xl rounded-2xl border border-white/10 bg-brand-900/85 px-6 py-10 sm:px-10 text-center shadow-xl backdrop-blur-md">
+        <slot />
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -11,6 +11,7 @@ import Button from '@/components/ui/form/Button/Button.astro';
 import { Hero } from '@/components/hero';
 import TypingEffect from '@/components/ui/TypingEffect.astro';
 import TechStack from '@/components/landing/TechStack.astro';
+import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 ---
 <PageLayout
   title="About Astro Rocket — Web Designer & Developer | Veghel"
@@ -296,19 +297,35 @@ import TechStack from '@/components/landing/TechStack.astro';
   </section>
 
   <!-- CTA -->
-  <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
-    <div class="mx-auto max-w-2xl px-6 text-center" data-reveal>
+  <section class="relative z-10 py-[var(--space-section-md)] bg-background border-t border-border">
+    <!-- Mobile: flat section, no card -->
+    <div class="glitch:hidden mx-auto max-w-2xl px-6 text-center" data-reveal>
+      <Badge variant="brand" pill class="mb-6">Let's talk</Badge>
       <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
         Sound like a good fit?
       </h2>
       <p class="text-lg text-foreground-muted mb-8 text-balance">
         If my background and approach match what you're looking for, I'm open to new projects. Let's have a conversation.
       </p>
-      <Button size="lg" href="/contact">
+      <Button size="lg" href="/contact" class="cta-btn-brand">
         Start a Project
         <Icon name="arrow-right" size="sm" />
       </Button>
     </div>
+
+    <!-- Desktop: contained LetterGlitch band with glass card -->
+    <LetterGlitchBand>
+      <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
+        Sound like a good fit?
+      </h2>
+      <p class="text-lg text-foreground-muted mb-8 text-balance">
+        If my background and approach match what you're looking for, I'm open to new projects. Let's have a conversation.
+      </p>
+      <Button size="lg" href="/contact" class="hero-btn-brand">
+        Start a Project
+        <Icon name="arrow-right" size="sm" />
+      </Button>
+    </LetterGlitchBand>
   </section>
 </PageLayout>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Card from '@/components/ui/data-display/Card/Card.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import BlogCard from '@/components/blog/BlogCard.astro';
+import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 import { getCollection } from 'astro:content';
 import siteConfig from '@/config/site.config';
 
@@ -323,8 +324,10 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   </section>
 
  <!-- CTA -->
-  <section class="relative z-10 py-[var(--space-section-md)] bg-background">
-    <div class="mx-auto max-w-2xl px-6 text-center" data-reveal>
+  <section class="relative z-10 py-[var(--space-section-md)] bg-background-secondary border-t border-border">
+    <!-- Mobile: flat section, no card -->
+    <div class="glitch:hidden mx-auto max-w-2xl px-6 text-center" data-reveal>
+      <Badge variant="brand" pill class="mb-6">Let's talk</Badge>
       <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
         Have a project in mind?
       </h2>
@@ -332,15 +335,36 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         Whether it's a new build or something that needs a fresh perspective — I'd love to hear about it.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <Button size="lg" href="/contact">
+        <Button size="lg" href="/contact" class="cta-btn-brand">
           Start a project
           <Icon name="arrow-right" size="sm" />
         </Button>
         <Button size="lg" variant="outline" href="/about">
           More about me
+          <Icon name="arrow-right" size="sm" />
         </Button>
       </div>
     </div>
+
+    <!-- Desktop: contained LetterGlitch band with glass card -->
+    <LetterGlitchBand>
+      <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
+        Have a project in mind?
+      </h2>
+      <p class="text-lg text-foreground-muted mb-8 text-balance">
+        Whether it's a new build or something that needs a fresh perspective — I'd love to hear about it.
+      </p>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <Button size="lg" href="/contact" class="hero-btn-brand">
+          Start a project
+          <Icon name="arrow-right" size="sm" />
+        </Button>
+        <Button size="lg" variant="outline" href="/about">
+          More about me
+          <Icon name="arrow-right" size="sm" />
+        </Button>
+      </div>
+    </LetterGlitchBand>
   </section>
 
 <script>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -10,6 +10,7 @@ import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Card from '@/components/ui/data-display/Card/Card.astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import { Hero } from '@/components/hero';
+import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 import { getCollection } from 'astro:content';
 
 const items = await getCollection('projects', ({ data }) => !data.draft);
@@ -93,8 +94,10 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
   )}
 
  <!-- CTA -->
-  <section class="py-[var(--space-section-md)] bg-background">
-    <div class="mx-auto max-w-2xl px-6 text-center" data-reveal>
+  <section class="relative z-10 py-[var(--space-section-md)] bg-background">
+    <!-- Mobile: flat section, no card -->
+    <div class="glitch:hidden mx-auto max-w-2xl px-6 text-center" data-reveal>
+      <Badge variant="brand" pill class="mb-6">Let's talk</Badge>
       <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
         Want something like this?
       </h2>
@@ -102,14 +105,35 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
         I build with the same care and craft you see here. If you've got a project, let's see what we can make together.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <Button size="lg" href="/contact">
+        <Button size="lg" href="/contact" class="cta-btn-brand">
           Start a project
           <Icon name="arrow-right" size="sm" />
         </Button>
         <Button size="lg" variant="outline" href="/about">
           More about me
+          <Icon name="arrow-right" size="sm" />
         </Button>
       </div>
     </div>
+
+    <!-- Desktop: contained LetterGlitch band with glass card -->
+    <LetterGlitchBand>
+      <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
+        Want something like this?
+      </h2>
+      <p class="text-lg text-foreground-muted mb-8 text-balance">
+        I build with the same care and craft you see here. If you've got a project, let's see what we can make together.
+      </p>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <Button size="lg" href="/contact" class="hero-btn-brand">
+          Start a project
+          <Icon name="arrow-right" size="sm" />
+        </Button>
+        <Button size="lg" variant="outline" href="/about">
+          More about me
+          <Icon name="arrow-right" size="sm" />
+        </Button>
+      </div>
+    </LetterGlitchBand>
   </section>
 </PageLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,6 +17,9 @@
 /* Dark mode variant */
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* LetterGlitch variant — desktop with fine pointer only */
+@custom-variant glitch (@media (min-width: 1024px) and (pointer: fine));
+
 /* -------------------------------------------------------------------------
    Tailwind Theme Configuration
    ------------------------------------------------------------------------- */
@@ -1106,6 +1109,25 @@
   background-color: var(--color-brand-700) !important;
   background-image: none !important;
   opacity: 0.85;
+}
+
+/* CTA primary button on mobile / coarse-pointer CTA sections —
+   brand-600 fill, matches the homepage hero primary button. */
+.cta-btn-brand {
+  background-color: var(--color-brand-600) !important;
+  background-image: none !important;
+  color: white !important;
+  border-color: transparent !important;
+}
+.cta-btn-brand:hover {
+  background-color: var(--color-brand-700) !important;
+  background-image: none !important;
+}
+:root:not(.dark) .cta-btn-brand {
+  background-color: var(--color-brand-500) !important;
+}
+:root:not(.dark) .cta-btn-brand:hover {
+  background-color: var(--color-brand-600) !important;
 }
 
 /* Header CTA — brand colour in light mode */


### PR DESCRIPTION
- Add LetterGlitch React effect and LetterGlitchBand pattern (desktop-only via glitch: variant)
- Add `glitch` custom variant (>=1024px + fine pointer) and `cta-btn-brand` helper class
- Update homepage, about, and projects CTA sections to mirror HansMartens layout: flat mobile card with brand CTA, desktop LetterGlitchBand with glass card

https://claude.ai/code/session_0172bNVVYuAFg9CEZzeUuRSf

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
