### PR TITLE
Sync blog page layout and components from HansMartens

### DIFF
--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -36,7 +36,7 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
 ---
 
 <header class="relative overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section)]">
-<div class="relative mx-auto max-w-4xl px-6 animate-hero-stagger">
+  <div class="relative z-[1] mx-auto max-w-4xl px-6 animate-hero-stagger">
     <!-- Tags -->
     {tags.length > 0 && (
       <div class="mb-[var(--space-heading-gap)] flex flex-wrap gap-2">
@@ -105,16 +105,16 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
   </div>
 
   {(svgSlug || image) && (
-    <div class="relative mx-auto max-w-5xl px-6 mt-[var(--space-section)] animate-hero-slide-up [animation-delay:450ms]">
+    <div class="relative z-[1] mx-auto max-w-5xl px-6 mt-[var(--space-section)] animate-hero-slide-up [animation-delay:450ms]">
       {svgSlug ? (
         <div
-          class="relative overflow-hidden rounded-xl border border-border shadow-2xl"
+          class="relative overflow-hidden rounded-xl border border-border shadow-lg"
           style="color: var(--brand-500);"
         >
           <BlogImageSVG slug={svgSlug} title={imageAlt || title} />
         </div>
       ) : image ? (
-        <div class="relative overflow-hidden rounded-xl border border-border shadow-2xl">
+        <div class="relative overflow-hidden rounded-xl border border-border shadow-lg">
           <Image
             src={image}
             alt={imageAlt || title}

--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -34,11 +34,11 @@ const estimatedWords = description.split(' ').length * 10; // Rough estimate
 const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
 ---
 
-<article class="group rounded-lg border border-brand-500/30 bg-background p-6 ring-1 ring-brand-500/20 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-brand-500 hover:shadow-md" data-reveal>
+<article class="group rounded-lg border border-brand-500/30 bg-background p-6 shadow-md ring-1 ring-brand-500/20 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-brand-500 hover:shadow-lg" data-reveal>
 
   <a href={href} class="block">
     <div
-      class="relative mb-4 overflow-hidden rounded-md
+      class="relative mb-4 overflow-hidden rounded-md shadow-md ring-1 ring-border/60 transition-shadow duration-300 group-hover:shadow-lg
         bg-background-secondary bg-gradient-to-br from-brand-100/65 to-transparent dark:from-brand-900/60 dark:to-brand-600/25"
       style="color: var(--brand-500);"
     >

--- a/src/components/blog/BlogImageSVG.astro
+++ b/src/components/blog/BlogImageSVG.astro
@@ -21,15 +21,13 @@ const svgContent = svgs[`/src/assets/blog/${slug}.svg`] ?? '';
     display: block;
   }
 
-  @media (min-width: 640px) {
-    .svg-host :global(svg) {
-      transform: scale(1.35);
-      transform-origin: center center;
-    }
+  .svg-host :global(svg) {
+    transform: scale(1.35);
+    transform-origin: center center;
   }
 
   /* ── Light mode ─────────────────────────────────────────────────────────
-     Brand-500 background — the saturated mid-tone brand colour. Light
+     Brand-600 background — the saturated mid-tone brand colour. Light
      icons and text sit on top for vivid, colourful images in both modes.
   ── */
   .svg-host :global(.bg)  { fill: var(--brand-600); }

--- a/src/components/blog/ShareButtons.astro
+++ b/src/components/blog/ShareButtons.astro
@@ -12,6 +12,7 @@ const encodedUrl = encodeURIComponent(url);
 const shareLinks = {
   twitter: `https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`,
   linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+  bluesky: `https://bsky.app/intent/compose?text=${encodedTitle}%20${encodedUrl}`,
 };
 ---
 
@@ -42,6 +43,19 @@ const shareLinks = {
     >
       <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
         <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+      </svg>
+    </a>
+
+    <!-- Bluesky -->
+    <a
+      href={shareLinks.bluesky}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-brand-500 text-white border border-brand-500 transition-all hover:bg-brand-600 hover:border-brand-600"
+      aria-label="Share on Bluesky"
+    >
+      <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.815 2.736 3.713 3.66 6.383 3.364-3.912.58-7.387 2.005-2.83 7.078 5.013 5.19 6.87-1.113 7.823-4.308.953 3.195 2.05 9.271 7.733 4.308 4.267-4.308 1.172-6.498-2.74-7.078 2.67.297 5.568-.628 6.383-3.364.246-.828.624-5.79.624-6.478 0-.69-.139-1.861-.902-2.206-.659-.298-1.664-.62-4.3 1.24C16.046 4.748 13.087 8.687 12 10.8Z"/>
       </svg>
     </a>
 

--- a/src/components/blog/TableOfContents.astro
+++ b/src/components/blog/TableOfContents.astro
@@ -114,11 +114,31 @@ const headingId = `toc-heading-${Math.random().toString(36).slice(2, 9)}`;
     const setActive = (slug: string) => {
       if (slug === active) return;
       active = slug;
+      let activeLink: HTMLAnchorElement | null = null;
       for (const a of links) {
-        a.setAttribute(
-          'data-active',
-          a.getAttribute('data-toc-link') === slug ? 'true' : 'false',
-        );
+        const isActive = a.getAttribute('data-toc-link') === slug;
+        a.setAttribute('data-active', isActive ? 'true' : 'false');
+        if (isActive) activeLink = a;
+      }
+
+      // Auto-scroll the TOC container so the active link stays visible.
+      // Only does work when the TOC is itself scrollable (the sticky
+      // sidebar variant has max-height + overflow-y: auto); on the
+      // inline TOC scrollHeight === clientHeight, so the branch is a
+      // no-op.
+      if (activeLink && toc.scrollHeight > toc.clientHeight) {
+        const linkRect = activeLink.getBoundingClientRect();
+        const tocRect = toc.getBoundingClientRect();
+        const padding = 12;
+        let delta = 0;
+        if (linkRect.top < tocRect.top + padding) {
+          delta = linkRect.top - tocRect.top - padding;
+        } else if (linkRect.bottom > tocRect.bottom - padding) {
+          delta = linkRect.bottom - tocRect.bottom + padding;
+        }
+        if (delta !== 0) {
+          toc.scrollBy({ top: delta, behavior: 'smooth' });
+        }
       }
     };
 

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -61,3 +61,28 @@ export async function getPublishedPosts(
 export function collectTags(posts: CollectionEntry<'blog'>[]): string[] {
   return [...new Set(posts.flatMap((p) => p.data.tags))].sort();
 }
+
+/** Tag occurrence counts across the given posts, sorted by count desc then alpha. */
+export function collectTagsWithCounts(
+  posts: CollectionEntry<'blog'>[]
+): { tag: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const p of posts) {
+    for (const t of p.data.tags) {
+      counts.set(t, (counts.get(t) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
+/** The most-used tags across the given posts, capped at `limit`. */
+export function collectTopTags(
+  posts: CollectionEntry<'blog'>[],
+  limit: number
+): string[] {
+  return collectTagsWithCounts(posts)
+    .slice(0, limit)
+    .map((t) => t.tag);
+}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,15 +6,19 @@ import TagList from '@/components/blog/TagList.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import CTA from '@/components/ui/marketing/CTA/CTA.astro';
+import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 import { Hero } from '@/components/hero';
 import siteConfig from '@/config/site.config';
 import { resolveSocialLinks } from '@/lib/utils';
 import {
   BLOG_POSTS_PER_PAGE,
-  collectTags,
+  collectTopTags,
   getPostUrl,
   getPublishedPosts,
 } from '@/lib/blog';
+
+/** How many of the most-used tags to surface in the cloud. */
+const TAG_CLOUD_LIMIT = 10;
 
 const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
 
@@ -30,7 +34,7 @@ const regularPostsAll = nonFeaturedPosts.length > 0 ? nonFeaturedPosts : posts;
 const totalPages = Math.max(1, Math.ceil(regularPostsAll.length / BLOG_POSTS_PER_PAGE));
 const regularPosts = regularPostsAll.slice(0, BLOG_POSTS_PER_PAGE);
 
-const allTags = collectTags(posts);
+const topTags = collectTopTags(posts, TAG_CLOUD_LIMIT);
 ---
 
 <PageLayout title="Blog — Astro Rocket" description="Articles on web design, development, and the web by Astro Rocket." showScrollProgress eagerReveal>
@@ -50,7 +54,7 @@ const allTags = collectTags(posts);
     featuredPosts.length > 0 && (
       <section id="featured-section" class="bg-background-secondary py-[var(--space-section-md)] border-t border-border">
         <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
-          <h2 class="font-display text-foreground text-3xl md:text-4xl font-bold" data-reveal>
+          <h2 class="font-display text-foreground text-3xl md:text-4xl font-bold text-center" data-reveal>
             Featured
           </h2>
 
@@ -76,15 +80,15 @@ const allTags = collectTags(posts);
   <!-- All Posts Section -->
   <section class:list={[featuredPosts.length > 0 ? 'bg-background' : 'bg-background-secondary', 'py-[var(--space-section-md)] border-t border-border']}>
     <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
-      <div class="flex flex-wrap items-start justify-between gap-4" data-reveal>
+      <div class="flex flex-col items-center gap-4" data-reveal>
         {
           featuredPosts.length > 0 && nonFeaturedPosts.length > 0 && (
-            <h2 class="font-display text-foreground text-3xl md:text-4xl font-bold">All posts</h2>
+            <h2 class="font-display text-foreground text-3xl md:text-4xl font-bold text-center">All posts</h2>
           )
         }
 
-        {allTags.length > 0 && (
-          <TagList tags={allTags} class="ml-auto" />
+        {topTags.length > 0 && (
+          <TagList tags={topTags} class="justify-center" />
         )}
       </div>
 
@@ -123,7 +127,8 @@ const allTags = collectTags(posts);
   </section>
 
   <!-- Follow CTA Section -->
-  <CTA variant="default" size="md" maxWidth="lg" glow={false} data-reveal class:list={[featuredPosts.length > 0 && '!bg-background-secondary']}>
+  <!-- Mobile: standard CTA, no LetterGlitch -->
+  <CTA variant="default" size="md" maxWidth="lg" glow={false} data-reveal class:list={['glitch:hidden', featuredPosts.length > 0 && '!bg-background-secondary']}>
     <h2 slot="heading" class="!text-4xl">Follow along</h2>
     <p slot="description" class="!text-lg text-balance">Stay in the loop — new articles, thoughts, and updates.</p>
 
@@ -155,4 +160,40 @@ const allTags = collectTags(posts);
       </a>
     </div>
   </CTA>
+
+  <!-- Desktop: contained LetterGlitch band with glass card -->
+  <section class:list={['hidden glitch:block relative z-10 py-[var(--space-section-md)]', featuredPosts.length > 0 ? 'bg-background-secondary' : 'bg-background']}>
+    <LetterGlitchBand>
+      <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">Follow along</h2>
+      <p class="text-lg text-foreground-muted mb-8 text-balance">Stay in the loop — new articles, thoughts, and updates.</p>
+
+      <div class="flex flex-wrap items-center justify-center gap-3">
+        <a
+          href="/rss.xml"
+          class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-brand-400 hover:bg-brand-500/20 hover:text-foreground"
+        >
+          <Icon name="rss" size="sm" />
+          RSS Feed
+        </a>
+        {socialLinks.map((link) => (
+          <a
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-brand-400 hover:bg-brand-500/20 hover:text-foreground"
+          >
+            <Icon name={link.icon} size="sm" />
+            {link.label}
+          </a>
+        ))}
+        <a
+          href={`mailto:${siteConfig.email}`}
+          class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-brand-400 hover:bg-brand-500/20 hover:text-foreground"
+        >
+          <Icon name="mail" size="sm" />
+          Email
+        </a>
+      </div>
+    </LetterGlitchBand>
+  </section>
 </PageLayout>

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -11,10 +11,13 @@ import siteConfig from '@/config/site.config';
 import { resolveSocialLinks } from '@/lib/utils';
 import {
   BLOG_POSTS_PER_PAGE,
-  collectTags,
+  collectTopTags,
   getPostUrl,
   getPublishedPosts,
 } from '@/lib/blog';
+
+/** How many of the most-used tags to surface in the cloud. */
+const TAG_CLOUD_LIMIT = 10;
 
 export async function getStaticPaths() {
   const posts = await getPublishedPosts('en');
@@ -39,7 +42,7 @@ const regularPostsAll = nonFeatured.length > 0 ? nonFeatured : posts;
 const start = (page - 1) * BLOG_POSTS_PER_PAGE;
 const pagePosts = regularPostsAll.slice(start, start + BLOG_POSTS_PER_PAGE);
 
-const allTags = collectTags(posts);
+const topTags = collectTopTags(posts, TAG_CLOUD_LIMIT);
 
 const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
 ---
@@ -63,17 +66,17 @@ const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
 
   <section class="bg-background-secondary py-[var(--space-section-md)] border-t border-border">
     <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
-      <div class="flex flex-wrap items-start justify-between gap-4" data-reveal>
+      <div class="flex flex-col items-center gap-4" data-reveal>
         <a
           href="/blog"
-          class="inline-flex items-center gap-2 text-sm font-medium text-foreground-muted hover:text-brand-500 transition-colors"
+          class="inline-flex items-center gap-2 rounded-lg border border-border-strong bg-transparent px-4 py-2 text-sm font-medium text-foreground-muted hover:border-brand-500 hover:text-brand-500 transition-colors"
         >
           <Icon name="arrow-left" size="sm" />
           Newest posts
         </a>
 
-        {allTags.length > 0 && (
-          <TagList tags={allTags} class="ml-auto" />
+        {topTags.length > 0 && (
+          <TagList tags={topTags} class="justify-center" />
         )}
       </div>
 

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -8,31 +8,42 @@ import Button from '@/components/ui/form/Button/Button.astro';
 import { Hero } from '@/components/hero';
 import {
   collectTags,
+  collectTopTags,
   getPostUrl,
   getPublishedPosts,
   tagToSlug,
 } from '@/lib/blog';
 
 export async function getStaticPaths() {
+  // Inlined because Astro's getStaticPaths runs in its own isolated
+  // scope and can't see frontmatter-level consts.
+  const TAG_CLOUD_LIMIT = 10;
+
   const posts = await getPublishedPosts('en');
   const tags = collectTags(posts);
+  const topTags = collectTopTags(posts, TAG_CLOUD_LIMIT);
 
   return tags.map((tag) => {
     const postsForTag = posts.filter((p) => p.data.tags.includes(tag));
+    // Make sure the active tag is always present in the cloud, even if
+    // it's not popular enough to make the top N; otherwise the user
+    // lands on a tag page that doesn't visually acknowledge the tag.
+    const visibleTags = topTags.includes(tag)
+      ? topTags
+      : [tag, ...topTags.slice(0, TAG_CLOUD_LIMIT - 1)];
     return {
       params: { tag: tagToSlug(tag) },
-      props: { tag, posts: postsForTag, allTags: tags },
+      props: { tag, posts: postsForTag, visibleTags },
     };
   });
 }
 
-const { tag, posts, allTags } = Astro.props;
+const { tag, posts, visibleTags } = Astro.props;
 ---
 
 <PageLayout
   title={`#${tag} — Blog`}
-  description={`Posts tagged "${tag}" on the Astro Rocket blog.`}
-  image={`/og/blog/tag/${tagToSlug(tag)}.svg`}
+  description={`Posts tagged "${tag}".`}
   eagerReveal
 >
   <Hero layout="centered" size="sm">
@@ -53,17 +64,17 @@ const { tag, posts, allTags } = Astro.props;
 
   <section class="bg-background-secondary py-[var(--space-section-md)] border-t border-border">
     <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
-      <div class="flex flex-wrap items-center justify-between gap-4" data-reveal>
+      <div class="flex flex-col items-center gap-4" data-reveal>
         <a
           href="/blog"
-          class="inline-flex items-center gap-2 text-sm font-medium text-foreground-muted hover:text-brand-500 transition-colors"
+          class="inline-flex items-center gap-2 rounded-lg border border-border-strong bg-transparent px-4 py-2 text-sm font-medium text-foreground-muted hover:border-brand-500 hover:text-brand-500 transition-colors"
         >
           <Icon name="arrow-left" size="sm" />
           All posts
         </a>
 
-        {allTags.length > 1 && (
-          <TagList tags={allTags} active={tag} />
+        {visibleTags.length > 0 && (
+          <TagList tags={visibleTags} active={tag} class="justify-center" />
         )}
       </div>
 


### PR DESCRIPTION
Centre blog index/pagination/tag pages with a top-N tag cloud, restyle back-links as pill buttons, and add a desktop LetterGlitchBand variant of the Follow Along CTA. Add Bluesky share button, baseline shadows on blog cards, auto-scroll for the active TOC link, and minor stacking and scaling fixes in ArticleHero / BlogImageSVG.

https://claude.ai/code/session_01BPMtYid7EWwNTBeoAvj15S

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
