### PR TITLE
Show branded placeholder in project hero when no image is provided

### DIFF
--- a/src/components/projects/ProjectHero.astro
+++ b/src/components/projects/ProjectHero.astro
@@ -66,7 +66,7 @@ const hasMedia = slides.length > 0;
     <div
       class:list={[
         'grid items-center gap-10',
-        hasMedia && 'lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] lg:gap-14',
+        'lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] lg:gap-14',
       ]}
     >
       <!-- Text column -->
@@ -110,12 +110,19 @@ const hasMedia = slides.length > 0;
         )}
       </div>
 
-      <!-- Media column (carousel or single image) -->
-      {hasMedia && (
-        <div class="animate-hero-slide-up [animation-delay:300ms]">
+      <!-- Media column (carousel, single image, or branded placeholder) -->
+      <div class="animate-hero-slide-up [animation-delay:300ms]">
+        {hasMedia ? (
           <ProjectCarousel slides={slides} label={`${title} screenshots`} />
-        </div>
-      )}
+        ) : (
+          <div
+            class="aspect-video w-full rounded-xl border border-border bg-gradient-to-br from-brand-500/20 via-brand-500/5 to-transparent flex items-center justify-center shadow-lg"
+            aria-hidden="true"
+          >
+            <Icon name="layers" size="lg" class="text-brand-500/60" />
+          </div>
+        )}
+      </div>
     </div>
   </div>
 </header>


### PR DESCRIPTION
Projects without an image or gallery now render a brand-gradient panel with a layers icon in the media column instead of collapsing the hero to a single column. Keeps the 2-column hero layout consistent across all projects in the theme, matching the pattern already used by BlogCard and the "More projects" grid for image-less entries.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
