### PR TITLE
Document sidebarPosition option in TOC blog post

### DIFF
--- a/src/content/blog/en/table-of-contents.mdx
+++ b/src/content/blog/en/table-of-contents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Table of Contents — Reading Anchors for Long Posts"
-description: "Astro Rocket renders an optional table of contents on blog posts in three layouts: inline card, sticky sidebar, or both. Pick the one that fits your audience."
+description: "Astro Rocket renders an optional table of contents on blog posts in three layouts: inline card, sticky sidebar, or both — and the sidebar can sit on the left or the right. Pick the combination that fits your audience."
 publishedAt: 2026-05-09
 author: "Hans Martens"
 tags: ["astro-rocket", "features", "blog", "navigation"]
@@ -20,16 +20,20 @@ Astro Rocket ships a built-in TOC component for blog posts with three layout opt
 | Layout | Mobile / tablet (`< xl`) | Desktop (`xl+`, ≥1280 px) |
 |---|---|---|
 | `'inline'` | Card at the top of the article | Card at the top of the article |
-| `'sidebar'` | TOC hidden | Sticky sidebar to the right of the article |
-| `'auto'` | Card at the top of the article | Sticky sidebar to the right of the article |
+| `'sidebar'` | TOC hidden | Sticky sidebar next to the article |
+| `'auto'` | Card at the top of the article | Sticky sidebar next to the article |
 
 **Inline** keeps your full reading width on every viewport — best when you want articles to read like a book and don't need the TOC to follow the reader. Mine started this way.
 
-**Sidebar** is the classic docs-style layout — a sticky list on the right that follows the reader on desktop and stays out of the way on phones. Hidden below the `xl` breakpoint so it doesn't compete with mobile reading.
+**Sidebar** is the classic docs-style layout — a sticky list that follows the reader on desktop and stays out of the way on phones. Hidden below the `xl` breakpoint so it doesn't compete with mobile reading.
 
 **Auto** combines both: phone and tablet readers get the inline card at the top, desktop readers get the sticky sidebar. This is what *this site* uses — try resizing the browser on any blog post.
 
 In all three, the article column stays at `max-w-4xl` so reading width never changes when the sidebar appears or disappears.
+
+### Left or right?
+
+Whenever the sidebar is active (`'sidebar'` or `'auto'`), you can pick which side it sits on with the `sidebarPosition` setting. `'left'` puts the TOC before the article — handy when you want the navigation to feel like a docs site or to mirror your main nav. `'right'` keeps it after the article, which is the more common blog convention. The article column stays the same width either way; only the column order changes.
 
 ## How to enable
 
@@ -38,15 +42,16 @@ Open `src/config/site.config.ts` and find the `articleFeatures.toc` block:
 ```ts
 articleFeatures: {
   toc: {
-    enabled: true,        // turn the TOC on site-wide
-    layout: 'auto',       // 'inline' | 'sidebar' | 'auto'
-    minHeadings: 3,       // hide TOC on posts with fewer than 3 headings
-    maxDepth: 3,          // include H2 + H3 (set to 2 for H2 only)
+    enabled: true,             // turn the TOC on site-wide
+    layout: 'auto',            // 'inline' | 'sidebar' | 'auto'
+    sidebarPosition: 'left',   // 'left' | 'right' (sidebar layouts only)
+    minHeadings: 3,            // hide TOC on posts with fewer than 3 headings
+    maxDepth: 3,               // include H2 + H3 (set to 2 for H2 only)
   },
 },
 ```
 
-Save, build, and every blog post with three or more headings now shows a TOC in the layout you chose.
+Save, build, and every blog post with three or more headings now shows a TOC in the layout — and on the side — you chose. `sidebarPosition` defaults to `'right'` if you omit it, and is ignored when `layout` is `'inline'`.
 
 ## How to disable
 
@@ -55,8 +60,9 @@ If you've decided you'd rather not have a TOC at all, set `enabled` to `false`:
 ```ts
 articleFeatures: {
   toc: {
-    enabled: false,       // ← TOC fully off
+    enabled: false,            // ← TOC fully off
     layout: 'inline',
+    sidebarPosition: 'right',
     minHeadings: 3,
     maxDepth: 3,
   },
@@ -85,10 +91,11 @@ You can also force-hide in the other direction: if you've enabled the TOC site-w
 Switching is a one-line change. If you start with `'inline'` and decide later you want a sidebar:
 
 ```ts
-layout: 'sidebar',  // or 'auto'
+layout: 'sidebar',           // or 'auto'
+sidebarPosition: 'left',     // or 'right'
 ```
 
-Save and rebuild — every existing blog post picks up the new layout automatically. No frontmatter migration, no per-post tweaks.
+Save and rebuild — every existing blog post picks up the new layout automatically. No frontmatter migration, no per-post tweaks. Flipping the sidebar from one side to the other is the same one-line change to `sidebarPosition`.
 
 ## How it works under the hood
 
@@ -97,6 +104,8 @@ The TOC is generated from the headings Astro extracts from your MDX file. There'
 Each heading already has an `id` (Astro's MDX integration auto-generates them via slugified text), so the TOC just turns those into anchor links. No external dependencies.
 
 For `auto`, both an inline card and a sidebar nav are rendered on every post, with CSS `xl:hidden` and `hidden xl:block` swapping which one is visible. Scroll-spy runs independently on whichever is currently in view, using `IntersectionObserver` with a tuned `rootMargin` so a heading becomes "active" when it scrolls into the upper portion of the viewport, not when it's already past the bottom.
+
+Left vs. right is a pure layout swap: the sidebar `<aside>` is rendered before or after the article in the DOM, and the grid template flips between `[15rem_minmax(0,1fr)]` and `[minmax(0,1fr)_15rem]`. No extra CSS, no extra JS — and the same scroll-spy script runs in either direction.
 
 ## What it costs (close to nothing)
 
@@ -122,4 +131,4 @@ If you want a different title above the list, the component accepts a `title` pr
 - Config: `src/config/site.config.ts` → `articleFeatures.toc`
 - Per-post override: `toc: false` in MDX frontmatter
 
-That's the whole feature. Three layouts, one config flag, an optional per-post override — and a scroll-spy that just works.
+That's the whole feature. Three layouts, a left-or-right sidebar, one config block, an optional per-post override — and a scroll-spy that just works.


### PR DESCRIPTION
Adds left-vs-right coverage to the table-of-contents article: a new 'Left or right?' subsection, the new field in the enable/disable code samples, and a note in the under-the-hood section explaining the grid swap.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
