### PR TITLE
Disable i18n on production until Dutch content exists

### DIFF
--- a/src/config/i18n.config.ts
+++ b/src/config/i18n.config.ts
@@ -32,9 +32,9 @@ export interface I18nConfig {
 }
 
 const i18nConfig: I18nConfig = {
-  enabled: true,
+  enabled: false,
   defaultLocale: 'en',
-  locales: ['en', 'nl'],
+  locales: ['en'],
   localeNames: {
     en: 'English',
     nl: 'Nederlands',


### PR DESCRIPTION
## Summary

PR #274 was merged and promoted to `astrorocket.dev` with i18n enabled (`locales: ['en', 'nl']`), but **no Dutch pages live under `src/pages/nl/`**. As a result, the production site is currently serving:

- A `LanguageSwitcher` dropdown listing "Nederlands" — clicking it goes to `/nl/<path>`, which returns **404**.
- `<link rel="alternate" hreflang="nl">` tags on every page pointing at those same 404 URLs.
- A sitemap that may now contain `/nl/*` entries that all 404.

This PR flips `enabled` back to `false` (the 1.3.0 default), restoring the single-locale behavior the live site expects.

## What changes

```diff
-  enabled: true,
+  enabled: false,
   defaultLocale: 'en',
-  locales: ['en', 'nl'],
+  locales: ['en'],
```

That's it. The whole i18n feature stays in the codebase, fully working — only the production flag is flipped off.

## Test plan

- [x] `pnpm build` with the change — confirmed 0 `hreflang` attrs and 0 `LanguageSwitcher` instances in `dist/client/index.html`, file count 80 (matches the 1.3.0 disabled-path baseline).
- [ ] **After merge & deploy:** verify `astrorocket.dev` no longer renders the LanguageSwitcher in the header.
- [ ] **After merge & deploy:** re-run Lighthouse mobile — should return to the 100/100/100/100 baseline from before #274.
- [ ] Verify `astrorocket.dev/sitemap-index.xml` no longer contains `/nl/*` entries.

## Future Dutch projects

When the time comes to ship a Dutch-language site on a different domain, the workflow stays simple: flip `enabled: true`, add the desired locales, and create `src/pages/<locale>/*.astro` files **before** deploying. The LanguageSwitcher and `hreflang` tags will pick those pages up automatically.

A follow-up will rewrite the LanguageSwitcher as a pure-CSS `<details>` dropdown so the enabled path also lands at 100/100 (currently a ~2-point drop from the inline JS).

https://claude.ai/code/session_01Af1puZemfrdRPQ9Sbk5NpJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af1puZemfrdRPQ9Sbk5NpJ)_