### PR TITLE
Cache canvas dimensions in LetterGlitch to remove per-frame reflow

### DIFF
--- a/src/components/effects/LetterGlitch.tsx
+++ b/src/components/effects/LetterGlitch.tsx
@@ -37,6 +37,11 @@ const LetterGlitch = ({
     }[]
   >([]);
   const grid = useRef({ columns: 0, rows: 0 });
+  // Cached canvas dimensions — updated only in resizeCanvas (called on init
+  // and on window resize). Reading getBoundingClientRect() per frame from
+  // drawLetters() forced a synchronous layout recompute on every animation
+  // tick (~215ms total reflow time on the homepage per Lighthouse Insights).
+  const dimensions = useRef({ width: 0, height: 0 });
   const context = useRef<CanvasRenderingContext2D | null>(null);
   const lastGlitchTime = useRef(Date.now());
   const activeColors = useRef<string[]>(glitchColors);
@@ -123,7 +128,7 @@ const LetterGlitch = ({
   const drawLetters = () => {
     if (!context.current || letters.current.length === 0) return;
     const ctx = context.current;
-    const { width, height } = canvasRef.current!.getBoundingClientRect();
+    const { width, height } = dimensions.current;
     ctx.clearRect(0, 0, width, height);
     ctx.font = `${fontSize}px monospace`;
     ctx.textBaseline = 'top';
@@ -150,6 +155,10 @@ const LetterGlitch = ({
 
     canvas.style.width = `${rect.width}px`;
     canvas.style.height = `${rect.height}px`;
+
+    // Cache so drawLetters can use these on every frame without forcing
+    // a fresh layout read.
+    dimensions.current = { width: rect.width, height: rect.height };
 
     if (context.current) {
       context.current.setTransform(dpr, 0, 0, dpr, 0, 0);


### PR DESCRIPTION
LetterGlitch.drawLetters() called canvasRef.current.getBoundingClientRect() on every animation frame to read width/height for the canvas clear region. Those values only change when the window/parent resizes, but reading them per frame forced a synchronous layout recompute.

Lighthouse Insights flagged this as a 215ms forced-reflow source on the homepage (location :371:51 in the bundled inline JS).

Cache the rect in a `dimensions` ref that's updated only inside resizeCanvas (called on init + on the existing window resize listener). drawLetters reads from the cache — zero per-frame layout reads.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
