### PR TITLE
TEST ONLY: flip i18n on (en+nl) for Lighthouse perf comparison

### DIFF
--- a/src/config/i18n.config.ts
+++ b/src/config/i18n.config.ts
@@ -32,9 +32,9 @@ export interface I18nConfig {
 }
 
 const i18nConfig: I18nConfig = {
-  enabled: false,
+  enabled: true,
   defaultLocale: 'en',
-  locales: ['en'],
+  locales: ['en', 'nl'],
   localeNames: {
     en: 'English',
     nl: 'Nederlands',


### PR DESCRIPTION
Not for merge to main. This branch exists to verify that turning i18n on does not regress Lighthouse scores vs the disabled-path baseline.

Changes:
- enabled: false → true
- locales: ['en'] → ['en', 'nl']

With these flags, the build emits:
- LanguageSwitcher in the header (1 instance per page)
- 3 hreflang attributes per page (en, nl, x-default)
- No /nl/* routes generated yet — the user must create src/pages/nl/*.astro files to populate non-default locale routes. For Lighthouse on / this is intentional (isolates the perf impact to the switcher + hreflang only, with no new pages confounding the comparison).

https://claude.ai/code/session_01Af1puZemfrdRPQ9Sbk5NpJ

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
