### PR TITLE
Promote theme-mode row to its own stacking context while open

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1200,4 +1200,13 @@ const buttonId = `${menuId}-button`;
       transform: none;
     }
   }
+
+  /* While the theme-mode dropdown is open, promote its row to a positioned
+     stacking context above sibling rows. The row sits in a non-flex
+     <section>, so a bare `z-index` is inert — `position: relative` is what
+     lets the panel paint above the colour-theme swatches below it. */
+  .mobile-menu-stagger:has(.ttg-panel:not(.hidden)) {
+    position: relative;
+    z-index: 60;
+  }
 </style>


### PR DESCRIPTION
The previous fix landed each stagger keyframe at `transform: none` so rows would drop their stacking context after the entry animation. That helped, but the row is still a tree-order sibling of the colour-theme swatch row inside a non-flex <section>, so the dropdown panel's z-50 still couldn't escape its row in practice.

Use :has(.ttg-panel:not(.hidden)) to give the row `position: relative; z-index: 60` only while the panel is open. A bare z-index is inert on the row because it isn't a flex item; `position: relative` is what actually lets the panel paint above the swatches below.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
