### PR TITLE
Fix mobile theme-mode dropdown bleeding through to swatches below

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1186,6 +1186,15 @@ const buttonId = `${menuId}-button`;
     }
   }
 
+  /* The stagger animation leaves `transform: translateY(0)` on each row,
+     which creates a stacking context per row. Without lifting the row that
+     owns an open dropdown, the panel's z-50 is trapped inside that row's
+     context and gets covered by later siblings (e.g. the colour-theme
+     swatches below it). */
+  .mobile-menu-stagger:has(.ttg-panel:not(.hidden)) {
+    z-index: 60;
+  }
+
   @keyframes mobileMenuItemIn {
     from {
       opacity: 0;


### PR DESCRIPTION
The mobile menu rows use a stagger-in animation that leaves transform: translateY(0) on each row, which creates a per-row stacking context. That trapped the ThemeModeDropdown panel's z-50 inside its own row, so the colour-theme swatches in the next row painted over it and showed through the panel.

Lift the row containing an open .ttg-panel via :has() so its absolute panel can stack above subsequent rows.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
