### PR TITLE
perf(hero): drop opacity animation from H1 title to free LCP

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1074,6 +1074,21 @@
 .animate-hero-stagger > *:nth-child(5)   { animation-delay: 360ms; }
 .animate-hero-stagger > *:nth-child(n+6) { animation-delay: 450ms; }
 
+/* The hero title slot is the LCP candidate. Animating its opacity (even
+   from 0.01) delays Chrome's LCP "render" timestamp by the full animation
+   duration — Lighthouse reported 2,250ms of element render delay caused
+   by exactly this. Override the title's animation to slide-only so the
+   text paints at full opacity from frame 0 and LCP fires immediately
+   after first paint. The 90ms stagger delay still applies. */
+.animate-hero-stagger > .hero-title-slot {
+  animation-name: hero-slide-up-no-fade;
+}
+
+@keyframes hero-slide-up-no-fade {
+  from { transform: translateY(40px); }
+  to   { transform: translateY(0); }
+}
+
 /* Floating header drop-in: lands from above as the hero rises from below.
    The translate values mirror the auto-hide hidden state so the entrance
    plays cleanly with the existing transition system. */


### PR DESCRIPTION
Lighthouse showed 2,250ms of LCP element render delay on the homepage H1 after the previous forced-reflow fix. Root cause: the hero-stagger animation starts the H1 at opacity 0.01 and animates to 1 over 1s. Modern Chrome's LCP algorithm does not accept very-low-opacity elements as rendered — the H1 is only counted as "painted" once opacity is visually meaningful, which lands near the end of the 1s animation. So LCP = first_paint + ~1100ms regardless of any other optimisation.

Override the title slot's animation to slide-only (no opacity change) so the text paints at full opacity from frame 0 and LCP fires as soon as the browser commits first paint. Badge / description / actions keep the original fade-in stagger.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
