### PR TITLE
Defer docMaxScrollY layout reads to rAF to remove residual reflow

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -560,18 +560,31 @@ const buttonId = `${menuId}-button`;
   const BAR_SCROLLED_CLASSES = ['bg-background/80', 'backdrop-blur-lg', 'border-b', 'border-border/50'];
 
   let docMaxScrollY = 0;
+  let docMaxRafTicking = false;
   let docMetricsInited = false;
-  function updateDocMaxScrollY() {
+  function readDocMaxScrollY() {
+    docMaxRafTicking = false;
     docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
+  }
+  function scheduleDocMaxUpdate() {
+    if (docMaxRafTicking) return;
+    docMaxRafTicking = true;
+    requestAnimationFrame(readDocMaxScrollY);
   }
   function initDocMetrics() {
     if (docMetricsInited) return;
     docMetricsInited = true;
-    updateDocMaxScrollY();
-    window.addEventListener('resize', updateDocMaxScrollY, { passive: true });
-    window.addEventListener('load', updateDocMaxScrollY);
+    // Initial read is synchronous so the value is ready before the
+    // first scroll event fires.
+    readDocMaxScrollY();
+    // Subsequent updates are deferred to rAF and coalesced — the
+    // ResizeObserver in particular fires repeatedly during reveal
+    // animations and would otherwise force a synchronous layout
+    // recompute on every firing.
+    window.addEventListener('resize', scheduleDocMaxUpdate, { passive: true });
+    window.addEventListener('load', scheduleDocMaxUpdate);
     if (typeof ResizeObserver !== 'undefined') {
-      new ResizeObserver(updateDocMaxScrollY).observe(document.documentElement);
+      new ResizeObserver(scheduleDocMaxUpdate).observe(document.documentElement);
     }
   }
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -267,21 +267,31 @@ schemas.push(...extraSchemas);
         const CIRCUMFERENCE = 131.95;
 
         // Cache `scrollHeight - innerHeight` so the per-frame scroll handler
-        // never reads layout-dependent properties. Reading `scrollHeight`
-        // inside the scroll callback would force a synchronous reflow when
-        // earlier scroll handlers (header scroll-watcher) had already
-        // written attributes — Lighthouse flagged this as a residual
-        // forced-reflow source. Refreshed via resize / load / ResizeObserver
-        // outside the scroll path.
+        // never reads layout-dependent properties. The ResizeObserver fires
+        // whenever element heights change (reveal animations cascading in,
+        // images loading, etc.), so we coalesce multiple firings within
+        // a single frame and defer the layout read to a rAF callback —
+        // the read then uses cached layout from the prior frame instead
+        // of forcing a synchronous recompute. Lighthouse flagged the
+        // un-deferred version as a 112ms forced-reflow source.
         let docMaxScrollY = 0;
-        function updateDocMaxScrollY() {
+        let docMaxRafTicking = false;
+        function readDocMaxScrollY() {
+          docMaxRafTicking = false;
           docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
         }
-        updateDocMaxScrollY();
-        window.addEventListener('resize', updateDocMaxScrollY, { passive: true });
-        window.addEventListener('load', updateDocMaxScrollY);
+        function scheduleDocMaxUpdate() {
+          if (docMaxRafTicking) return;
+          docMaxRafTicking = true;
+          requestAnimationFrame(readDocMaxScrollY);
+        }
+        // Initial read is synchronous so the value is ready before the
+        // first scroll event fires.
+        readDocMaxScrollY();
+        window.addEventListener('resize', scheduleDocMaxUpdate, { passive: true });
+        window.addEventListener('load', scheduleDocMaxUpdate);
         if (typeof ResizeObserver !== 'undefined') {
-          new ResizeObserver(updateDocMaxScrollY).observe(document.documentElement);
+          new ResizeObserver(scheduleDocMaxUpdate).observe(document.documentElement);
         }
 
         function initBackToTop() {


### PR DESCRIPTION
## Summary

Found via Lighthouse Insights: 112 ms of forced reflow attributed to line `:371:51` of the bundled inline JS — which maps back to:

```js
docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
```

That's the cache updater I added in PR #258 to *avoid* the previous reflow. The cache itself is still the right idea, but the **`ResizeObserver` callback fires repeatedly during the page lifecycle** — reveal animations cascading in, images loading, font swap — and reading `scrollHeight` synchronously inside the observer callback (while layout is being mutated by the same events) reintroduced the reflow.

## Fix

Wrap the read in `requestAnimationFrame` and coalesce multiple firings within one frame via a ticking flag:

```js
let docMaxRafTicking = false;
function readDocMaxScrollY() {
  docMaxRafTicking = false;
  docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
}
function scheduleDocMaxUpdate() {
  if (docMaxRafTicking) return;
  docMaxRafTicking = true;
  requestAnimationFrame(readDocMaxScrollY);
}
```

The rAF callback runs at the start of the next frame using committed layout from the prior frame — the read is cached rather than forced. Multiple ResizeObserver firings within one frame collapse into a single read.

The initial read still runs synchronously so the value is ready before the first scroll event fires.

## Files changed

- `src/layouts/BaseLayout.astro` — back-to-top progress ring's `docMaxScrollY` cache
- `src/components/layout/Header.astro` — header scroll-watcher + scroll progress bar's `docMaxScrollY` cache

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm check` — 0 errors / 0 warnings
- [x] `pnpm build` — succeeds
- [ ] Re-run mobile Lighthouse against the deploy preview — target: forced reflow at `:371:51` removed, score returns to 100
- [ ] Visual check: back-to-top progress ring still tracks the page scroll correctly
- [ ] Visual check: header floating capsule + scroll progress bar still respond to scroll on the homepage

This should be the last reflow source flagged by Insights — the 112 → 0 drop is the only remaining gap to 100/100/100/100 on mobile.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE2FP9tLrCfjVCMTexMD4K)_