### PR TITLE
Sync single project page from HansMartens

### DIFF
--- a/src/components/projects/ProjectCarousel.astro
+++ b/src/components/projects/ProjectCarousel.astro
@@ -1,0 +1,225 @@
+---
+/**
+ * ProjectCarousel — swipeable image carousel for project heroes.
+ *
+ * - Native scroll-snap for touch swipe (zero JS for the swipe gesture itself)
+ * - Tiny vanilla script wires up prev/next buttons + active dot indicator
+ * - Keyboard: arrow keys move slides when any nav control has focus
+ * - First slide loads eagerly, the rest lazy — Lighthouse-friendly on mobile
+ */
+import { Image } from 'astro:assets';
+import type { ImageMetadata } from 'astro';
+
+interface Slide {
+  src: ImageMetadata;
+  alt: string;
+}
+
+interface Props {
+  slides: Slide[];
+  /** Optional aria-label for the carousel region. */
+  label?: string;
+}
+
+const { slides, label = 'Project screenshots' } = Astro.props;
+const carouselId = `carousel-${Math.random().toString(36).slice(2, 9)}`;
+const hasMultiple = slides.length > 1;
+---
+
+<div
+  class="project-carousel relative"
+  data-carousel
+  id={carouselId}
+  role="region"
+  aria-roledescription="carousel"
+  aria-label={label}
+>
+  <!-- Decorative brand glow behind the frame -->
+  <div
+    class="pointer-events-none absolute -inset-4 -z-10 rounded-2xl bg-brand-500/10 blur-2xl dark:bg-brand-500/15"
+    aria-hidden="true"
+  ></div>
+
+  <div class="relative overflow-hidden rounded-xl border border-border shadow-xl ring-1 ring-black/5 dark:ring-white/10">
+    <div
+      class="carousel-track flex snap-x snap-mandatory overflow-x-auto scroll-smooth"
+      data-carousel-track
+      tabindex="0"
+      aria-live="polite"
+    >
+      {slides.map((slide, i) => (
+        <div
+          class="carousel-slide w-full shrink-0 snap-center"
+          role="group"
+          aria-roledescription="slide"
+          aria-label={`${i + 1} of ${slides.length}`}
+          data-carousel-slide
+          data-index={i}
+        >
+          <Image
+            src={slide.src}
+            alt={slide.alt}
+            widths={[640, 960, 1280]}
+            sizes="(max-width: 1024px) 100vw, 640px"
+            class="aspect-video w-full object-cover"
+            loading={i === 0 ? 'eager' : 'lazy'}
+          />
+        </div>
+      ))}
+    </div>
+  </div>
+
+  {hasMultiple && (
+    <div class="mt-4 flex items-center justify-between gap-3">
+      <button
+        type="button"
+        class="carousel-nav inline-flex h-10 w-10 items-center justify-center rounded-lg border border-border-strong bg-background text-foreground shadow-sm transition-colors hover:border-brand-500 hover:bg-background-secondary hover:text-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+        data-carousel-prev
+        aria-label="Previous slide"
+        aria-controls={carouselId}
+      >
+        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+      </button>
+
+      <div class="flex items-center gap-3">
+        <div
+          class="flex items-center gap-2"
+          role="tablist"
+          aria-label="Choose slide"
+          data-carousel-dots
+        >
+          {slides.map((_, i) => (
+            <button
+              type="button"
+              class="carousel-dot h-2 w-2 rounded-full bg-border transition-all hover:bg-brand-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[active=true]:w-6 data-[active=true]:bg-brand-500"
+              data-carousel-dot
+              data-index={i}
+              role="tab"
+              aria-label={`Go to slide ${i + 1}`}
+              aria-selected={i === 0 ? 'true' : 'false'}
+              data-active={i === 0 ? 'true' : 'false'}
+            ></button>
+          ))}
+        </div>
+        <span
+          class="text-xs font-medium text-foreground-muted tabular-nums"
+          data-carousel-counter
+          aria-hidden="true"
+        >
+          <span data-carousel-current>1</span> / {slides.length}
+        </span>
+      </div>
+
+      <button
+        type="button"
+        class="carousel-nav inline-flex h-10 w-10 items-center justify-center rounded-lg border border-border-strong bg-background text-foreground shadow-sm transition-colors hover:border-brand-500 hover:bg-background-secondary hover:text-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+        data-carousel-next
+        aria-label="Next slide"
+        aria-controls={carouselId}
+      >
+        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+    </div>
+  )}
+</div>
+
+<style>
+  .carousel-track {
+    /* Hide native scrollbar — swipe gesture still works */
+    scrollbar-width: none;
+  }
+  .carousel-track::-webkit-scrollbar {
+    display: none;
+  }
+</style>
+
+<script>
+  function initProjectCarousels() {
+    const carousels = document.querySelectorAll<HTMLElement>(
+      '[data-carousel]:not([data-carousel-init])'
+    );
+
+    carousels.forEach((carousel) => {
+      carousel.setAttribute('data-carousel-init', 'true');
+
+      const track = carousel.querySelector<HTMLElement>('[data-carousel-track]');
+      const slides = carousel.querySelectorAll<HTMLElement>('[data-carousel-slide]');
+      const prevBtn = carousel.querySelector<HTMLButtonElement>('[data-carousel-prev]');
+      const nextBtn = carousel.querySelector<HTMLButtonElement>('[data-carousel-next]');
+      const dots = carousel.querySelectorAll<HTMLButtonElement>('[data-carousel-dot]');
+      const counter = carousel.querySelector<HTMLElement>('[data-carousel-current]');
+
+      if (!track || slides.length === 0) return;
+
+      const scrollToIndex = (index: number) => {
+        const slide = slides[index];
+        if (!slide) return;
+        track.scrollTo({ left: slide.offsetLeft, behavior: 'smooth' });
+      };
+
+      const currentIndex = () => {
+        // Find the slide whose left edge is closest to the current scrollLeft.
+        let closest = 0;
+        let smallestDiff = Infinity;
+        slides.forEach((slide, i) => {
+          const diff = Math.abs(slide.offsetLeft - track.scrollLeft);
+          if (diff < smallestDiff) {
+            smallestDiff = diff;
+            closest = i;
+          }
+        });
+        return closest;
+      };
+
+      prevBtn?.addEventListener('click', () => {
+        const i = currentIndex();
+        scrollToIndex(Math.max(0, i - 1));
+      });
+
+      nextBtn?.addEventListener('click', () => {
+        const i = currentIndex();
+        scrollToIndex(Math.min(slides.length - 1, i + 1));
+      });
+
+      dots.forEach((dot) => {
+        dot.addEventListener('click', () => {
+          const i = parseInt(dot.dataset.index ?? '0', 10);
+          scrollToIndex(i);
+        });
+      });
+
+      // Keyboard nav when the track is focused
+      track.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'ArrowLeft') {
+          e.preventDefault();
+          scrollToIndex(Math.max(0, currentIndex() - 1));
+        } else if (e.key === 'ArrowRight') {
+          e.preventDefault();
+          scrollToIndex(Math.min(slides.length - 1, currentIndex() + 1));
+        }
+      });
+
+      // Track active slide on scroll to update dots + counter
+      let scrollTimeout: number | undefined;
+      track.addEventListener('scroll', () => {
+        if (scrollTimeout) window.clearTimeout(scrollTimeout);
+        scrollTimeout = window.setTimeout(() => {
+          const i = currentIndex();
+          dots.forEach((dot, j) => {
+            const active = i === j;
+            dot.dataset.active = active ? 'true' : 'false';
+            dot.setAttribute('aria-selected', active ? 'true' : 'false');
+          });
+          if (counter) counter.textContent = String(i + 1);
+        }, 80);
+      }, { passive: true });
+    });
+  }
+
+  initProjectCarousels();
+  document.addEventListener('astro:after-swap', initProjectCarousels);
+</script>

--- a/src/components/projects/ProjectGallery.astro
+++ b/src/components/projects/ProjectGallery.astro
@@ -21,7 +21,7 @@ const id = Math.random().toString(36).slice(2, 8);
     <!-- Carousel track -->
     <div
       id={`track-${id}`}
-      class="flex overflow-x-auto snap-x snap-mandatory rounded-xl border border-border"
+      class="flex overflow-x-auto snap-x snap-mandatory rounded-xl border border-border shadow-xl"
       style="scrollbar-width: none;"
     >
       {images.map((img, i) => (

--- a/src/components/projects/ProjectHero.astro
+++ b/src/components/projects/ProjectHero.astro
@@ -3,6 +3,12 @@ import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
+import ProjectCarousel from '@/components/projects/ProjectCarousel.astro';
+
+interface GallerySlide {
+  src: ImageMetadata;
+  alt: string;
+}
 
 interface Props {
   title: string;
@@ -12,10 +18,12 @@ interface Props {
   client?: string;
   role?: string;
   services?: string[];
+  meta?: string[];
   url?: string;
   repo?: string;
   image?: ImageMetadata;
   imageAlt?: string;
+  gallery?: GallerySlide[];
 }
 
 const {
@@ -25,108 +33,89 @@ const {
   year,
   client,
   role,
+  services = [],
+  meta = [],
   url,
   repo,
   image,
   imageAlt,
+  gallery = [],
 } = Astro.props;
 
-const hasMeta = year || client || role;
+// Prefer gallery when provided; fall back to the single hero image; build a
+// 1-slide carousel out of the image so the visual frame stays consistent.
+const slides: GallerySlide[] =
+  gallery.length > 0
+    ? gallery
+    : image
+      ? [{ src: image, alt: imageAlt || title }]
+      : [];
+const hasMedia = slides.length > 0;
 ---
 
-<header class="relative overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section)]">
-  <div class="relative mx-auto max-w-4xl px-6 animate-hero-stagger">
+<header class="relative overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section-md)]">
+  <!-- Soft brand wash behind the hero -->
+  <div
+    class="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[60%]
+           bg-[radial-gradient(ellipse_at_top,var(--color-brand-500)/8%,transparent_70%)]
+           dark:bg-[radial-gradient(ellipse_at_top,var(--color-brand-500)/12%,transparent_70%)]"
+    aria-hidden="true"
+  ></div>
 
-    <!-- Tags -->
-    {tags.length > 0 && (
-      <div class="mb-[var(--space-heading-gap)] flex flex-wrap gap-2">
-        {tags.map((tag) => (
-          <span class="inline-flex items-center rounded-full bg-brand-100 dark:bg-brand-900/30 px-3 py-1 text-xs font-semibold text-brand-700 dark:text-brand-300 ring-1 ring-inset ring-brand-200 dark:ring-brand-800">
-            {tag}
-          </span>
-        ))}
-      </div>
-    )}
+  <div class="mx-auto max-w-7xl px-6">
+    <div
+      class:list={[
+        'grid items-center gap-10',
+        hasMedia && 'lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] lg:gap-14',
+      ]}
+    >
+      <!-- Text column -->
+      <div class="animate-hero-stagger min-w-0">
+        <h1 class="font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl lg:text-6xl mb-[var(--space-heading-gap)] text-balance">
+          {title}
+        </h1>
 
-    <!-- Title -->
-    <h1 class="font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl lg:text-6xl mb-[var(--space-heading-gap)]">
-      {title}
-    </h1>
+        <p class="text-lg md:text-xl text-foreground-muted leading-relaxed mb-[var(--space-stack-lg)]">
+          {description}
+        </p>
 
-    <!-- Description -->
-    <p class="text-xl text-foreground-muted leading-relaxed max-w-3xl mb-[var(--space-stack-lg)]">
-      {description}
-    </p>
+        {meta.length > 0 && (
+          <p class="mb-[var(--space-stack-lg)] flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-foreground-muted">
+            {meta.map((item, i) => (
+              <>
+                {i > 0 && (
+                  <span class="text-brand-500" aria-hidden="true">·</span>
+                )}
+                <span>{item}</span>
+              </>
+            ))}
+          </p>
+        )}
 
-    <!-- Meta row -->
-    {hasMeta && (
-      <div class="flex flex-wrap items-center gap-[var(--space-stack-lg)] text-sm text-foreground-muted mb-[var(--space-stack-lg)]">
-        {year && (
-          <div class="flex items-center gap-2">
-            <svg class="h-5 w-5 text-foreground-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
-            </svg>
-            <span>{year}</span>
+        {(url || repo) && (
+          <div class="flex flex-wrap gap-3 mb-[var(--space-stack-lg)]">
+            {url && (
+              <Button href={url} target="_blank" rel="noopener noreferrer" size="md">
+                <Icon name="external-link" size="sm" />
+                View live site
+              </Button>
+            )}
+            {repo && (
+              <Button href={repo} target="_blank" rel="noopener noreferrer" variant="outline" size="md">
+                <Icon name="github" size="sm" />
+                View source
+              </Button>
+            )}
           </div>
         )}
-
-        {client && (
-          <>
-            {year && <div class="h-8 w-px bg-border hidden md:block" aria-hidden="true"></div>}
-            <div class="flex items-center gap-2">
-              <svg class="h-5 w-5 text-foreground-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
-              </svg>
-              <span>{client}</span>
-            </div>
-          </>
-        )}
-
-        {role && (
-          <>
-            {(year || client) && <div class="h-8 w-px bg-border hidden md:block" aria-hidden="true"></div>}
-            <div class="flex items-center gap-2">
-              <svg class="h-5 w-5 text-foreground-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 00.75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 00-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0112 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 01-.673-.38m0 0A2.18 2.18 0 013 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 013.413-.387m7.5 0V5.25A2.25 2.25 0 0013.5 3h-3a2.25 2.25 0 00-2.25 2.25v.894m7.5 0a48.667 48.667 0 00-7.5 0M12 12.75h.008v.008H12v-.008z" />
-              </svg>
-              <span>{role}</span>
-            </div>
-          </>
-        )}
       </div>
-    )}
 
-    <!-- Action buttons -->
-    {(url || repo) && (
-      <div class="flex flex-wrap gap-3">
-        {url && (
-          <Button href={url} target="_blank" rel="noopener noreferrer" size="md">
-            <Icon name="external-link" size="sm" />
-            View live site
-          </Button>
-        )}
-        {repo && (
-          <Button href={repo} target="_blank" rel="noopener noreferrer" variant="outline" size="md">
-            <Icon name="github" size="sm" />
-            View source
-          </Button>
-        )}
-      </div>
-    )}
-  </div>
-
-  {image && (
-    <div class="relative mx-auto max-w-5xl px-6 mt-[var(--space-section)] animate-hero-slide-up [animation-delay:450ms]">
-      <div class="relative overflow-hidden rounded-xl border border-border shadow-2xl">
-        <Image
-          src={image}
-          alt={imageAlt || title}
-          widths={[640, 960, 1280, 1920]}
-          sizes="(max-width: 640px) 640px, (max-width: 960px) 960px, (max-width: 1280px) 1280px, 1920px"
-          class="aspect-video w-full object-cover"
-          loading="eager"
-        />
-      </div>
+      <!-- Media column (carousel or single image) -->
+      {hasMedia && (
+        <div class="animate-hero-slide-up [animation-delay:300ms]">
+          <ProjectCarousel slides={slides} label={`${title} screenshots`} />
+        </div>
+      )}
     </div>
-  )}
+  </div>
 </header>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -78,6 +78,15 @@ const projects = defineCollection({
       repo: z.string().url().optional(),
       image: image().optional(),
       imageAlt: z.string().optional(),
+      /** Optional gallery — when provided, renders a swipeable carousel in the hero in place of the single `image`. */
+      gallery: z
+        .array(
+          z.object({
+            src: image(),
+            alt: z.string(),
+          })
+        )
+        .default([]),
       tags: z.array(z.string()).default([]),
       featured: z.boolean().default(false),
       order: z.number().default(99),
@@ -85,7 +94,12 @@ const projects = defineCollection({
       client: z.string().optional(),
       role: z.string().optional(),
       services: z.array(z.string()).default([]),
+      /** Optional editorial tagline — short facts rendered as a single line under the hero description with brand-coloured dot separators. */
+      meta: z.array(z.string()).default([]),
       draft: z.boolean().default(false),
+      placeholder: z.boolean().default(false),
+      /** Per-project override: hide table of contents on this project */
+      toc: z.boolean().optional(),
     }),
 });
 

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -1,12 +1,22 @@
 ---
-import type { ImageMetadata } from 'astro';
+import type { ImageMetadata, MarkdownHeading } from 'astro';
 import type { CollectionEntry } from 'astro:content';
+import { Image } from 'astro:assets';
+
+interface GallerySlide {
+  src: ImageMetadata;
+  alt: string;
+}
 import BaseLayout from './BaseLayout.astro';
 import Header from '@/components/layout/Header.astro';
 import Footer from '@/components/layout/Footer.astro';
 import Breadcrumbs from '@/components/seo/Breadcrumbs.astro';
 import ProjectHero from '@/components/projects/ProjectHero.astro';
+import TableOfContents from '@/components/blog/TableOfContents.astro';
+import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 import Card from '@/components/ui/data-display/Card/Card.astro';
+import Badge from '@/components/ui/data-display/Badge/Badge.astro';
+import Button from '@/components/ui/form/Button/Button.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import siteConfig from '@/config/site.config';
 import { getProjectOgPath } from '@/lib/og';
@@ -18,14 +28,19 @@ interface Props {
   client?: string;
   role?: string;
   services?: string[];
+  meta?: string[];
   url?: string;
   repo?: string;
   tags?: string[];
   image?: ImageMetadata;
   imageAlt?: string;
+  gallery?: GallerySlide[];
   /** Project slug, used to resolve the per-project dynamic OG image. */
   slug?: string;
   related?: CollectionEntry<'projects'>[];
+  headings?: MarkdownHeading[];
+  /** Per-project override: hide table of contents on this project */
+  toc?: boolean;
 }
 
 const {
@@ -35,18 +50,34 @@ const {
   client,
   role,
   services = [],
+  meta = [],
   url,
   repo,
   tags = [],
   image,
   imageAlt,
+  gallery = [],
   slug,
   related = [],
+  headings = [],
+  toc: tocOverride,
 } = Astro.props;
 
 // Prefer the project's own image; otherwise serve the per-project dynamic OG
 // image (see src/pages/og/projects/[slug].svg.ts).
 const ogImage = image?.src || (slug ? getProjectOgPath(slug) : siteConfig.ogImage);
+
+// Mirror the blog TOC wiring — projects use the same site-wide config.
+const tocConfig = siteConfig.articleFeatures?.toc;
+const showToc = !!tocConfig?.enabled && tocOverride !== false;
+const tocLayout = tocConfig?.layout ?? 'auto';
+const sidebarActive = showToc && (tocLayout === 'sidebar' || tocLayout === 'auto');
+// Inline TOC is now opt-in: 'auto' shows only the desktop sidebar so the
+// mobile/landscape/tablet experience isn't dominated by a TOC card the
+// majority of visitors don't use. Posts that want the inline TOC visible
+// everywhere can set `toc.layout: 'inline'` in frontmatter.
+const inlineActive = showToc && tocLayout === 'inline';
+const sidebarOnLeft = (tocConfig?.sidebarPosition ?? 'right') === 'left';
 
 const breadcrumbs = [
   { label: 'Home', href: '/' },
@@ -69,6 +100,7 @@ const breadcrumbs = [
     size="lg"
     showCta={false}
     showScrollProgress
+    maxWidth={sidebarActive ? '7xl' : '6xl'}
   />
 
   <div class="min-h-screen pt-16">
@@ -80,61 +112,119 @@ const breadcrumbs = [
       client={client}
       role={role}
       services={services}
+      meta={meta}
       url={url}
       repo={repo}
       image={image}
       imageAlt={imageAlt}
+      gallery={gallery}
     />
 
     <article class="pt-8 pb-[var(--space-section-md)]">
-      <div class="mx-auto max-w-4xl px-6">
-        <Breadcrumbs items={breadcrumbs} class="mb-8" />
+      <div class:list={[
+        'mx-auto px-6',
+        sidebarActive && (sidebarOnLeft
+          ? 'max-w-7xl xl:grid xl:grid-cols-[15rem_minmax(0,1fr)] xl:gap-10'
+          : 'max-w-7xl xl:grid xl:grid-cols-[minmax(0,1fr)_15rem] xl:gap-10'),
+        !sidebarActive && 'max-w-4xl',
+      ]}>
+        {sidebarActive && sidebarOnLeft && (
+          <aside class="hidden xl:block" aria-label="Table of contents">
+            <TableOfContents
+              headings={headings}
+              maxDepth={tocConfig?.maxDepth ?? 3}
+              minHeadings={tocConfig?.minHeadings ?? 3}
+              sticky
+            />
+          </aside>
+        )}
 
-        <div class="prose prose-lg max-w-none" data-reveal-content>
-          <slot />
+        <div class:list={[sidebarActive && 'min-w-0 max-w-4xl w-full mx-auto xl:mx-0']}>
+          <Breadcrumbs items={breadcrumbs} class="mb-8" />
+
+          {inlineActive && (
+            <div class="mb-10 rounded-xl border border-border bg-background-secondary p-5">
+              <TableOfContents
+                headings={headings}
+                maxDepth={tocConfig?.maxDepth ?? 3}
+                minHeadings={tocConfig?.minHeadings ?? 3}
+              />
+            </div>
+          )}
+
+          <div class="prose prose-lg max-w-none" data-reveal-content>
+            <slot />
+          </div>
+
+          <footer class="border-border mt-12 border-t pt-8" data-reveal>
+            <a
+              href="/projects"
+              class="text-brand-600 hover:text-brand-500 dark:text-brand-400 dark:hover:text-brand-300 inline-flex items-center gap-2 text-sm font-medium transition-colors"
+            >
+              <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+              </svg>
+              Back to Projects
+            </a>
+          </footer>
         </div>
 
-        <footer class="border-border mt-12 border-t pt-8" data-reveal>
-          <a
-            href="/projects"
-            class="text-brand-600 hover:text-brand-500 dark:text-brand-400 dark:hover:text-brand-300 inline-flex items-center gap-2 text-sm font-medium transition-colors"
-          >
-            <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-            </svg>
-            Back to Projects
-          </a>
-        </footer>
+        {sidebarActive && !sidebarOnLeft && (
+          <aside class="hidden xl:block" aria-label="Table of contents">
+            <TableOfContents
+              headings={headings}
+              maxDepth={tocConfig?.maxDepth ?? 3}
+              minHeadings={tocConfig?.minHeadings ?? 3}
+              sticky
+            />
+          </aside>
+        )}
       </div>
     </article>
 
     {related.length > 0 && (
       <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border" data-reveal>
-        <div class="mx-auto max-w-4xl px-6">
-          <h2 class="font-display text-2xl font-bold text-foreground mb-6">More projects</h2>
+        <div class="mx-auto max-w-6xl px-6">
+          <h2 class="font-display text-2xl md:text-3xl font-bold text-foreground mb-8">More projects</h2>
           <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {related.map((project) => (
               <Card
                 variant="elevated"
                 hover
-                padding="lg"
+                padding="none"
                 href={`/projects/${project.id.replace(/\.mdx?$/, '')}`}
-                class="group flex flex-col"
+                class="group flex flex-col overflow-hidden"
               >
-                <div class="flex flex-1 flex-col">
-                  <div class="mb-3 flex items-start justify-between gap-4">
-                    <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
-                      <Icon name="layers" size="sm" />
-                    </div>
-                    <Icon name="arrow-up-right" size="sm" class="text-foreground-muted group-hover:text-brand-500 transition-colors shrink-0" />
+                {project.data.image ? (
+                  <div class="overflow-hidden p-5 pb-0">
+                    <Image
+                      src={project.data.image}
+                      alt={project.data.imageAlt || project.data.title}
+                      widths={[400, 600]}
+                      sizes="(max-width: 640px) 100vw, 400px"
+                      class="block h-auto w-full rounded-md shadow-md ring-1 ring-border/60 transition-transform duration-300 group-hover:scale-[1.02]"
+                      loading="lazy"
+                    />
                   </div>
-                  <div class="mb-2 flex items-baseline gap-2">
+                ) : (
+                  <div class="p-5 pb-0">
+                    <div class="aspect-video w-full rounded-md shadow-md ring-1 ring-border/60 bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center">
+                      <Icon name="layers" size="md" class="text-brand-500" />
+                    </div>
+                  </div>
+                )}
+                <div class="flex flex-1 flex-col p-5">
+                  <div class="mb-2 flex items-baseline justify-between gap-2">
                     <h3 class="font-display text-base font-bold text-foreground">{project.data.title}</h3>
                     {project.data.year && (
-                      <span class="text-xs text-foreground-muted">{project.data.year}</span>
+                      <span class="text-xs text-foreground-muted shrink-0">{project.data.year}</span>
                     )}
                   </div>
-                  <p class="text-sm text-foreground-muted leading-relaxed flex-1">{project.data.description}</p>
+                  <p class="text-sm text-foreground-muted leading-relaxed mb-4">{project.data.description}</p>
+                  <span class="inline-flex items-center gap-1.5 text-sm font-medium text-brand-500">
+                    View project
+                    <Icon name="arrow-right" size="sm" class="transition-transform duration-300 group-hover:translate-x-1" />
+                  </span>
                 </div>
               </Card>
             ))}
@@ -142,7 +232,56 @@ const breadcrumbs = [
         </div>
       </section>
     )}
+
+    <!-- Closing CTA -->
+    <section class="relative z-10 py-[var(--space-section-md)] bg-background border-t border-border">
+      <!-- Mobile: flat section, no glitch band -->
+      <div class="glitch:hidden mx-auto max-w-2xl px-6 text-center" data-reveal>
+        <Badge variant="brand" pill class="mb-6">Let's talk</Badge>
+        <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
+          Have a project in mind?
+        </h2>
+        <p class="text-lg text-foreground-muted mb-8 text-balance">
+          Whether it's a new build or something that needs a fresh perspective — I'd love to hear about it.
+        </p>
+        <div class="flex flex-col sm:flex-row gap-4 justify-center">
+          <Button size="lg" href="/contact" class="cta-btn-brand">
+            Start a project
+            <Icon name="arrow-right" size="sm" />
+          </Button>
+          <Button size="lg" variant="outline" href="/projects">
+            All projects
+            <Icon name="arrow-right" size="sm" />
+          </Button>
+        </div>
+      </div>
+
+      <!-- Desktop: LetterGlitch band with glass card -->
+      <LetterGlitchBand>
+        <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
+          Have a project in mind?
+        </h2>
+        <p class="text-lg text-foreground-muted mb-8 text-balance">
+          Whether it's a new build or something that needs a fresh perspective — I'd love to hear about it.
+        </p>
+        <div class="flex flex-col sm:flex-row gap-4 justify-center">
+          <Button size="lg" href="/contact" class="hero-btn-brand">
+            Start a project
+            <Icon name="arrow-right" size="sm" />
+          </Button>
+          <Button size="lg" variant="outline" href="/projects">
+            All projects
+            <Icon name="arrow-right" size="sm" />
+          </Button>
+        </div>
+      </LetterGlitchBand>
+    </section>
   </div>
 
-  <Footer slot="footer" layout="simple" background="secondary" />
+  <Footer
+    slot="footer"
+    layout="simple"
+    background="secondary"
+    maxWidth={sidebarActive ? '7xl' : '6xl'}
+  />
 </BaseLayout>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -4,6 +4,7 @@ import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
   const allProjects = await getCollection('projects', ({ data }) => {
+    if (data.placeholder) return false;
     return import.meta.env.PROD ? data.draft !== true : true;
   });
 
@@ -19,7 +20,7 @@ export async function getStaticPaths() {
 }
 
 const { project, related } = Astro.props;
-const { Content } = await render(project);
+const { Content, headings } = await render(project);
 ---
 
 <ProjectLayout
@@ -29,13 +30,17 @@ const { Content } = await render(project);
   client={project.data.client}
   role={project.data.role}
   services={project.data.services}
+  meta={project.data.meta}
   url={project.data.url}
   repo={project.data.repo}
   tags={project.data.tags}
   image={project.data.image}
   imageAlt={project.data.imageAlt}
+  gallery={project.data.gallery}
   slug={project.id.replace(/\.mdx?$/, '')}
   related={related}
+  headings={headings}
+  toc={project.data.toc}
 >
   <Content />
 </ProjectLayout>


### PR DESCRIPTION
Redesign individual project pages with a 2-column hero (text + image carousel), optional sidebar TOC, restyled "More projects" grid, and a new "Have a project in mind?" CTA section with a LetterGlitchBand on desktop. Adds ProjectCarousel component and extends the project schema with optional gallery, meta, placeholder, and toc fields.

Keeps the dynamic per-project OG image fallback (getProjectOgPath) since it's a useful default for theme adopters who haven't set a project image.

Drops showGitHubPill from the layout (not supported by the current Header) and the dead 'auto' branch from inlineActive's class list.

https://claude.ai/code/session_01BPMtYid7EWwNTBeoAvj15S

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
