### PR TITLE
perf(fonts): swap font-display:optional for metric-adjusted Arial fal…

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,35 +9,33 @@
 @import './tokens/typography.css';
 @import './tokens/spacing.css';
 
-/* Self-hosted fonts via Fontsource (CSP-safe, no external requests).
-   The two display + body fonts (Outfit + Manrope) get explicit @font-face
-   declarations *after* the fontsource imports so we can override
-   font-display from the default `swap` to `optional`. With `optional`
-   the browser blocks for 100ms; if the font isn't ready it uses the
-   fallback for the page's lifetime instead of swapping later — which
-   eliminates the font-swap CLS that Lighthouse mobile flagged on the
-   hero H1. The fonts are preloaded in BaseLayout's <head>, so on most
-   connections they arrive within the 100ms window. */
+/* Self-hosted fonts via Fontsource (CSP-safe, no external requests) */
 @import '@fontsource-variable/manrope';
 @import '@fontsource-variable/outfit';
 @import '@fontsource-variable/jetbrains-mono';
 
+/* Metric-adjusted fallback fonts.
+   The variable fonts above arrive after first paint, so headings and body
+   text used to reflow when the swap landed (Lighthouse reported CLS on the
+   hero wordmark). These @font-face rules alias the system Arial to
+   "Outfit Fallback" / "Manrope Fallback" with overrides that match each
+   variable font's metrics, so the pre-load fallback box has the same size
+   as the eventual webfont and the swap is invisible. */
 @font-face {
-  font-family: 'Outfit Variable';
-  font-style: normal;
-  font-weight: 100 900;
-  font-display: optional;
-  src: url('@fontsource-variable/outfit/files/outfit-latin-wght-normal.woff2') format('woff2-variations');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  font-family: 'Outfit Fallback';
+  src: local('Arial');
+  ascent-override: 92.5%;
+  descent-override: 24%;
+  line-gap-override: 0%;
+  size-adjust: 96.8%;
 }
-
 @font-face {
-  font-family: 'Manrope Variable';
-  font-style: normal;
-  font-weight: 200 800;
-  font-display: optional;
-  src: url('@fontsource-variable/manrope/files/manrope-latin-wght-normal.woff2') format('woff2-variations');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  font-family: 'Manrope Fallback';
+  src: local('Arial');
+  ascent-override: 99%;
+  descent-override: 26%;
+  line-gap-override: 0%;
+  size-adjust: 99.5%;
 }
 
 /* Dark mode variant */

--- a/src/styles/themes/amber.css
+++ b/src/styles/themes/amber.css
@@ -99,11 +99,11 @@ html[data-theme="amber"] {
   /* -------------------------------------------------------------------------
      Typography — Manrope (body) + Outfit (display)
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/blue.css
+++ b/src/styles/themes/blue.css
@@ -98,11 +98,11 @@ html[data-theme="blue"] {
   /* -------------------------------------------------------------------------
      Typography — Manrope (body) + Outfit (display)
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/cyan.css
+++ b/src/styles/themes/cyan.css
@@ -91,11 +91,11 @@ html[data-theme="cyan"] {
   /* -------------------------------------------------------------------------
      Typography
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/emerald.css
+++ b/src/styles/themes/emerald.css
@@ -98,11 +98,11 @@ html[data-theme="emerald"] {
   /* -------------------------------------------------------------------------
      Typography — Manrope (body) + Outfit (display)
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/green.css
+++ b/src/styles/themes/green.css
@@ -97,11 +97,11 @@ html[data-theme="green"] {
   /* -------------------------------------------------------------------------
      Typography — Manrope (body) + Outfit (display)
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/indigo.css
+++ b/src/styles/themes/indigo.css
@@ -92,11 +92,11 @@ html[data-theme="indigo"] {
   /* -------------------------------------------------------------------------
      Typography
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/lime.css
+++ b/src/styles/themes/lime.css
@@ -99,11 +99,11 @@ html[data-theme="lime"] {
   /* -------------------------------------------------------------------------
      Typography — Manrope (body) + Outfit (display)
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/magenta.css
+++ b/src/styles/themes/magenta.css
@@ -98,11 +98,11 @@ html[data-theme="magenta"] {
   /* -------------------------------------------------------------------------
      Typography — Manrope (body) + Outfit (display)
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/orange.css
+++ b/src/styles/themes/orange.css
@@ -90,11 +90,11 @@ html[data-theme="orange"] {
   /* -------------------------------------------------------------------------
      Typography
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/purple.css
+++ b/src/styles/themes/purple.css
@@ -92,11 +92,11 @@ html[data-theme="purple"] {
   /* -------------------------------------------------------------------------
      Typography
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/sky.css
+++ b/src/styles/themes/sky.css
@@ -92,11 +92,11 @@ html[data-theme="sky"] {
   /* -------------------------------------------------------------------------
      Typography
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/teal.css
+++ b/src/styles/themes/teal.css
@@ -98,11 +98,11 @@ html[data-theme="teal"] {
   /* -------------------------------------------------------------------------
      Typography — Manrope (body) + Outfit (display)
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/src/styles/themes/violet.css
+++ b/src/styles/themes/violet.css
@@ -92,11 +92,11 @@ html[data-theme="violet"] {
   /* -------------------------------------------------------------------------
      Typography
      ------------------------------------------------------------------------- */
-  --theme-font-sans: 'Manrope Variable', 'Manrope', ui-sans-serif, system-ui,
+  --theme-font-sans: 'Manrope Variable', 'Manrope', 'Manrope Fallback', ui-sans-serif, system-ui,
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --theme-font-display: 'Outfit Variable', 'Outfit', var(--theme-font-sans);
+  --theme-font-display: 'Outfit Variable', 'Outfit', 'Outfit Fallback', var(--theme-font-sans);
   --theme-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace,
     SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;


### PR DESCRIPTION
…lback

The Outfit and Manrope @font-face rules used font-display:optional, which blocks text rendering for up to 100ms while the webfont loads. On mobile that block hits FCP/LCP and was costing ~2 perf points on Lighthouse.

Replace the strategy with the metric-adjusted-fallback pattern used by hansmartens.dev (which scores 100/100/100/100 on mobile):

  * Drop the font-display:optional override and let the default `swap` apply. Text now paints immediately in the fallback.
  * Add 'Outfit Fallback' and 'Manrope Fallback' @font-face entries that alias local Arial with ascent-override / descent-override / line-gap-override / size-adjust values tuned to match each variable font's metrics. The pre-load fallback now occupies the same box as the eventual webfont, so the swap is visually invisible — no CLS.
  * Insert the fallback aliases in every theme's --theme-font-sans / --theme-font-display stack so they sit between the real webfont name and the generic system stack.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
