### PR TITLE
Fix forced reflow in header scroll handler and prune dead morphToBar code

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -70,7 +70,6 @@ interface Props extends HTMLAttributes<'header'> {
   scrollProgressPosition?: 'top' | 'bottom';
   autoHide?: boolean;
   invertOnReturn?: boolean;
-  morphToBar?: boolean;
 }
 
 const {
@@ -94,7 +93,6 @@ const {
   scrollProgressPosition = 'bottom',
   autoHide = true,
   invertOnReturn = true,
-  morphToBar = false,
   logoText,
   hideLogo = false,
   class: className,
@@ -156,7 +154,6 @@ const buttonId = `${menuId}-button`;
   data-header-color-scheme={colorScheme}
   data-header-auto-hide={autoHide ? 'true' : 'false'}
   data-header-invert-on-return={invertOnReturn ? 'true' : 'false'}
-  data-morph-to-bar={morphToBar ? 'true' : 'false'}
   {...attrs}
 >
   <div class={cn(innerClasses, 'hdr-inner')}>
@@ -553,12 +550,39 @@ const buttonId = `${menuId}-button`;
 </script>
 
 <script>
+  // Header scroll behaviour + scroll-progress bar driven by a single rAF.
+  // All layout reads are taken before any DOM writes, and `docMaxScrollY`
+  // is cached via ResizeObserver so the scroll path never reads
+  // `scrollHeight` — which would force a synchronous layout recompute
+  // after attribute writes earlier in the same frame.
   const SCROLL_THRESHOLD = 60;
   const AUTO_HIDE_THRESHOLD = 150;
   const BAR_SCROLLED_CLASSES = ['bg-background/80', 'backdrop-blur-lg', 'border-b', 'border-border/50'];
 
-  function initScrollWatcher() {
-    const scrollHeaders = document.querySelectorAll<HTMLElement>('header[data-header-shape="floating"], header[data-header-shape="bar"]');
+  let docMaxScrollY = 0;
+  let docMetricsInited = false;
+  function updateDocMaxScrollY() {
+    docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
+  }
+  function initDocMetrics() {
+    if (docMetricsInited) return;
+    docMetricsInited = true;
+    updateDocMaxScrollY();
+    window.addEventListener('resize', updateDocMaxScrollY, { passive: true });
+    window.addEventListener('load', updateDocMaxScrollY);
+    if (typeof ResizeObserver !== 'undefined') {
+      new ResizeObserver(updateDocMaxScrollY).observe(document.documentElement);
+    }
+  }
+
+  function initScrollDriven() {
+    initDocMetrics();
+
+    const scrollHeaders = document.querySelectorAll<HTMLElement>(
+      'header[data-header-shape="floating"], header[data-header-shape="bar"]'
+    );
+    const progressBar = document.getElementById('scroll-progress-bar');
+
     scrollHeaders.forEach((header) => {
       if (header.dataset.scrollInit) return;
       header.dataset.scrollInit = 'true';
@@ -576,11 +600,14 @@ const buttonId = `${menuId}-button`;
         ticking = true;
 
         requestAnimationFrame(() => {
+          // ── READS (gather everything before touching the DOM) ──
           const currentScrollY = window.scrollY;
           const menuId = header.dataset.menuId;
           const menu = menuId ? document.getElementById(menuId) : null;
           const menuOpen = menu && !menu.classList.contains('hidden');
+          const wasHidden = header.hasAttribute('data-header-hidden');
 
+          // ── WRITES ──
           if (currentScrollY > SCROLL_THRESHOLD) {
             header.setAttribute('data-scrolled', '');
             if (isTransparentBar) {
@@ -606,9 +633,11 @@ const buttonId = `${menuId}-button`;
                   header.setAttribute('data-header-hidden', '');
                 }
               } else {
-                if (header.hasAttribute('data-header-hidden')) {
-                  const maxScrollY = document.documentElement.scrollHeight - window.innerHeight;
-                  lastShownAtY = Math.min(currentScrollY, Math.max(0, maxScrollY - AUTO_HIDE_THRESHOLD));
+                if (wasHidden) {
+                  lastShownAtY = Math.min(
+                    currentScrollY,
+                    Math.max(0, docMaxScrollY - AUTO_HIDE_THRESHOLD),
+                  );
                   header.setAttribute('data-header-returned', '');
                 }
                 header.removeAttribute('data-header-hidden');
@@ -620,6 +649,13 @@ const buttonId = `${menuId}-button`;
             }
           }
 
+          // Drive the scroll-progress bar in the same frame, using the
+          // already-read currentScrollY and the cached docMaxScrollY.
+          if (progressBar) {
+            const pct = docMaxScrollY > 0 ? (currentScrollY / docMaxScrollY) * 100 : 0;
+            progressBar.style.width = `${pct}%`;
+          }
+
           lastScrollY = currentScrollY;
           ticking = false;
         });
@@ -628,79 +664,34 @@ const buttonId = `${menuId}-button`;
       window.addEventListener('scroll', onScroll, { passive: true });
       onScroll();
     });
-  }
 
-  initScrollWatcher();
-</script>
-
-<script>
-  function initScrollProgress() {
-    const bar = document.getElementById('scroll-progress-bar');
-    if (!bar) return;
-    if (bar.dataset.progressInit) return;
-    bar.dataset.progressInit = 'true';
-
-    let ticking = false;
-
-    function update() {
-      if (!bar) return;
-      const scrollTop = window.scrollY;
-      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
-      const pct = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
-      bar!.style.width = `${pct}%`;
-      ticking = false;
+    // Edge case: a progress bar exists without a header scroll-watcher.
+    // Drive it with its own minimal rAF so the bar still updates.
+    if (progressBar && scrollHeaders.length === 0 && !progressBar.dataset.progressInit) {
+      progressBar.dataset.progressInit = 'true';
+      let pTicking = false;
+      const updateProgress = () => {
+        const pct = docMaxScrollY > 0 ? (window.scrollY / docMaxScrollY) * 100 : 0;
+        progressBar.style.width = `${pct}%`;
+        pTicking = false;
+      };
+      window.addEventListener(
+        'scroll',
+        () => {
+          if (!pTicking) {
+            pTicking = true;
+            requestAnimationFrame(updateProgress);
+          }
+        },
+        { passive: true },
+      );
+      updateProgress();
     }
-
-    window.addEventListener('scroll', () => {
-      if (!ticking) {
-        ticking = true;
-        requestAnimationFrame(update);
-      }
-    }, { passive: true });
-
-    update();
   }
 
-  initScrollProgress();
-  document.addEventListener('astro:page-load', initScrollProgress);
-  document.addEventListener('astro:after-swap', initScrollProgress);
-</script>
-
-<script>
-  import { navigate } from 'astro:transitions/client';
-
-  function initNavMorph() {
-    const header = document.querySelector<HTMLElement>(
-      'header[data-morph-to-bar="true"][data-header-shape="floating"]'
-    );
-    if (!header) return;
-    if (header.dataset.navMorphInit) return;
-    header.dataset.navMorphInit = 'true';
-
-    header.querySelectorAll<HTMLAnchorElement>('a[href]').forEach((link) => {
-      link.addEventListener('click', async (e) => {
-        const href = link.getAttribute('href');
-        if (
-          !href ||
-          href.startsWith('#') ||
-          href.startsWith('http') ||
-          href.startsWith('//') ||
-          href.startsWith('mailto:') ||
-          href.startsWith('tel:')
-        ) return;
-        if (href === window.location.pathname) return;
-        if (header.hasAttribute('data-scrolled')) return; // already bar shape, navigate normally
-
-        e.preventDefault();
-        header.setAttribute('data-scrolled', '');
-        await new Promise((r) => setTimeout(r, 300));
-        navigate(href);
-      });
-    });
-  }
-
-  initNavMorph();
-  document.addEventListener('astro:page-load', initNavMorph);
+  initScrollDriven();
+  document.addEventListener('astro:page-load', initScrollDriven);
+  document.addEventListener('astro:after-swap', initScrollDriven);
 </script>
 
 <style is:global>
@@ -725,13 +716,6 @@ const buttonId = `${menuId}-button`;
     backdrop-filter: blur(24px);
     border-color: var(--color-border);
     box-shadow: 0 8px 32px -8px rgba(0, 0, 0, 0.14), 0 2px 8px -2px rgba(0, 0, 0, 0.08);
-  }
-
-  [data-header-shape="floating"][data-morph-to-bar="true"][data-scrolled] {
-    width: 100%;
-    max-width: 100%;
-    border-radius: 0;
-    margin-top: 0;
   }
 
   [data-header-shape="floating"] .hdr-inner {
@@ -814,12 +798,6 @@ const buttonId = `${menuId}-button`;
     }
     [data-header-shape="floating"][data-header-hidden] {
       translate: -50% calc(-100% - 1.5rem) !important;
-    }
-    [data-header-shape="floating"][data-morph-to-bar="true"][data-scrolled] {
-      width: 100%;
-      max-width: 100%;
-      border-radius: 0;
-      margin-top: 0;
     }
   }
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -71,6 +71,10 @@ schemas.push(...extraSchemas);
     <link rel="preload" as="font" type="font/woff2" href={manropeFont} crossorigin="anonymous" />
     <link rel="preload" as="font" type="font/woff2" href={outfitFont} crossorigin="anonymous" />
 
+    {siteConfig.articleFeatures?.comments?.enabled && (
+      <link rel="preconnect" href="https://giscus.app" crossorigin />
+    )}
+
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href={siteConfig.branding.favicon.svg} />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -21,7 +21,6 @@ interface Props {
   includeOrgSchema?: boolean;
   includePersonSchema?: boolean;
   includeProfessionalServiceSchema?: boolean;
-  morphToBar?: boolean;
 }
 
 const {
@@ -34,7 +33,6 @@ const {
   includeOrgSchema = false,
   includePersonSchema = false,
   includeProfessionalServiceSchema = false,
-  morphToBar = false,
 } = Astro.props;
 ---
 
@@ -62,7 +60,6 @@ const {
     autoHide={false}
     scrollProgressPosition="top"
     invertOnReturn={false}
-    morphToBar={morphToBar}
   />
 
   <slot />


### PR DESCRIPTION
## Summary

Addresses the three Lighthouse Insights flagged on astrorocket.dev: a 537 ms forced reflow in the header scroll handler, a 1.3 s critical-chain on the Header script bundle, and zero preconnected origins.

### Forced reflow — fixed

Within a single scroll event two rAFs ran on the same frame:

1. The header scroll-watcher wrote `data-scrolled` / `data-header-hidden` (layout invalidated)
2. The scroll-progress-bar then read `scrollHeight` to compute the percentage — synchronous layout recompute = the 537 ms reflow

Fixes:
- **Merged the two scroll scripts into one rAF callback.** All reads are now taken up front, all writes happen afterward in the same frame.
- **Cached `docMaxScrollY` (= `scrollHeight - innerHeight`) outside the scroll path.** It refreshes on `resize`, `load`, and via a `ResizeObserver` on `document.documentElement`, so the scroll handler never reads layout-dependent properties.

### Critical-chain — resolved as side effect

After removing `initNavMorph` and merging the two scroll scripts, the Header script is small enough that Astro now inlines it directly into the HTML. There's no longer an external `Header.astro_ast_…js` chunk in `dist/client/_astro/` — the 1,302 ms critical-path fetch Lighthouse flagged simply disappears.

### Preconnect — added, conditionally

Added a conditional `<link rel="preconnect" href="https://giscus.app" crossorigin>` in `BaseLayout`. It only renders when `articleFeatures.comments.enabled` is `true`, so sites without comments don't pay for an unused preconnect, and sites with comments get a warmed DNS+TLS handshake before the lazy-loaded Giscus iframe fires.

### Dead code — removed

The `morphToBar` prop on `<Header>` and `<LandingLayout>` defaulted to `false` everywhere and was never set to `true` — the entire `initNavMorph` script (~30 lines) ran on every page load only to bail on a failing `querySelector`. Removed:

- `morphToBar` prop on `Header.astro` (interface + default)
- `morphToBar` prop on `LandingLayout.astro` (interface + default + pass-through)
- `data-morph-to-bar` attribute on the header element
- `initNavMorph` script block + `astro:transitions/client` import
- Two `[data-morph-to-bar="true"]` CSS rules

## Files changed

- `src/components/layout/Header.astro` — merged scroll scripts, cached docMaxScrollY, removed morph code
- `src/layouts/BaseLayout.astro` — conditional Giscus preconnect
- `src/layouts/LandingLayout.astro` — removed morph pass-through

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm check` — 0 errors, 0 warnings (only pre-existing deprecation hints)
- [x] `pnpm build` — succeeds; no `Header.astro_*.js` chunk emitted (script is now inlined)
- [ ] Deploy preview: re-run Lighthouse and confirm forced reflow drops (target: <50 ms)
- [ ] Deploy preview: confirm header scroll behaviour still works on homepage (floating capsule → solid bar at scroll threshold, auto-hide on scroll down past 150 px, return on scroll up)
- [ ] Deploy preview: confirm scroll-progress bar still tracks correctly on blog posts
- [ ] Deploy preview: confirm preconnect to giscus.app does NOT appear when `articleFeatures.comments.enabled` is `false` (default), and DOES appear when set to `true`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE2FP9tLrCfjVCMTexMD4K)_