### PR TITLE
Drop ResizeObserver from docMaxScrollY cache to remove residual reflow

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -551,41 +551,29 @@ const buttonId = `${menuId}-button`;
 
 <script>
   // Header scroll behaviour + scroll-progress bar driven by a single rAF.
-  // All layout reads are taken before any DOM writes, and `docMaxScrollY`
-  // is cached via ResizeObserver so the scroll path never reads
-  // `scrollHeight` — which would force a synchronous layout recompute
-  // after attribute writes earlier in the same frame.
+  // All layout reads are taken before any DOM writes. `docMaxScrollY` is
+  // cached and refreshed only on resize + load — we deliberately avoid
+  // a ResizeObserver here because it fires repeatedly during the page
+  // load period (image loads, reveal animations, font swap), and reading
+  // scrollHeight in those callbacks reintroduces forced reflow even when
+  // wrapped in rAF, because other scripts queue layout writes between
+  // the observer firing and the rAF. Tiny drift while the page settles
+  // is invisible for scroll-progress UIs.
   const SCROLL_THRESHOLD = 60;
   const AUTO_HIDE_THRESHOLD = 150;
   const BAR_SCROLLED_CLASSES = ['bg-background/80', 'backdrop-blur-lg', 'border-b', 'border-border/50'];
 
   let docMaxScrollY = 0;
-  let docMaxRafTicking = false;
   let docMetricsInited = false;
-  function readDocMaxScrollY() {
-    docMaxRafTicking = false;
+  function updateDocMaxScrollY() {
     docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
-  }
-  function scheduleDocMaxUpdate() {
-    if (docMaxRafTicking) return;
-    docMaxRafTicking = true;
-    requestAnimationFrame(readDocMaxScrollY);
   }
   function initDocMetrics() {
     if (docMetricsInited) return;
     docMetricsInited = true;
-    // Initial read is synchronous so the value is ready before the
-    // first scroll event fires.
-    readDocMaxScrollY();
-    // Subsequent updates are deferred to rAF and coalesced — the
-    // ResizeObserver in particular fires repeatedly during reveal
-    // animations and would otherwise force a synchronous layout
-    // recompute on every firing.
-    window.addEventListener('resize', scheduleDocMaxUpdate, { passive: true });
-    window.addEventListener('load', scheduleDocMaxUpdate);
-    if (typeof ResizeObserver !== 'undefined') {
-      new ResizeObserver(scheduleDocMaxUpdate).observe(document.documentElement);
-    }
+    updateDocMaxScrollY();
+    window.addEventListener('resize', updateDocMaxScrollY, { passive: true });
+    window.addEventListener('load', updateDocMaxScrollY);
   }
 
   function initScrollDriven() {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -267,32 +267,22 @@ schemas.push(...extraSchemas);
         const CIRCUMFERENCE = 131.95;
 
         // Cache `scrollHeight - innerHeight` so the per-frame scroll handler
-        // never reads layout-dependent properties. The ResizeObserver fires
-        // whenever element heights change (reveal animations cascading in,
-        // images loading, etc.), so we coalesce multiple firings within
-        // a single frame and defer the layout read to a rAF callback —
-        // the read then uses cached layout from the prior frame instead
-        // of forcing a synchronous recompute. Lighthouse flagged the
-        // un-deferred version as a 112ms forced-reflow source.
-        let docMaxScrollY = 0;
-        let docMaxRafTicking = false;
-        function readDocMaxScrollY() {
-          docMaxRafTicking = false;
+        // never reads layout-dependent properties. We deliberately do NOT
+        // use a ResizeObserver here: it fires repeatedly during the page
+        // load period (image loads, animations cascading in, font swap),
+        // and reading scrollHeight in the observer callback re-introduces
+        // forced reflow even when wrapped in rAF, because other scripts
+        // queue layout writes between the observer firing and the rAF.
+        // resize + load events are sufficient: the initial value is
+        // accurate enough for progress UIs, and `load` refreshes it once
+        // every resource has settled. Tiny drift while the page settles
+        // is invisible to the reader.
+        let docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
+        function updateDocMaxScrollY() {
           docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
         }
-        function scheduleDocMaxUpdate() {
-          if (docMaxRafTicking) return;
-          docMaxRafTicking = true;
-          requestAnimationFrame(readDocMaxScrollY);
-        }
-        // Initial read is synchronous so the value is ready before the
-        // first scroll event fires.
-        readDocMaxScrollY();
-        window.addEventListener('resize', scheduleDocMaxUpdate, { passive: true });
-        window.addEventListener('load', scheduleDocMaxUpdate);
-        if (typeof ResizeObserver !== 'undefined') {
-          new ResizeObserver(scheduleDocMaxUpdate).observe(document.documentElement);
-        }
+        window.addEventListener('resize', updateDocMaxScrollY, { passive: true });
+        window.addEventListener('load', updateDocMaxScrollY);
 
         function initBackToTop() {
           const btn = document.getElementById('back-to-top');


### PR DESCRIPTION
## Summary

After PR #261 wrapped the `docMaxScrollY` read in `requestAnimationFrame`, Lighthouse Insights still flagged 95 ms of forced reflow at the same source line.

**Diagnosis:** the rAF wrapping doesn't help if other scripts (reveal animations, image loads) queue layout writes between the `ResizeObserver` firing and the rAF callback executing. The `ResizeObserver` was firing repeatedly during the page load period (every image load, every reveal animation expanding height, every font swap), and every firing led to a deferred read that, by the time it ran, had to recompute layout because writes had already happened in the same tick.

## Fix

Drop the `ResizeObserver` entirely. The cache is now refreshed only on `resize` and `load` events.

- **Initial value** is accurate at script execution time.
- **`load` event** refreshes it once every resource has settled — after that, document height is stable and the cache is accurate forever.
- **Brief window between page load and `load` event** the cache may be slightly stale, but for a back-to-top progress ring or scroll-progress percentage that drift is invisible (sub-100px out of multi-thousand-px pages).

Trade-off accepted: we lose live tracking of dynamic content height changes (rare on a static-first Astro site) in exchange for zero forced reflow.

## Files changed

- `src/layouts/BaseLayout.astro` — back-to-top progress ring's `docMaxScrollY` cache
- `src/components/layout/Header.astro` — header scroll-watcher's `docMaxScrollY` cache

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm check` — 0 errors / 0 warnings
- [x] `pnpm build` — succeeds
- [ ] Re-run mobile Lighthouse against the deploy preview — target: forced reflow removed entirely, score back to 100
- [ ] Visual check: back-to-top progress ring still tracks scroll
- [ ] Visual check: header scroll-watcher still hides/shows correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE2FP9tLrCfjVCMTexMD4K)_