### PR TITLE
Remove pill/underline/domain from blog SVGs and re-center icon + title

### DIFF
--- a/src/assets/blog/animations-in-astro-rocket.svg
+++ b/src/assets/blog/animations-in-astro-rocket.svg
@@ -10,13 +10,10 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide Zap -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
   </g>
-  <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">animations</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">animations</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/astro-rocket-configuration-guide.svg
+++ b/src/assets/blog/astro-rocket-configuration-guide.svg
@@ -10,7 +10,7 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide Sliders -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <line x1="4" x2="4" y1="21" y2="14"/>
     <line x1="4" x2="4" y1="10" y2="3"/>
     <line x1="12" x2="12" y1="21" y2="12"/>
@@ -21,10 +21,7 @@
     <line x1="10" x2="14" y1="8" y2="8"/>
     <line x1="18" x2="22" y1="16" y2="16"/>
   </g>
-  <text x="600" y="410" font-size="92" text-anchor="middle" letter-spacing="-3" class="txt">configuration</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="92" text-anchor="middle" letter-spacing="-3" class="txt">configuration</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/astro-rocket-features.svg
+++ b/src/assets/blog/astro-rocket-features.svg
@@ -10,15 +10,12 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide Sparkles -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/>
     <path d="M20 3v4"/><path d="M22 5h-4"/>
     <path d="M4 17v2"/><path d="M5 18H3"/>
   </g>
-  <text x="600" y="410" font-size="120" text-anchor="middle" letter-spacing="-4" class="txt">features</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="120" text-anchor="middle" letter-spacing="-4" class="txt">features</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/astro-rocket-getting-started.svg
+++ b/src/assets/blog/astro-rocket-getting-started.svg
@@ -10,16 +10,13 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide Rocket -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
     <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
     <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
     <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/>
   </g>
-  <text x="600" y="410" font-size="108" text-anchor="middle" letter-spacing="-3" class="txt">get started</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="108" text-anchor="middle" letter-spacing="-3" class="txt">get started</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/astro-rocket-intro.svg
+++ b/src/assets/blog/astro-rocket-intro.svg
@@ -10,13 +10,10 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide Zap -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
   </g>
-  <text x="600" y="410" font-size="120" text-anchor="middle" letter-spacing="-4" class="txt">intro</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="120" text-anchor="middle" letter-spacing="-4" class="txt">intro</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/astro-rocket-is-live.svg
+++ b/src/assets/blog/astro-rocket-is-live.svg
@@ -10,16 +10,13 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide Rocket -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
     <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
     <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
     <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/>
   </g>
-  <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-4" class="txt">Astro Rocket</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-4" class="txt">Astro Rocket</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/colour-mode-system.svg
+++ b/src/assets/blog/colour-mode-system.svg
@@ -10,7 +10,7 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide SunMoon -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <path d="M12 8a2.83 2.83 0 0 0 4 4 4 4 0 1 1-4-4"/>
     <path d="M12 2v2"/>
     <path d="M12 20v2"/>
@@ -21,10 +21,7 @@
     <path d="m6.3 17.7-1.4 1.4"/>
     <path d="m19.1 4.9-1.4 1.4"/>
   </g>
-  <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">colour mode</text>
-  <line x1="360" y1="436" x2="840" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">colour mode</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/component-library.svg
+++ b/src/assets/blog/component-library.svg
@@ -19,10 +19,7 @@
     <rect width="7" height="9" x="14" y="12" rx="1"/>
     <rect width="7" height="5" x="3" y="16" rx="1"/>
   </g>
-  <text x="600" y="410" font-size="88" text-anchor="middle" letter-spacing="-2" class="txt">components</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="88" text-anchor="middle" letter-spacing="-2" class="txt">components</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/contact-form-resend-setup.svg
+++ b/src/assets/blog/contact-form-resend-setup.svg
@@ -10,14 +10,11 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide Mail -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <rect width="20" height="16" x="2" y="4" rx="2"/>
     <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
   </g>
-  <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-3" class="txt">contact form</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="390" y="464" width="420" height="38" rx="19" class="pil"/>
-  <text x="600" y="488" font-size="13" text-anchor="middle" letter-spacing="1.5" class="ptx">resend · vercel · godaddy</text>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-3" class="txt">contact form</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/dark-mode-hero-gradient.svg
+++ b/src/assets/blog/dark-mode-hero-gradient.svg
@@ -10,7 +10,7 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide Sunset -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <path d="M12 10V2"/>
     <path d="m4.93 10.93 1.41 1.41"/>
     <path d="M2 18h2"/>
@@ -20,10 +20,7 @@
     <path d="m16 6-4 4-4-4"/>
     <path d="M16 18a4 4 0 0 0-8 0"/>
   </g>
-  <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">gradient</text>
-  <line x1="370" y1="436" x2="830" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">gradient</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/design-system-color-tokens.svg
+++ b/src/assets/blog/design-system-color-tokens.svg
@@ -10,13 +10,10 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide Droplet -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <path d="M12 22a7 7 0 0 0 7-7c0-2-1-3.9-3-5.5s-3.5-4-4-6.5c-.5 2.5-2 4.9-4 6.5C6 11.1 5 13 5 15a7 7 0 0 0 7 7z"/>
   </g>
-  <text x="600" y="410" font-size="100" text-anchor="middle" letter-spacing="-3" class="txt">color tokens</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="100" text-anchor="middle" letter-spacing="-3" class="txt">color tokens</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/giscus-comments.svg
+++ b/src/assets/blog/giscus-comments.svg
@@ -7,42 +7,14 @@
     .pil { fill: var(--brand-400); fill-opacity: 0.25; stroke: var(--brand-200); stroke-opacity: 0.4; stroke-width: 1; }
     .ptx { fill: var(--brand-100); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; }
     .cor { stroke: var(--brand-300); stroke-width: 1.5; fill: none; stroke-opacity: 0.45; }
-    .bub-a { fill: var(--brand-100); fill-opacity: 0.85; }
-    .bub-b { fill: var(--brand-300); fill-opacity: 0.40; stroke: var(--brand-200); stroke-opacity: 0.55; stroke-width: 1.5; }
-    .bub-line { stroke: var(--brand-500); stroke-width: 0.8; stroke-opacity: 0.5; }
-    .avatar { fill: var(--brand-50); fill-opacity: 0.85; }
   </style>
   <rect width="1200" height="630" class="bg"/>
-
-  <!-- Comment bubbles -->
-  <g transform="translate(380, 130)">
-    <!-- Bubble 1 (left) -->
-    <circle cx="22" cy="34" r="16" class="avatar"/>
-    <path d="M 50 12 H 360 a 12 12 0 0 1 12 12 v 36 a 12 12 0 0 1 -12 12 H 78 l -18 14 v -14 H 50 a 12 12 0 0 1 -12 -12 V 24 a 12 12 0 0 1 12 -12 z" class="bub-a"/>
-    <line x1="64" y1="32" x2="220" y2="32" class="bub-line"/>
-    <line x1="64" y1="46" x2="270" y2="46" class="bub-line"/>
-
-    <!-- Bubble 2 (right, reply) -->
-    <g transform="translate(40, 100)">
-      <path d="M 12 12 H 320 a 12 12 0 0 1 12 12 v 36 a 12 12 0 0 1 -12 12 H 60 l -18 14 v -14 H 12 a 12 12 0 0 1 -12 -12 V 24 a 12 12 0 0 1 12 -12 z" class="bub-b"/>
-      <line x1="28" y1="34" x2="200" y2="34" class="bub-line"/>
-      <line x1="28" y1="50" x2="240" y2="50" class="bub-line"/>
-      <circle cx="350" cy="36" r="14" class="avatar"/>
-    </g>
-
-    <!-- Bubble 3 -->
-    <g transform="translate(0, 200)">
-      <circle cx="22" cy="34" r="16" class="avatar"/>
-      <path d="M 50 12 H 380 a 12 12 0 0 1 12 12 v 36 a 12 12 0 0 1 -12 12 H 78 l -18 14 v -14 H 50 a 12 12 0 0 1 -12 -12 V 24 a 12 12 0 0 1 12 -12 z" class="bub-a"/>
-      <line x1="64" y1="32" x2="260" y2="32" class="bub-line"/>
-      <line x1="64" y1="46" x2="300" y2="46" class="bub-line"/>
-    </g>
+  <!-- Lucide MessagesSquare — two overlapping speech bubbles -->
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
+    <path d="M14 9a2 2 0 0 1-2 2H6l-4 4V4c0-1.1.9-2 2-2h8a2 2 0 0 1 2 2z"/>
+    <path d="M18 9h2a2 2 0 0 1 2 2v11l-4-4h-6a2 2 0 0 1-2-2v-1"/>
   </g>
-
-  <text x="600" y="450" font-size="86" text-anchor="middle" letter-spacing="-2" class="txt">comments</text>
-  <line x1="380" y1="476" x2="820" y2="476" class="ln"/>
-  <rect x="450" y="504" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="527" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">comments</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/hero-scroll-indicator.svg
+++ b/src/assets/blog/hero-scroll-indicator.svg
@@ -10,17 +10,14 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- First chevron (brighter) — mirrors the solid chevron in the hero -->
-  <g transform="translate(552, 165) scale(4)" class="ico" opacity="0.9">
+  <g transform="translate(552, 192) scale(4)" class="ico" opacity="0.9">
     <polyline points="6 9 12 15 18 9" />
   </g>
   <!-- Second chevron (faded) — mirrors the ghost chevron in the hero -->
-  <g transform="translate(552, 220) scale(4)" class="ico" opacity="0.4">
+  <g transform="translate(552, 247) scale(4)" class="ico" opacity="0.4">
     <polyline points="6 9 12 15 18 9" />
   </g>
-  <text x="600" y="412" font-size="96" text-anchor="middle" letter-spacing="-1" class="txt">scroll indicator</text>
-  <line x1="360" y1="438" x2="840" y2="438" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="488" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="439" font-size="96" text-anchor="middle" letter-spacing="-1" class="txt">scroll indicator</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/hero-typing-effect.svg
+++ b/src/assets/blog/hero-typing-effect.svg
@@ -10,14 +10,11 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide Terminal -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <polyline points="4 17 10 11 4 5"/>
     <line x1="12" x2="20" y1="19" y2="19"/>
   </g>
-  <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">typing effect</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">typing effect</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/hi-im-hans-martens.svg
+++ b/src/assets/blog/hi-im-hans-martens.svg
@@ -10,11 +10,11 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide user (person) icon -->
-  <g transform="translate(540, 188) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 200) scale(5)" class="ico" opacity="0.9">
     <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/>
     <circle cx="12" cy="7" r="4"/>
   </g>
-  <text x="600" y="418" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">introduction</text>
+  <text x="600" y="430" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">introduction</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/independent-footer-menu.svg
+++ b/src/assets/blog/independent-footer-menu.svg
@@ -3,49 +3,15 @@
     .bg  { fill: var(--brand-500); }
     .ico { stroke: var(--brand-100); stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; fill: none; }
     .txt { fill: var(--brand-50); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; font-weight: 800; }
-    .ln  { stroke: var(--brand-300); stroke-width: 1; stroke-opacity: 0.35; }
-    .pil { fill: var(--brand-400); fill-opacity: 0.25; stroke: var(--brand-200); stroke-opacity: 0.4; stroke-width: 1; }
-    .ptx { fill: var(--brand-100); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; }
     .cor { stroke: var(--brand-300); stroke-width: 1.5; fill: none; stroke-opacity: 0.45; }
-    .frame { fill: none; stroke: var(--brand-200); stroke-opacity: 0.55; stroke-width: 1.5; }
-    .chip { fill: var(--brand-300); fill-opacity: 0.30; }
-    .chip-alt { fill: var(--brand-100); fill-opacity: 0.85; }
   </style>
   <rect width="1200" height="630" class="bg"/>
-
-  <!-- Schematic page with separate header + footer menus -->
-  <g transform="translate(360, 130)">
-    <!-- Page frame -->
-    <rect x="0" y="0" width="480" height="200" rx="14" class="frame"/>
-
-    <!-- Header bar with 4 chips -->
-    <rect x="20" y="20" width="60" height="14" rx="7" class="chip-alt"/>
-    <rect x="280" y="22" width="40" height="10" rx="5" class="chip"/>
-    <rect x="332" y="22" width="40" height="10" rx="5" class="chip"/>
-    <rect x="384" y="22" width="40" height="10" rx="5" class="chip"/>
-    <rect x="436" y="22" width="32" height="10" rx="5" class="chip"/>
-    <line x1="20" y1="50" x2="460" y2="50" class="ln"/>
-
-    <!-- Body lines -->
-    <line x1="20" y1="78" x2="320" y2="78" class="ln"/>
-    <line x1="20" y1="98" x2="380" y2="98" class="ln"/>
-    <line x1="20" y1="118" x2="280" y2="118" class="ln"/>
-
-    <!-- Divider before footer -->
-    <line x1="20" y1="148" x2="460" y2="148" class="ln"/>
-
-    <!-- Footer chips: different set! Privacy, Terms, Contact, Imprint -->
-    <rect x="20" y="166" width="50" height="10" rx="5" class="chip"/>
-    <rect x="82" y="166" width="40" height="10" rx="5" class="chip"/>
-    <rect x="134" y="166" width="56" height="10" rx="5" class="chip-alt"/>
-    <rect x="202" y="166" width="48" height="10" rx="5" class="chip-alt"/>
-    <rect x="262" y="166" width="40" height="10" rx="5" class="chip-alt"/>
+  <!-- Lucide PanelBottom — page outline with a divider near the bottom -->
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
+    <rect width="18" height="18" x="3" y="3" rx="2"/>
+    <path d="M3 15h18"/>
   </g>
-
-  <text x="600" y="410" font-size="86" text-anchor="middle" letter-spacing="-2" class="txt">footer menu</text>
-  <line x1="360" y1="436" x2="840" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">footer menu</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/scroll-progress-bar.svg
+++ b/src/assets/blog/scroll-progress-bar.svg
@@ -20,10 +20,7 @@
     <!-- Indicator dot -->
     <circle cx="298" cy="20" r="7" fill="var(--brand-50)" fill-opacity="0.95"/>
   </g>
-  <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">progress</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">progress</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/scroll-progress-ring.svg
+++ b/src/assets/blog/scroll-progress-ring.svg
@@ -31,10 +31,7 @@
     <path d="m18 15-6-6-6 6" stroke="var(--brand-100)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
   </g>
 
-  <text x="600" y="410" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">progress ring</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="488" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">progress ring</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/seo-in-astro-rocket.svg
+++ b/src/assets/blog/seo-in-astro-rocket.svg
@@ -10,14 +10,11 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide Search -->
-  <g transform="translate(540, 180) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <circle cx="11" cy="11" r="8"/>
     <path d="m21 21-4.3-4.3"/>
   </g>
-  <text x="600" y="410" font-size="120" text-anchor="middle" letter-spacing="-4" class="txt">seo</text>
-  <line x1="380" y1="436" x2="820" y2="436" class="ln"/>
-  <rect x="450" y="464" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="487" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="120" text-anchor="middle" letter-spacing="-4" class="txt">seo</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/assets/blog/table-of-contents.svg
+++ b/src/assets/blog/table-of-contents.svg
@@ -3,41 +3,18 @@
     .bg  { fill: var(--brand-500); }
     .ico { stroke: var(--brand-100); stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; fill: none; }
     .txt { fill: var(--brand-50); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; font-weight: 800; }
-    .ln  { stroke: var(--brand-300); stroke-width: 1; stroke-opacity: 0.35; }
-    .pil { fill: var(--brand-400); fill-opacity: 0.25; stroke: var(--brand-200); stroke-opacity: 0.4; stroke-width: 1; }
-    .ptx { fill: var(--brand-100); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; }
     .cor { stroke: var(--brand-300); stroke-width: 1.5; fill: none; stroke-opacity: 0.45; }
-    .frame { fill: none; stroke: var(--brand-200); stroke-opacity: 0.55; stroke-width: 1.5; }
-    .rail  { stroke: var(--brand-200); stroke-opacity: 0.55; stroke-width: 2; }
-    .bar   { fill: var(--brand-100); fill-opacity: 0.85; }
-    .bar-d { fill: var(--brand-300); fill-opacity: 0.45; }
-    .dot   { fill: var(--brand-50); }
   </style>
   <rect width="1200" height="630" class="bg"/>
-
-  <!-- TOC card -->
-  <g transform="translate(420, 130)">
-    <rect x="0" y="0" width="360" height="220" rx="14" class="frame"/>
-    <!-- Title -->
-    <rect x="24" y="22" width="120" height="8" rx="4" class="bar"/>
-    <line x1="24" y1="48" x2="336" y2="48" class="ln"/>
-    <!-- Vertical rail -->
-    <line x1="36" y1="68" x2="36" y2="200" class="rail"/>
-    <!-- Items -->
-    <rect x="48" y="70" width="160" height="6" rx="3" class="bar"/>
-    <circle cx="36" cy="73" r="3" class="dot"/>
-    <rect x="60" y="92" width="120" height="6" rx="3" class="bar-d"/>
-    <rect x="60" y="110" width="140" height="6" rx="3" class="bar-d"/>
-    <rect x="48" y="132" width="180" height="6" rx="3" class="bar"/>
-    <rect x="60" y="154" width="100" height="6" rx="3" class="bar-d"/>
-    <rect x="48" y="176" width="150" height="6" rx="3" class="bar"/>
-    <rect x="60" y="198" width="120" height="6" rx="3" class="bar-d"/>
+  <!-- Lucide ListTree -->
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
+    <path d="M21 12h-8"/>
+    <path d="M21 6H8"/>
+    <path d="M21 18h-8"/>
+    <path d="M3 6v4c0 1.1.9 2 2 2h3"/>
+    <path d="M3 10v6c0 1.1.9 2 2 2h3"/>
   </g>
-
-  <text x="600" y="430" font-size="80" text-anchor="middle" letter-spacing="-2" class="txt">on this page</text>
-  <line x1="360" y1="456" x2="840" y2="456" class="ln"/>
-  <rect x="450" y="484" width="300" height="38" rx="19" class="pil"/>
-  <text x="600" y="507" font-size="16" text-anchor="middle" class="ptx">hansmartens.dev</text>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">on this page</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>


### PR DESCRIPTION
- Removed the brand pill, divider line, and 'hansmartens.dev' / domain text from all 20 blog hero SVGs to give a cleaner, more focused look.
- Re-centered the icon + title block on every image so they sit on the visual center of the canvas after the pill area was removed.
- Rewrote the three new blog SVGs (table-of-contents, independent- footer-menu, giscus-comments) to follow the canonical Lucide-icon pattern used by every other blog hero (single outline icon at scale 5, title text below). Bespoke schematic illustrations replaced with Lucide icons: ListTree, PanelBottom, MessagesSquare.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
