### PR TITLE
Light-mode brand-600 alignment: blog SVG hero + mobile menu icons

### DIFF
--- a/src/components/blog/BlogImageSVG.astro
+++ b/src/components/blog/BlogImageSVG.astro
@@ -32,7 +32,7 @@ const svgContent = svgs[`/src/assets/blog/${slug}.svg`] ?? '';
      Brand-500 background — the saturated mid-tone brand colour. Light
      icons and text sit on top for vivid, colourful images in both modes.
   ── */
-  .svg-host :global(.bg)  { fill: var(--brand-500); }
+  .svg-host :global(.bg)  { fill: var(--brand-600); }
   .svg-host :global(.ico) { stroke: var(--brand-50); }
   .svg-host :global(.txt) { fill: var(--brand-50); }
   .svg-host :global(.ln)  { stroke: var(--brand-200); stroke-opacity: 0.5; }

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -291,7 +291,7 @@ const buttonId = `${menuId}-button`;
             id={buttonId}
             class={cn(
               'hdr-hamburger inline-flex items-center justify-center rounded-md p-2 md:hidden',
-              'text-brand-700 dark:text-foreground',
+              'text-brand-600 dark:text-foreground',
               'transition-colors',
               'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
               isFloating ? 'hover:bg-secondary/40' : 'hover:bg-secondary'


### PR DESCRIPTION
## Summary

Two small light-mode brand-color tweaks to align with the `brand-700` → `brand-600` refresh that landed in 1.1.0 (header site name, footer site name, hero H1, primary button).

### 1. Blog SVG hero background

The blog hero SVGs rendered with `brand-500` in light mode and `brand-600` in dark mode. Light mode now also uses `brand-600` so the SVGs render uniformly across both modes.

Single-line change in `BlogImageSVG.astro`. The dark-mode override was already `brand-600`.

### 2. Mobile hamburger + close icons

The `hdr-hamburger` button rendered at `text-brand-700` in light mode (one shade darker than the current brand-600 site name and logo it sits next to). Now `text-brand-600` so the icon matches its surroundings. Dark mode (`text-foreground`) unchanged.

## Test plan

- [ ] Visual check on a deploy preview: blog index, individual blog posts, related-posts cards — light mode hero SVGs should look slightly darker; dark mode identical to before.
- [ ] Mobile viewport: hamburger and close (X) icons should match the brand-600 site name next to them in light mode.
- [ ] Spot-check across a few colour themes (Orange, Blue, Emerald) for legibility on `brand-600`.