### PR TITLE
Use brand-700 for mobile hamburger button across all headers

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -293,12 +293,11 @@ const buttonId = `${menuId}-button`;
             type="button"
             id={buttonId}
             class={cn(
-              'inline-flex items-center justify-center rounded-md p-2 md:hidden',
+              'hdr-hamburger inline-flex items-center justify-center rounded-md p-2 md:hidden',
+              'text-brand-700 dark:text-foreground',
               'transition-colors',
               'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
-              isFloating
-                ? 'hdr-invert-text'
-                : 'text-foreground-muted hover:text-foreground hover:bg-secondary'
+              isFloating ? 'hover:bg-secondary/40' : 'hover:bg-secondary'
             )}
             aria-expanded="false"
             aria-controls={menuId}


### PR DESCRIPTION
Unifies the mobile menu trigger color so it reads as brand-700 on every header variant (including the floating homepage header), instead of flipping between muted-foreground and the invert/on-hero white tone.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
