### PR TITLE
Move Backstory section above CTA on about page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -36,45 +36,8 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
     </p>
   </Hero>
 
-  <!-- More about me -->
-  <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
-    <div class="mx-auto max-w-6xl px-6">
-      <div class="grid gap-10 lg:grid-cols-2">
-        <!-- Text -->
-        <div class="flex flex-col justify-center gap-4" data-reveal="right">
-          <Badge variant="brand" pill class="self-start">Backstory</Badge>
-          <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
-            The longer story
-          </h2>
-          <p class="text-lg text-foreground-muted leading-relaxed">
-            You've seen the work, the process, and the tools. If you'd like to know the person behind them, I've put the whole story in one place.
-          </p>
-          <Button size="lg" href="https://hansmartens.dev/blog/hans-martens-web-designer-veghel" target="_blank" rel="noopener noreferrer" class="self-start mt-2">
-            Read the full story
-            <Icon name="arrow-right" size="sm" />
-          </Button>
-        </div>
-
-        <!-- Image -->
-        <div class="mx-auto w-full max-w-sm sm:max-w-md lg:max-w-none" data-reveal="left" data-reveal-delay="1">
-          <a
-            href="https://hansmartens.dev/blog/hans-martens-web-designer-veghel"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="group block overflow-hidden rounded-2xl border border-brand-500/20 bg-brand-500/5 shadow-md ring-1 ring-border/60 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg hover:border-brand-500/40"
-            aria-label="Read the introduction post"
-          >
-            <div class="transition-transform duration-300 group-hover:scale-105">
-              <BlogImageSVG slug="hi-im-hans-martens" title="Hi, I'm Hans Martens — the longer story" />
-            </div>
-          </a>
-        </div>
-      </div>
-    </div>
-  </section>
-
   <!-- What's possible now -->
-  <section class="py-[var(--space-section-md)] bg-background border-t border-border">
+  <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-12 lg:grid-cols-2">
         <!-- Left: text -->
@@ -140,7 +103,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
     </div>
   </section>
   <!-- Values -->
-  <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
+  <section class="py-[var(--space-section-md)] bg-background border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
       <div class="mb-8 text-center flex flex-col items-center gap-4" data-reveal>
         <div class="flex flex-col items-center gap-6">
@@ -201,10 +164,10 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
     badge="Tools & Tech"
     title="My Stack"
     description="The tools I rely on every day to build fast, modern websites — chosen for performance, great developer experience, and reliability."
-    background="primary"
+    background="secondary"
   />
   <!-- FAQ -->
-  <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
+  <section class="py-[var(--space-section-md)] bg-background border-t border-border">
     <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
       <div class="flex flex-col items-center gap-4 text-center" data-reveal>
         <div class="flex flex-col items-center gap-6">
@@ -332,6 +295,43 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
             </details>
           </div>
         </Card>
+      </div>
+    </div>
+  </section>
+
+  <!-- More about me -->
+  <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
+    <div class="mx-auto max-w-6xl px-6">
+      <div class="grid gap-10 lg:grid-cols-2">
+        <!-- Text -->
+        <div class="flex flex-col justify-center gap-4" data-reveal="right">
+          <Badge variant="brand" pill class="self-start">Backstory</Badge>
+          <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
+            The longer story
+          </h2>
+          <p class="text-lg text-foreground-muted leading-relaxed">
+            You've seen the work, the process, and the tools. If you'd like to know the person behind them, I've put the whole story in one place.
+          </p>
+          <Button size="lg" href="https://hansmartens.dev/blog/hans-martens-web-designer-veghel" target="_blank" rel="noopener noreferrer" class="self-start mt-2">
+            Read the full story
+            <Icon name="arrow-right" size="sm" />
+          </Button>
+        </div>
+
+        <!-- Image -->
+        <div class="mx-auto w-full max-w-sm sm:max-w-md lg:max-w-none" data-reveal="left" data-reveal-delay="1">
+          <a
+            href="https://hansmartens.dev/blog/hans-martens-web-designer-veghel"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="group block overflow-hidden rounded-2xl border border-brand-500/20 bg-brand-500/5 shadow-md ring-1 ring-border/60 transition-all duration-300 hover:-translate-y-0.5 hover:shadow-lg hover:border-brand-500/40"
+            aria-label="Read the introduction post"
+          >
+            <div class="transition-transform duration-300 group-hover:scale-105">
+              <BlogImageSVG slug="hi-im-hans-martens" title="Hi, I'm Hans Martens — the longer story" />
+            </div>
+          </a>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Reorders the Backstory block to sit just before the CTA and swaps the zebra section backgrounds so the alternating pattern stays intact.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
