### PR TITLE
Update homepage hero gradient top color from brand-600 to brand-500

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -327,13 +327,13 @@
 
   /* Hero gradient — dark mode */
   .dark .hero-dark-gradient {
-    background: linear-gradient(to bottom, var(--color-brand-600) 0%, #000 100%);
+    background: linear-gradient(to bottom, var(--color-brand-500) 0%, #000 100%);
   }
 
   .hero-dark-gradient {
     position: relative;
     isolation: isolate;
-    background: linear-gradient(to bottom, var(--color-brand-600) 0%, #000 100%);
+    background: linear-gradient(to bottom, var(--color-brand-500) 0%, #000 100%);
   }
   html:not(.dark) .hero-dark-gradient {
     --color-foreground:           oklch(91% 0.008 250);


### PR DESCRIPTION
Switches the top of the hero gradient in both light and dark modes to a brighter brand-500, keeping black at the bottom.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
