### PR TITLE
Add sidebarPosition setting for blog TOC sidebar

### DIFF
--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -51,6 +51,11 @@ export interface SiteConfig {
        *               and tablet readers still get the navigation
        */
       layout?: 'inline' | 'sidebar' | 'auto';
+      /**
+       * Which side the sidebar TOC sits on (only applies when `layout` is
+       * 'sidebar' or 'auto'). Defaults to 'right'.
+       */
+      sidebarPosition?: 'left' | 'right';
       /** Minimum headings before the TOC renders (avoid TOCs on short posts) */
       minHeadings?: number;
       /** Deepest heading level to include (2 = H2 only, 3 = H2+H3, etc.) */
@@ -139,6 +144,7 @@ const siteConfig: SiteConfig = {
     toc: {
       enabled: true,
       layout: 'auto',
+      sidebarPosition: 'left',
       minHeadings: 3,
       maxDepth: 3,
     },

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -66,6 +66,7 @@ const showComments = !!commentsConfig?.enabled && commentsOverride !== false;
 const tocLayout = tocConfig?.layout ?? 'inline';
 const sidebarActive = showToc && (tocLayout === 'sidebar' || tocLayout === 'auto');
 const inlineActive = showToc && (tocLayout === 'inline' || tocLayout === 'auto');
+const sidebarOnLeft = (tocConfig?.sidebarPosition ?? 'right') === 'left';
 
 const ogImage = image?.src || siteConfig.ogImage;
 
@@ -129,8 +130,22 @@ const blogPostingSchema = createBlogPostSchema({
   <article class="pt-8 pb-[var(--space-section-md)]">
     <div class:list={[
       'mx-auto px-6',
-      sidebarActive ? 'max-w-7xl xl:grid xl:grid-cols-[minmax(0,1fr)_15rem] xl:gap-10' : 'max-w-4xl',
+      sidebarActive && (sidebarOnLeft
+        ? 'max-w-7xl xl:grid xl:grid-cols-[15rem_minmax(0,1fr)] xl:gap-10'
+        : 'max-w-7xl xl:grid xl:grid-cols-[minmax(0,1fr)_15rem] xl:gap-10'),
+      !sidebarActive && 'max-w-4xl',
     ]}>
+      {sidebarActive && sidebarOnLeft && (
+        <aside class="hidden xl:block" aria-label="Table of contents">
+          <TableOfContents
+            headings={headings}
+            maxDepth={tocConfig?.maxDepth ?? 3}
+            minHeadings={tocConfig?.minHeadings ?? 3}
+            sticky
+          />
+        </aside>
+      )}
+
       <div class:list={[sidebarActive && 'min-w-0 max-w-4xl w-full mx-auto xl:mx-0']}>
       <!-- Breadcrumbs -->
       <Breadcrumbs items={breadcrumbs} class="mb-8" />
@@ -184,7 +199,7 @@ const blogPostingSchema = createBlogPostSchema({
       </footer>
       </div>
 
-      {sidebarActive && (
+      {sidebarActive && !sidebarOnLeft && (
         <aside class="hidden xl:block" aria-label="Table of contents">
           <TableOfContents
             headings={headings}


### PR DESCRIPTION
Lets users place the sidebar TOC on the left or right of the article via articleFeatures.toc.sidebarPosition in site.config.ts. Defaults to 'right' to preserve existing behavior; site config ships with 'left'.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
