### PR TITLE
Style site name in headers with brand-700

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -170,7 +170,7 @@ const buttonId = `${menuId}-button`;
             <span
               class={cn(
                 'font-display text-xl font-bold tracking-tight',
-                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-brand-500 dark:text-foreground md:text-on-invert' : 'text-brand-500 dark:text-foreground')
+                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-brand-700 dark:text-foreground md:text-on-invert' : 'text-brand-700 dark:text-foreground')
               )}
             >
               {logoText || siteConfig.name}
@@ -755,11 +755,11 @@ const buttonId = `${menuId}-button`;
     transition: color 300ms;
   }
   [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-brand-700);
   }
 
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-brand-700);
   }
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text {
     color: var(--color-foreground-muted);
@@ -849,13 +849,13 @@ const buttonId = `${menuId}-button`;
   }
 
   [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-brand-700);
   }
   .dark [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
     color: var(--color-foreground);
   }
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-brand-700);
   }
   .dark [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
     color: var(--color-foreground);
@@ -874,10 +874,10 @@ const buttonId = `${menuId}-button`;
 
   @media (max-width: 767px) {
     html:not(.dark) [data-header-shape="floating"][data-header-color-scheme="invert"] .hdr-logo-text {
-      color: var(--color-brand-500);
+      color: var(--color-brand-700);
     }
     html:not(.dark) [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
-      color: var(--color-brand-500);
+      color: var(--color-brand-700);
     }
   }
 
@@ -897,7 +897,7 @@ const buttonId = `${menuId}-button`;
     color: oklch(8% 0 0);
   }
   .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-brand-700);
   }
   .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .theme-dropdown-wrapper button,
   .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .ttg-wrapper .ttg-trigger {


### PR DESCRIPTION
Apply brand-700 to the sitename across the standard header (default and inverted) and the floating header's color schemes so the wordmark reads more strongly than the brand-500 used elsewhere.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
