### PR TITLE
Use brand-700 for site name in light mode across headers, footers, an…

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -142,7 +142,7 @@ function getSocialIcon(platform: string): string {
             ) : (
               <a href="/" class="flex items-center gap-2">
                 <Logo size="md" />
-                <span class="font-display text-base font-bold text-brand-500 dark:text-foreground">
+                <span class="font-display text-base font-bold text-brand-700 dark:text-foreground">
                   {siteConfig.name}
                 </span>
               </a>
@@ -312,7 +312,7 @@ function getSocialIcon(platform: string): string {
           ) : (
             <a href="/" class="flex items-center gap-2">
               <Logo size="md" />
-              <span class="font-display text-xl font-bold text-brand-500 dark:text-foreground">
+              <span class="font-display text-xl font-bold text-brand-700 dark:text-foreground">
                 {siteConfig.name}
               </span>
             </a>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -170,7 +170,7 @@ const buttonId = `${menuId}-button`;
             <span
               class={cn(
                 'font-display text-xl font-bold tracking-tight',
-                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-brand-500 dark:text-foreground md:text-on-invert' : 'text-brand-500 dark:text-foreground')
+                isFloating ? 'hdr-logo-text' : (isInvert ? 'text-brand-700 dark:text-foreground md:text-on-invert' : 'text-brand-700 dark:text-foreground')
               )}
             >
               {logoText || siteConfig.name}
@@ -754,11 +754,11 @@ const buttonId = `${menuId}-button`;
     transition: color 300ms;
   }
   [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-brand-700);
   }
 
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-brand-700);
   }
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-invert-text {
     color: var(--color-foreground-muted);
@@ -848,13 +848,13 @@ const buttonId = `${menuId}-button`;
   }
 
   [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-brand-700);
   }
   .dark [data-header-shape="floating"][data-header-color-scheme="invert"][data-scrolled] .hdr-logo-text {
     color: var(--color-foreground);
   }
   [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
-    color: var(--color-brand-500);
+    color: var(--color-brand-700);
   }
   .dark [data-header-shape="floating"][data-header-color-scheme="default"] .hdr-logo-text {
     color: var(--color-foreground);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,7 +37,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">Available for new projects</Badge>
 
     <h1 slot="title">
-      <span class="text-brand-500 dark:text-foreground [-webkit-text-fill-color:currentColor]">Astro Rocket —</span><br />
+      <span class="text-brand-700 dark:text-foreground [-webkit-text-fill-color:currentColor]">Astro Rocket —</span><br />
       <span class="text-foreground [-webkit-text-fill-color:currentColor]">Web Designer</span><span class="text-foreground [-webkit-text-fill-color:currentColor]"> &amp; Developer</span>
     </h1>
 


### PR DESCRIPTION
…d hero

Standardizes the site name color in light mode to brand-700 in the regular header, the homepage floating header (default and inverted/scrolled states), all footer layouts, and the hero H1. Dark-mode overrides are preserved.

https://claude.ai/code/session_01KuVbAdrNhEMe2xz5vLwUQg

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
