### PR TITLE
End mobile-menu stagger at transform: none

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1186,15 +1186,10 @@ const buttonId = `${menuId}-button`;
     }
   }
 
-  /* The stagger animation leaves `transform: translateY(0)` on each row,
-     which creates a stacking context per row. Without lifting the row that
-     owns an open dropdown, the panel's z-50 is trapped inside that row's
-     context and gets covered by later siblings (e.g. the colour-theme
-     swatches below it). */
-  .mobile-menu-stagger:has(.ttg-panel:not(.hidden)) {
-    z-index: 60;
-  }
-
+  /* End at `transform: none` (not translateY(0)) so each row drops its
+     stacking context after the entry animation. Otherwise the
+     ThemeModeDropdown panel's z-50 is trapped inside its row and the
+     colour-theme swatches in the next row paint through it. */
   @keyframes mobileMenuItemIn {
     from {
       opacity: 0;
@@ -1202,7 +1197,7 @@ const buttonId = `${menuId}-button`;
     }
     to {
       opacity: 1;
-      transform: translateY(0);
+      transform: none;
     }
   }
 </style>


### PR DESCRIPTION
The previous fix relied on z-index on the row to lift it above its siblings, but z-index only takes effect on positioned/flex/grid items, so the rule was a no-op. The deeper issue is that the entry animation ends with transform: translateY(0), which keeps each row as its own stacking context — trapping the ThemeModeDropdown panel's z-50 inside its row so later rows (the colour swatches) paint over it.

Land the keyframe on transform: none instead. After the animation the row no longer creates a stacking context, and the panel's z-50 stacks above subsequent rows naturally in every header variant.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
