### PR TITLE
Cache scrollHeight in BaseLayout back-to-top to remove residual reflow

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -266,6 +266,24 @@ schemas.push(...extraSchemas);
         const THRESHOLD = 400;
         const CIRCUMFERENCE = 131.95;
 
+        // Cache `scrollHeight - innerHeight` so the per-frame scroll handler
+        // never reads layout-dependent properties. Reading `scrollHeight`
+        // inside the scroll callback would force a synchronous reflow when
+        // earlier scroll handlers (header scroll-watcher) had already
+        // written attributes — Lighthouse flagged this as a residual
+        // forced-reflow source. Refreshed via resize / load / ResizeObserver
+        // outside the scroll path.
+        let docMaxScrollY = 0;
+        function updateDocMaxScrollY() {
+          docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
+        }
+        updateDocMaxScrollY();
+        window.addEventListener('resize', updateDocMaxScrollY, { passive: true });
+        window.addEventListener('load', updateDocMaxScrollY);
+        if (typeof ResizeObserver !== 'undefined') {
+          new ResizeObserver(updateDocMaxScrollY).observe(document.documentElement);
+        }
+
         function initBackToTop() {
           const btn = document.getElementById('back-to-top');
           if (!btn || btn.dataset.bttInit) return;
@@ -306,8 +324,7 @@ schemas.push(...extraSchemas);
           }
 
           function updateFrame() {
-            const scrollable = document.documentElement.scrollHeight - window.innerHeight;
-            const pct = scrollable > 0 ? Math.min(1, Math.max(0, window.scrollY / scrollable)) : 0;
+            const pct = docMaxScrollY > 0 ? Math.min(1, Math.max(0, window.scrollY / docMaxScrollY)) : 0;
             if (ring) {
               ring.style.strokeDashoffset = String(CIRCUMFERENCE * (1 - pct));
             }
@@ -335,10 +352,8 @@ schemas.push(...extraSchemas);
             window.removeEventListener('scroll', onScroll);
           }, { once: true });
 
-          // Defer initial layout read to the next frame so it doesn't force
-          // a sync reflow during page load (the JS style writes above
-          // invalidate layout; reading scrollHeight immediately would force
-          // the browser to recompute before returning).
+          // Run the first frame on rAF so it picks up the initial scroll
+          // position after layout has settled.
           requestAnimationFrame(updateFrame);
         }
 


### PR DESCRIPTION
The back-to-top button's progress ring read
document.documentElement.scrollHeight - window.innerHeight on every scroll frame. The header scroll-watcher writes data-scrolled attributes earlier in the same frame, invalidating layout; the back-to-top read then forced a synchronous layout recompute.

Lighthouse Insights flagged this as a residual ~93 ms forced reflow source on the homepage (where there is no TOC, so the previous scroll-spy fix didn't help).

Cache docMaxScrollY at init and refresh via resize / load / ResizeObserver outside the scroll path — same pattern already used in Header.astro. The per-frame scroll handler now only reads window.scrollY (which is cheap and not invalidated by attribute writes elsewhere) plus the cached value.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
