### PR TITLE
Add maxWidth prop to Header/Footer; widen on blog posts with sidebar TOC

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -75,6 +75,8 @@ interface Props extends HTMLAttributes<'footer'> {
   hideLogo?: boolean;
   /** Tagline text under logo */
   tagline?: string;
+  /** Max width of the inner container. Defaults to `'6xl'`. */
+  maxWidth?: '4xl' | '5xl' | '6xl' | '7xl' | 'full';
 }
 
 const {
@@ -90,9 +92,18 @@ const {
   legalLinks,
   hideLogo = false,
   tagline,
+  maxWidth = '6xl',
   class: className,
   ...attrs
 } = Astro.props;
+
+const maxWidthClass = {
+  '4xl': 'max-w-4xl',
+  '5xl': 'max-w-5xl',
+  '6xl': 'max-w-6xl',
+  '7xl': 'max-w-7xl',
+  full: 'max-w-full',
+}[maxWidth];
 
 // Get navigation items — footer nav is configured independently from the
 // header in `nav.config.ts` (see `footerNavItems`).
@@ -137,7 +148,7 @@ function getSocialIcon(platform: string): string {
 ---
 
 <footer class={footerClasses} {...attrs}>
-  <div class="mx-auto max-w-6xl px-6">
+  <div class={cn('mx-auto px-6', maxWidthClass)}>
     {layout === 'simple' && (
       <>
       <div class="flex flex-col md:flex-row justify-between items-center gap-[var(--space-stack-lg)]">

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -70,6 +70,11 @@ interface Props extends HTMLAttributes<'header'> {
   scrollProgressPosition?: 'top' | 'bottom';
   autoHide?: boolean;
   invertOnReturn?: boolean;
+  /**
+   * Max width of the inner container (only applies when `shape='bar'`).
+   * Defaults to `'6xl'` (the historical width).
+   */
+  maxWidth?: '4xl' | '5xl' | '6xl' | '7xl' | 'full';
 }
 
 const {
@@ -95,11 +100,19 @@ const {
   invertOnReturn = true,
   logoText,
   hideLogo = false,
+  maxWidth = '6xl',
   class: className,
   ...attrs
 } = Astro.props;
 
 const isFloating = shape === 'floating';
+const maxWidthClass = {
+  '4xl': 'max-w-4xl',
+  '5xl': 'max-w-5xl',
+  '6xl': 'max-w-6xl',
+  '7xl': 'max-w-7xl',
+  full: 'max-w-full',
+}[maxWidth];
 const effectiveShowScrollProgress = showScrollProgress || (isFloating && !autoHide);
 const isInvert = colorScheme === 'invert';
 
@@ -124,7 +137,7 @@ const headerClasses = cn(
   className
 );
 
-const innerClasses = headerInnerVariants({ size, shape });
+const innerClasses = cn(headerInnerVariants({ size, shape }), !isFloating && maxWidthClass);
 
 function isActive(href: string): boolean {
   if (!showActiveState) return false;
@@ -363,7 +376,7 @@ const buttonId = `${menuId}-button`;
         >
           <div class={cn(
             'space-y-1 py-4',
-            isFloating ? 'px-4' : 'mx-auto max-w-6xl px-6'
+            isFloating ? 'px-4' : cn('mx-auto px-6', maxWidthClass)
           )}>
             {navItems.map(({ label, href }) => (
               <a

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -111,6 +111,7 @@ const blogPostingSchema = createBlogPostSchema({
     size="lg"
     showCta={false}
     showScrollProgress
+    maxWidth={sidebarActive ? '7xl' : '6xl'}
   />
 
   <div class="min-h-screen pt-16">
@@ -258,5 +259,5 @@ const blogPostingSchema = createBlogPostSchema({
   </CTA>
   </div>
 
-  <Footer slot="footer" layout="simple" background="secondary" />
+  <Footer slot="footer" layout="simple" background="secondary" maxWidth={sidebarActive ? '7xl' : '6xl'} />
 </BaseLayout>


### PR DESCRIPTION
So the header logo and footer columns share the same outer edges as the blog article wrapper when the sidebar TOC is active (max-w-7xl). Other pages still default to max-w-6xl, and floating-header geometry is untouched.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
