### PR TITLE
perf(reveal): replace getBoundingClientRect bucketing with Intersecti…

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -388,54 +388,47 @@ schemas.push(...extraSchemas);
 
           if (!els.length) return;
 
-          // Above-the-fold = elements whose top is at least 25% inside the
-          // initial viewport. Anything just barely poking above the fold
-          // would otherwise animate while the user can't see it.
-          const fold = window.innerHeight * 0.75;
-          const aboveFold = [];
-          const belowFold = [];
-          els.forEach(function (el) {
-            const rect = el.getBoundingClientRect();
-            if (rect.top < fold && rect.bottom > 0) {
-              aboveFold.push(el);
-            } else {
-              belowFold.push(el);
-            }
-          });
-
-          aboveFold.forEach(function (el, i) {
-            setTimeout(function () {
-              el.classList.add('is-visible');
-            }, 250 + i * 80);
-          });
-
-          if (!belowFold.length) return;
-          // Negative bottom rootMargin: trigger only when the element is
-          // meaningfully on screen, so the user actually sees the animation
-          // play instead of finding it already finished.
+          // A single IntersectionObserver handles both initial above-the-fold
+          // stagger and below-the-fold scroll-triggered reveal. The previous
+          // implementation called getBoundingClientRect() on every element to
+          // bucket above/below fold, which Lighthouse flagged as ~50ms of
+          // forced reflow on mobile. The IntersectionObserver computes
+          // visibility asynchronously without forcing a synchronous layout.
           const eager = document.body.hasAttribute('data-eager-reveal');
+          let firstCallback = true;
+          let staggerIndex = 0;
+
           const observer = new IntersectionObserver(function (entries) {
+            const isFirst = firstCallback;
+            firstCallback = false;
             entries.forEach(function (entry) {
-              if (entry.isIntersecting) {
+              if (isFirst) {
+                // Initial dispatch: any intersection with the viewport
+                // counts as above-the-fold and gets a staggered reveal.
+                if (entry.isIntersecting) {
+                  const i = staggerIndex++;
+                  setTimeout(function () {
+                    entry.target.classList.add('is-visible');
+                  }, 250 + i * 80);
+                  observer.unobserve(entry.target);
+                }
+              } else if (entry.intersectionRatio >= 0.15) {
+                // Subsequent dispatches: only fire when the element is
+                // meaningfully on screen, so the animation actually plays
+                // where the user can see it.
                 entry.target.classList.add('is-visible');
                 observer.unobserve(entry.target);
               }
             });
-          }, { threshold: 0.15, rootMargin: eager ? '0px 0px -5% 0px' : '0px 0px -10% 0px' });
-          belowFold.forEach(function (el) { observer.observe(el); });
-        }
+          }, { threshold: [0, 0.15], rootMargin: eager ? '0px 0px -5% 0px' : '0px 0px -10% 0px' });
 
-        // Defer to the next frame so getBoundingClientRect reads happen
-        // after the browser has computed initial layout, turning a forced
-        // sync reflow into a cheap cached read.
-        function deferredInitReveal() {
-          requestAnimationFrame(initReveal);
+          els.forEach(function (el) { observer.observe(el); });
         }
 
         if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', deferredInitReveal);
+          document.addEventListener('DOMContentLoaded', initReveal);
         } else {
-          deferredInitReveal();
+          initReveal();
         }
       })();
     </script>


### PR DESCRIPTION
…onObserver

Lighthouse mobile flagged the reveal-on-scroll script in BaseLayout as ~50ms of forced reflow, costing 2 perf points. The script looped over every [data-reveal] element calling getBoundingClientRect() to bucket above/below the fold. Even deferred behind requestAnimationFrame, the batch synchronous layout read is expensive on mobile.

Use a single IntersectionObserver with thresholds [0, 0.15] instead. The first callback acts as the above-the-fold bucket (any intersection triggers the staggered reveal); subsequent callbacks handle below-the- fold elements when they reach the 15% threshold. Visibility is computed asynchronously, so no synchronous layout is forced.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
