### PR TITLE
Update Lighthouse score copy to reflect perfect mobile + desktop run

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ pnpm build
 
 Astro Rocket is optimized for Core Web Vitals:
 
-- **Lighthouse Score**: 95+ across all categories
+- **Lighthouse Score**: 100/100/100/100 on both mobile and desktop
 - **Zero JavaScript** by default (islands architecture)
 - **Optimized fonts** with `font-display: swap`
 - **Image optimization** via Astro's built-in processing

--- a/src/components/landing/LighthouseScores.astro
+++ b/src/components/landing/LighthouseScores.astro
@@ -19,7 +19,7 @@ import LighthouseScoresGrid from '@/components/landing/LighthouseScoresGrid.astr
         </h2>
       </div>
       <p class="text-lg text-foreground-muted max-w-2xl mx-auto text-balance">
-        Performance, accessibility, best practices, and SEO — every score perfect on desktop. <a href="https://hansmartens.dev/blog/lighthouse-score-explained" target="_blank" rel="noopener noreferrer" class="text-brand-500 hover:text-brand-400 underline underline-offset-4 decoration-brand-500/40 hover:decoration-brand-400 transition-colors">What does this score mean?</a>
+        Performance, accessibility, best practices, and SEO — every score perfect on mobile and desktop. <a href="https://hansmartens.dev/blog/lighthouse-score-explained" target="_blank" rel="noopener noreferrer" class="text-brand-500 hover:text-brand-400 underline underline-offset-4 decoration-brand-500/40 hover:decoration-brand-400 transition-colors">What does this score mean?</a>
       </p>
     </div>
 

--- a/src/content/projects/astro-rocket.mdx
+++ b/src/content/projects/astro-rocket.mdx
@@ -121,7 +121,7 @@ The closing call-to-action on the homepage, projects index, and about page uses 
 
 ## Lighthouse: 100 Across the Board
 
-Astro Rocket scores **100 on every Lighthouse category** — Performance, Accessibility, Best Practices, and SEO — on the live demo at [astrorocket.dev](https://astrorocket.dev). That's not a tuned benchmark page; it's the full site with animations, a theme switcher, typed headlines, a contact form, the cursor trail, and the LetterGlitch CTA.
+Astro Rocket scores **100 on every Lighthouse category — on both mobile and desktop** — Performance, Accessibility, Best Practices, and SEO — on the live demo at [astrorocket.dev](https://astrorocket.dev). That's not a tuned benchmark page; it's the full site with animations, a theme switcher, typed headlines, a contact form, the cursor trail, and the LetterGlitch CTA.
 
 The result ships back into the theme as a reusable `LighthouseScores` component — four authentic Lighthouse-style circular gauges that animate from zero to 100 as the section enters the viewport, ready to drop into any landing page.
 


### PR DESCRIPTION
Astro Rocket now scores 100/100/100/100 on both mobile and desktop, so the prose on the landing section, README, and the project page no longer needs to qualify the result as "desktop only" or "95+".

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
