### PR TITLE
docs: expand i18n section with create-velocity-astro instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,27 @@ The following changes were made to the free Velocity theme to create Astro Rocke
 
 ### Internationalization (i18n)
 
-The base theme is i18n-ready with locale-aware content collection schemas. Full i18n support with language routing and a `LanguageSwitcher` component can be added via the **[create-velocity-astro](https://github.com/southwellmedia/create-velocity-astro)** CLI from Southwell Media.
+The base theme is i18n-ready with locale-aware content collection schemas. Full i18n support — locale-prefixed routes, a `LanguageSwitcher` component, translated navigation, and `hreflang` SEO tags — can be added via the **[create-velocity-astro](https://github.com/southwellmedia/create-velocity-astro)** CLI from Southwell Media.
+
+#### Enabling full i18n
+
+Scaffold a fresh project with i18n turned on:
+
+```bash
+# Pick your package manager
+npm create velocity-astro@latest my-site -- --i18n
+pnpm create velocity-astro my-site --i18n
+yarn create velocity-astro my-site --i18n
+```
+
+Omit `--i18n` to be prompted interactively. The CLI then adds:
+
+- Locale-prefixed routes (`/en/`, `/es/`, `/fr/`, …)
+- A `LanguageSwitcher` component wired into the header
+- Translated navigation and example content per locale
+- `hreflang` SEO tags on every page
+
+For the full list of options and prompts, see the [create-velocity-astro README](https://github.com/southwellmedia/create-velocity-astro). The CLI is maintained by Southwell Media and is the source of truth for i18n setup.
 
 ---
 


### PR DESCRIPTION
## Summary
- Expands the README's **Internationalization (i18n)** section from a one-line teaser into a short "Enabling full i18n" subsection.
- Adds the exact `create-velocity-astro` invocation for npm, pnpm, and yarn (with the `--i18n` flag), plus a 4-bullet list of what the CLI adds (locale-prefixed routes, `LanguageSwitcher`, translated nav, `hreflang` tags).
- Points readers to the upstream [create-velocity-astro README](https://github.com/southwellmedia/create-velocity-astro) as the source of truth, so we don't duplicate (and slowly desync) Southwell Media's docs.

Resolves #207.

## Test plan
- [ ] Render the README on GitHub and confirm the new subsection displays correctly under **Internationalization (i18n)**.
- [ ] Verify the three install commands match the current upstream README on `southwellmedia/create-velocity-astro`.
- [ ] Click each link in the new section and confirm it resolves.
- [ ] Confirm no other sections of the README were touched.

https://claude.ai/code/session_016NWn3dpDb6965nxYsYziJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016NWn3dpDb6965nxYsYziJQ)_