### PR TITLE
Update scroll-bar and scroll-ring blog snippets to match 1.2.1 impl

### DIFF
--- a/src/content/blog/en/scroll-progress-bar.mdx
+++ b/src/content/blog/en/scroll-progress-bar.mdx
@@ -30,10 +30,25 @@ The bar is enabled on three page types, each with a different position:
 The bar is an absolutely positioned `div` inside the `<header>` element. A small script updates its `width` on every scroll event, capped with `requestAnimationFrame` to avoid layout thrashing:
 
 ```ts
+// Cache the document max scroll position once, refresh only on
+// resize + load. Reading scrollHeight inside the per-frame scroll
+// handler would force a synchronous layout recompute every time
+// other scripts (header scroll-watcher, reveal animations) had
+// mutated the DOM earlier in the same frame.
+let docMaxScrollY = 0;
+function updateDocMaxScrollY() {
+  docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
+}
+window.addEventListener('resize', updateDocMaxScrollY, { passive: true });
+window.addEventListener('load', updateDocMaxScrollY);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', updateDocMaxScrollY, { once: true });
+} else {
+  updateDocMaxScrollY();
+}
+
 function update() {
-  const scrollTop = window.scrollY;
-  const docHeight = document.documentElement.scrollHeight - window.innerHeight;
-  const pct = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+  const pct = docMaxScrollY > 0 ? (window.scrollY / docMaxScrollY) * 100 : 0;
   bar.style.width = `${pct}%`;
 }
 
@@ -46,6 +61,12 @@ window.addEventListener('scroll', () => {
 ```
 
 The bar colour is `var(--color-brand-500)` — it automatically matches your active colour theme and updates instantly when the visitor switches themes.
+
+## Why the document height is cached
+
+A simpler version of the script reads `document.documentElement.scrollHeight - window.innerHeight` directly inside the scroll handler. That works, but on a page with other scroll-driven scripts (the header scroll-watcher writing `data-scrolled`, reveal animations toggling `is-visible` classes), the read forces a synchronous layout recompute every frame — Lighthouse mobile flagged this as 100+ ms of forced reflow on the demo site.
+
+Caching `docMaxScrollY` and updating it only on `resize`, `load`, and `DOMContentLoaded` lets the per-frame handler do nothing but read `window.scrollY` (which is cheap and not invalidated by attribute writes elsewhere) plus the cached value. The cache is briefly `0` between script-init and `DOMContentLoaded`, but the reader can't see that — `window.scrollY` is also `0` at that point, so the bar correctly stays empty.
 
 ## The two props
 

--- a/src/content/blog/en/scroll-progress-ring.mdx
+++ b/src/content/blog/en/scroll-progress-ring.mdx
@@ -68,11 +68,26 @@ The circle has a radius of 21 px. Its circumference is:
 
 Both `stroke-dasharray` and the initial `stroke-dashoffset` are set to `131.95`. When offset equals the full circumference the arc is invisible — the dash starts and ends at the same point, so nothing is drawn. As the offset decreases toward `0`, more of the arc becomes visible.
 
+The maximum scroll position is cached once and refreshed only on `resize` and `load` (or `DOMContentLoaded` if the script runs during parsing) — reading `scrollHeight` inside the per-frame scroll handler would force a synchronous layout recompute every time other scripts had mutated the DOM earlier in the same frame:
+
+```js
+var docMaxScrollY = 0;
+function updateDocMaxScrollY() {
+  docMaxScrollY = document.documentElement.scrollHeight - window.innerHeight;
+}
+window.addEventListener('resize', updateDocMaxScrollY, { passive: true });
+window.addEventListener('load', updateDocMaxScrollY);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', updateDocMaxScrollY, { once: true });
+} else {
+  updateDocMaxScrollY();
+}
+```
+
 On each scroll frame:
 
 ```js
-var scrollable = document.documentElement.scrollHeight - window.innerHeight;
-var pct = scrollable > 0 ? window.scrollY / scrollable : 0;
+var pct = docMaxScrollY > 0 ? window.scrollY / docMaxScrollY : 0;
 ring.style.strokeDashoffset = String(CIRCUMFERENCE * (1 - pct));
 ```
 
@@ -95,7 +110,7 @@ function onScroll() {
 window.addEventListener('scroll', onScroll, { passive: true });
 ```
 
-`updateFrame` resets `ticking` to `false` at the end of each frame, allowing the next scroll event to schedule a new update. Combined with `{ passive: true }`, this ensures the scroll handler never blocks the main thread.
+`updateFrame` reads from the cached `docMaxScrollY` plus `window.scrollY` (cheap, not invalidated by attribute writes elsewhere) and resets `ticking` to `false` at the end of each frame, allowing the next scroll event to schedule a new update. Combined with `{ passive: true }`, this ensures the scroll handler never blocks the main thread — and never forces a synchronous layout.
 
 ## Automatic theme colour
 


### PR DESCRIPTION
## Summary

Documentation cleanup. Two blog posts had code snippets that showed the pre-1.2.1 implementation (reading `scrollHeight` directly inside the scroll handler). After the 1.2.1 perf fixes the actual code caches `docMaxScrollY` and refreshes only on `resize` / `load` / `DOMContentLoaded`.

Updated both snippets to match the shipped code and added a short "Why we cache" callout in `scroll-progress-bar.mdx` that explains the forced-reflow gotcha — useful context for anyone copying the pattern into their own theme.

## Files changed

- `src/content/blog/en/scroll-progress-bar.mdx` — snippet now shows cached `docMaxScrollY` pattern; added "Why the document height is cached" section explaining the rationale
- `src/content/blog/en/scroll-progress-ring.mdx` — snippet now shows cached `docMaxScrollY` pattern; updated the rAF-throttling section to mention reading from cache rather than forcing layout

No code changes, no version bump — pure docs.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm check` — 0 errors / 0 warnings
- [x] `pnpm build` — both posts re-render without schema errors
- [ ] Visual check on the live posts after deploy: code blocks render correctly, no broken syntax highlighting

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE2FP9tLrCfjVCMTexMD4K)_