### PR TITLE
Enable TOC on demo site with 'auto' layout

### DIFF
--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -137,8 +137,8 @@ const siteConfig: SiteConfig = {
   blogImageOverlay: true,
   articleFeatures: {
     toc: {
-      enabled: false,
-      layout: 'inline',
+      enabled: true,
+      layout: 'auto',
       minHeadings: 3,
       maxDepth: 3,
     },


### PR DESCRIPTION
Activates the table of contents sitewide on the Astro Rocket demo:
- Inline card on phone/tablet (< xl)
- Sticky sidebar on desktop (xl+) Posts with fewer than 3 headings still skip the TOC, and individual posts can opt out with toc: false in frontmatter.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
