### PR TITLE
Defer initial scrollHeight read until DOMContentLoaded

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -571,9 +571,22 @@ const buttonId = `${menuId}-button`;
   function initDocMetrics() {
     if (docMetricsInited) return;
     docMetricsInited = true;
-    updateDocMaxScrollY();
+    // Don't read scrollHeight at script-init — this script is processed
+    // by Astro and runs early enough that the document hasn't been
+    // fully parsed/laid out yet. Reading then forces a synchronous
+    // layout for the partial document, which Lighthouse flagged as a
+    // ~100ms forced-reflow source on mobile. Defer the first read to
+    // DOMContentLoaded and refresh on load + resize. Brief startup
+    // window where docMaxScrollY is 0 is invisible: the scroll watcher
+    // only consults it during the auto-hide return branch, which can't
+    // fire until the user has actually scrolled.
     window.addEventListener('resize', updateDocMaxScrollY, { passive: true });
     window.addEventListener('load', updateDocMaxScrollY);
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', updateDocMaxScrollY, { once: true });
+    } else {
+      updateDocMaxScrollY();
+    }
   }
 
   function initScrollDriven() {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -267,22 +267,31 @@ schemas.push(...extraSchemas);
         const CIRCUMFERENCE = 131.95;
 
         // Cache `scrollHeight - innerHeight` so the per-frame scroll handler
-        // never reads layout-dependent properties. We deliberately do NOT
-        // use a ResizeObserver here: it fires repeatedly during the page
-        // load period (image loads, animations cascading in, font swap),
-        // and reading scrollHeight in the observer callback re-introduces
-        // forced reflow even when wrapped in rAF, because other scripts
-        // queue layout writes between the observer firing and the rAF.
-        // resize + load events are sufficient: the initial value is
-        // accurate enough for progress UIs, and `load` refreshes it once
-        // every resource has settled. Tiny drift while the page settles
-        // is invisible to the reader.
-        let docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
+        // never reads layout-dependent properties. We deliberately:
+        //   * Avoid a ResizeObserver — it fires during the page load period
+        //     (image loads, reveal animations, font swap) and reading
+        //     scrollHeight in those callbacks reintroduces forced reflow.
+        //   * Avoid reading scrollHeight at script-init — this script is
+        //     `is:inline` and runs during HTML parsing, before layout is
+        //     committed. Reading scrollHeight then forces the browser to
+        //     compute layout for the partial document — Lighthouse flagged
+        //     this as ~100ms of forced reflow on mobile.
+        // We start at 0 and read for the first time on DOMContentLoaded
+        // (parser done, initial layout cheap) and again on `load` (after
+        // every resource has settled). The brief window where the cache
+        // is 0 is invisible: the back-to-top button only shows after
+        // scrollY > 400, by which point DOMContentLoaded has fired.
+        let docMaxScrollY = 0;
         function updateDocMaxScrollY() {
           docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
         }
         window.addEventListener('resize', updateDocMaxScrollY, { passive: true });
         window.addEventListener('load', updateDocMaxScrollY);
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', updateDocMaxScrollY, { once: true });
+        } else {
+          updateDocMaxScrollY();
+        }
 
         function initBackToTop() {
           const btn = document.getElementById('back-to-top');


### PR DESCRIPTION
## Summary

The previous round of fixes dropped the `ResizeObserver`, but Lighthouse Insights still flagged ~104 ms of forced reflow at line `:373:53` of the homepage. That line maps to:

```js
let docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
```

**Why it's reflow:** the inline scripts that cache `docMaxScrollY` run during HTML parsing — before the browser has committed layout for the (still-parsing) document. Reading `scrollHeight` at that moment forces the browser to compute layout for the partial document right then.

## Fix

Initialize `docMaxScrollY = 0` and defer the first read until **`DOMContentLoaded`** (parser done, initial layout exists and is cheap to query). Existing `load` and `resize` refreshes stay.

The brief window where `docMaxScrollY` is `0` is invisible to the reader:
- The back-to-top button hides until `scrollY > 400`, by which point `DOMContentLoaded` has long fired.
- The header scroll-watcher only consults `docMaxScrollY` in the auto-hide-return branch, which can't fire until the user has actually scrolled past the threshold.

## Files changed

- `src/layouts/BaseLayout.astro` — back-to-top progress ring's `docMaxScrollY` cache
- `src/components/layout/Header.astro` — header scroll-watcher's `docMaxScrollY` cache

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm check` — 0 errors / 0 warnings
- [x] `pnpm build` — succeeds
- [ ] Re-run mobile Lighthouse — target: forced reflow gone, score at 100 (or in 99-100 noise band)
- [ ] Visual check: scroll the homepage — back-to-top progress ring still tracks, header still hides/shows

This is the last forced-reflow source the Insights have flagged. If mobile is still under 100 after this, the remaining gap is run-to-run variance, not a fixable issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE2FP9tLrCfjVCMTexMD4K)_