### PR TITLE
Improve color contrast on primary button and footer logo

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -142,7 +142,7 @@ function getSocialIcon(platform: string): string {
             ) : (
               <a href="/" class="flex items-center gap-2">
                 <Logo size="md" />
-                <span class="font-display text-base font-bold text-brand-500 dark:text-foreground">
+                <span class="font-display text-base font-bold text-brand-700 dark:text-foreground">
                   {siteConfig.name}
                 </span>
               </a>
@@ -209,7 +209,7 @@ function getSocialIcon(platform: string): string {
               ) : (
                 <a href="/" class="flex items-center gap-2">
                   <Logo size="md" />
-                  <span class="font-display text-base font-bold text-brand-500 dark:text-foreground">
+                  <span class="font-display text-base font-bold text-brand-700 dark:text-foreground">
                     {siteConfig.name}
                   </span>
                 </a>

--- a/src/components/ui/form/Button/Button.astro
+++ b/src/components/ui/form/Button/Button.astro
@@ -62,12 +62,12 @@ const classes = cn(
 </Element>
 
 <style is:global>
-  /* Light mode: brand-500 fill instead of black */
+  /* Light mode: brand-700 fill — ensures ≥4.5:1 contrast with white text across all themes */
   html:not(.dark) .btn-primary {
-    background-color: var(--color-brand-500);
+    background-color: var(--color-brand-700);
   }
   html:not(.dark) .btn-primary:hover {
-    background-color: var(--color-brand-600);
+    background-color: var(--color-brand-800);
   }
 
   /*


### PR DESCRIPTION
The brand-500 token sits around L=62% in OKLCH, giving roughly 3.6:1 against white — below the WCAG AA 4.5:1 threshold for 16px body text. Two places used it directly with white/brand text in light mode and were flagged by Lighthouse:

- Primary button background (.btn-primary in light mode) — white text on brand-500 fill on the homepage "Get it on GitHub" CTA.
- Footer logo wordmark — brand-500 text on the white footer background.

Both now use brand-700 (L≈45%), which clears 4.5:1 across every theme in the palette. Hover state on the primary button shifts to brand-800.

https://claude.ai/code/session_019HZw32ZJLzHAuKaUwRmAbZ

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
