### PR TITLE
Swap Languages → Globe icon on i18n blog cover

### DIFF
--- a/src/assets/blog/i18n-in-astro-rocket.svg
+++ b/src/assets/blog/i18n-in-astro-rocket.svg
@@ -6,14 +6,11 @@
     .cor { stroke: var(--brand-300); stroke-width: 1.5; fill: none; stroke-opacity: 0.45; }
   </style>
   <rect width="1200" height="630" class="bg"/>
-  <!-- Lucide Languages -->
+  <!-- Lucide Globe -->
   <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
-    <path d="m5 8 6 6"/>
-    <path d="m4 14 6-6 2-3"/>
-    <path d="M2 5h12"/>
-    <path d="M7 2h1"/>
-    <path d="m22 22-5-10-5 10"/>
-    <path d="M14 18h6"/>
+    <circle cx="12" cy="12" r="10"/>
+    <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/>
+    <path d="M2 12h20"/>
   </g>
   <text x="600" y="435" font-size="92" text-anchor="middle" letter-spacing="-3" class="txt">i18n</text>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>

--- a/src/content/blog/en/i18n-in-astro-rocket.mdx
+++ b/src/content/blog/en/i18n-in-astro-rocket.mdx
@@ -8,7 +8,7 @@ featured: true
 locale: en
 image: "../../../assets/blog/i18n-in-astro-rocket.svg"
 svgSlug: "i18n-in-astro-rocket"
-imageAlt: "Lucide Languages icon centred on a brand-coloured background with the label 'i18n'"
+imageAlt: "Globe icon centred on a brand-coloured background with the label 'i18n'"
 ---
 
 Astro Rocket 1.3.0 ships native, opt-in internationalization. You can now run your site in two (or twenty) languages without leaving the theme — no scaffolding CLI, no plugins, no separate package. This post walks through what the feature is, what it costs (spoiler: nothing if you leave it off), and exactly how to turn it on for an English-plus-Dutch site.


### PR DESCRIPTION
## Summary

Swaps the cover image icon on the i18n blog post from Lucide `Languages` (an "A" with quotation marks — ambiguous without prior context) to Lucide `Globe` (circle with meridian curves and equator line — the universal symbol for "international").

Bonus: Globe is the same icon already used in the `LanguageSwitcher` trigger in the header, so the blog cover and the in-product UI now share visual language.

## Before / after

| Before (Languages) | After (Globe) |
|---|---|
| `path m5 8 6 6` (etc.) | `circle r=10` + meridian curves + equator |

Everything else on the cover is unchanged: brand-500 background, scale-5 icon transform, "i18n" label, corner brackets.

## Files

- `src/assets/blog/i18n-in-astro-rocket.svg` — icon swap
- `src/content/blog/en/i18n-in-astro-rocket.mdx` — `imageAlt` updated to match

## Test plan

- [x] `pnpm build` — clean
- [x] SVG inspected: `<circle>` + 2 meridian curves + equator path present
- [ ] **After merge & deploy:** check the post cover at `astrorocket.dev/blog/i18n-in-astro-rocket` shows the globe

https://claude.ai/code/session_01Af1puZemfrdRPQ9Sbk5NpJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af1puZemfrdRPQ9Sbk5NpJ)_