### PR TITLE
Fix mobile Lighthouse perf regression: TOC forced reflow + font-swap CLS

### DIFF
--- a/src/components/blog/TableOfContents.astro
+++ b/src/components/blog/TableOfContents.astro
@@ -125,14 +125,14 @@ const headingId = `toc-heading-${Math.random().toString(36).slice(2, 9)}`;
     const io = new IntersectionObserver(
       (entries) => {
         // Pick the topmost heading currently intersecting the upper part
-        // of the viewport. Falls back to the last one above the fold.
+        // of the viewport. We use entry.boundingClientRect (already cached
+        // on the entry by the browser) instead of calling
+        // getBoundingClientRect() on the target — the latter forces a
+        // synchronous layout recompute, which Lighthouse flagged as a
+        // ~200ms forced-reflow source on mobile.
         const visible = entries
           .filter((e) => e.isIntersecting)
-          .sort(
-            (a, b) =>
-              a.target.getBoundingClientRect().top -
-              b.target.getBoundingClientRect().top,
-          );
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
         if (visible.length > 0 && visible[0].target.id) {
           setActive(visible[0].target.id);
         }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,10 +9,36 @@
 @import './tokens/typography.css';
 @import './tokens/spacing.css';
 
-/* Self-hosted fonts via Fontsource (CSP-safe, no external requests) */
+/* Self-hosted fonts via Fontsource (CSP-safe, no external requests).
+   The two display + body fonts (Outfit + Manrope) get explicit @font-face
+   declarations *after* the fontsource imports so we can override
+   font-display from the default `swap` to `optional`. With `optional`
+   the browser blocks for 100ms; if the font isn't ready it uses the
+   fallback for the page's lifetime instead of swapping later — which
+   eliminates the font-swap CLS that Lighthouse mobile flagged on the
+   hero H1. The fonts are preloaded in BaseLayout's <head>, so on most
+   connections they arrive within the 100ms window. */
 @import '@fontsource-variable/manrope';
 @import '@fontsource-variable/outfit';
 @import '@fontsource-variable/jetbrains-mono';
+
+@font-face {
+  font-family: 'Outfit Variable';
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: optional;
+  src: url('@fontsource-variable/outfit/files/outfit-latin-wght-normal.woff2') format('woff2-variations');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: 'Manrope Variable';
+  font-style: normal;
+  font-weight: 200 800;
+  font-display: optional;
+  src: url('@fontsource-variable/manrope/files/manrope-latin-wght-normal.woff2') format('woff2-variations');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
 
 /* Dark mode variant */
 @custom-variant dark (&:where(.dark, .dark *));


### PR DESCRIPTION
## Summary

Mobile Lighthouse on the live demo dropped from 100 to 90 on Performance after 1.2.0 deployed. Insights pointed at two issues — this PR addresses both.

### 1. Forced reflow ~200 ms in TOC scroll-spy

The new TOC scroll-spy iterates entries inside an `IntersectionObserver` callback and previously sorted them by calling `entry.target.getBoundingClientRect().top` — a layout-triggering read inside a callback that may run after attribute writes earlier in the same frame. On mobile this adds up to ~200 ms of forced reflow time.

The `IntersectionObserverEntry` already exposes a cached `boundingClientRect`, so the fix is one line:

```js
.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
```

No layout read, same behaviour.

### 2. CLS 0.197 on the hero H1 from font-swap

`@fontsource-variable/outfit` and `@fontsource-variable/manrope` ship `@font-face` rules with the default `font-display: swap`. On throttled mobile networks the fallback font paints first, then Outfit swaps in and the H1 text re-flows — `"& Developer"` ends up on a different line.

Added explicit `@font-face` declarations **after** the fontsource imports that re-declare the same `font-family` + Latin `unicode-range` with `font-display: optional`. CSS rule ordering means these later rules win for the Latin range. Behaviour:

- Browser blocks 100 ms for the font.
- If the font arrives → uses it. (Combined with the existing `<link rel="preload">` in `BaseLayout`, this is the common case.)
- If not → uses the fallback for the **entire page lifetime**, no swap.

Either path → no CLS.

Verified two `font-display:optional` entries in the built HTML for Outfit Variable + Manrope Variable.

## Files changed

- `src/components/blog/TableOfContents.astro` — `getBoundingClientRect()` → `entry.boundingClientRect`
- `src/styles/global.css` — explicit `@font-face` rules with `font-display: optional` for Outfit + Manrope

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds; built HTML contains 2× `font-display:optional` entries
- [ ] Re-run Lighthouse on mobile against the deploy preview — target: Performance back to 100, CLS < 0.1
- [ ] Verify the TOC scroll-spy still highlights the active section correctly on a long blog post
- [ ] Visual check: hero H1 renders identically once Outfit is loaded

## Trade-offs

`font-display: optional` means first-visit users on slow networks (e.g. mobile 3G) may see the fallback font for the entire page lifetime if the web font misses the 100 ms window. Cached subsequent visits and most modern connections will get Outfit instantly thanks to the preload. Acceptable for a portfolio/blog theme — same trade-off Vercel's `next/font` makes by default.

Desktop score (currently 100/100/100/100) is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE2FP9tLrCfjVCMTexMD4K)_