### PR TITLE
style(home): match reference H1 sizing and mobile line breaks

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,9 +35,9 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   <Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator>
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">Available for new projects</Badge>
 
-    <h1 slot="title">
-      <span class="text-brand-600 dark:text-foreground [-webkit-text-fill-color:currentColor]">Astro Rocket —</span><br />
-      <span class="text-brand-600 dark:text-foreground [-webkit-text-fill-color:currentColor]">Web Designer</span><span class="text-brand-600 dark:text-foreground [-webkit-text-fill-color:currentColor]"> &amp; Developer</span>
+    <h1 slot="title" class="!text-[clamp(2rem,11.2vw,3rem)] sm:!text-5xl md:!text-6xl lg:!text-7xl">
+      <span class="text-brand-600 dark:text-foreground [-webkit-text-fill-color:currentColor] whitespace-nowrap">Astro Rocket —</span><br />
+      <span class="text-brand-600 dark:text-foreground [-webkit-text-fill-color:currentColor]">Web Designer</span><br class="md:hidden" /><span class="text-brand-600 dark:text-foreground [-webkit-text-fill-color:currentColor]"> &amp; Developer</span>
     </h1>
 
     <p slot="description">


### PR DESCRIPTION
Mirror the HansMartens repo H1 treatment on the homepage hero: fluid clamp() sizing with sm/md/lg overrides, whitespace-nowrap on the brand name, and an md:hidden break so "Astro Rocket —" / "Web Designer" / "& Developer" each get their own line in mobile portrait, while "Web Designer & Developer" merges to one line from md and up.

https://claude.ai/code/session_01Lh43pkfBMNnH7PHkMk5Dgc

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
