### PR TITLE
Fix CI red X: remove unused @ts-expect-error in ThemeModeDropdown

### DIFF
--- a/src/components/layout/ThemeModeDropdown.astro
+++ b/src/components/layout/ThemeModeDropdown.astro
@@ -327,7 +327,6 @@ const { class: className } = Astro.props;
       const mql = window.matchMedia('(prefers-color-scheme: dark)');
       const onSchemeChange = () => syncSystemSubLine();
       if (mql.addEventListener) mql.addEventListener('change', onSchemeChange);
-      // @ts-expect-error legacy Safari
       else if (mql.addListener) mql.addListener(onSchemeChange);
     }
   }


### PR DESCRIPTION
## Summary
- The latest commit on `main` (1fec3f3) shows a red X on the repo home page because the `build` CI job failed on the type-check step.
- Root cause: `src/components/layout/ThemeModeDropdown.astro:330` had `// @ts-expect-error legacy Safari` above the `mql.addListener` fallback, but under the current TS lib types that line no longer produces an error — so TypeScript reported `ts(2578) Unused '@ts-expect-error' directive` and exited 1.
- Removed the unused directive. The same pattern in `BaseLayout.astro:205` already lives without the directive, so this aligns the two files.

## Test plan
- [x] `pnpm run lint` — clean
- [x] `pnpm run check` — 0 errors, 0 warnings (was 1 error before)
- [x] `pnpm run build` — completes successfully
- [ ] CI on this PR shows the `build` job green
- [ ] After merge, the latest commit on `main` shows a green check instead of a red X

https://claude.ai/code/session_01VvD6Sk5ayDS9UYLE7Vxj3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvD6Sk5ayDS9UYLE7Vxj3c)_