### PR TITLE
Add dark-mode brand glow blobs to hero and CTA sections

### DIFF
--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -36,6 +36,11 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
 ---
 
 <header class="relative overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section)]">
+  <div
+    class="pointer-events-none absolute left-1/2 -top-40 -z-10 h-[36rem] w-[180vw] max-w-none -translate-x-1/2 rounded-[50%] blur-3xl dark:bg-brand-500/20"
+    aria-hidden="true"
+  ></div>
+
   <div class="relative z-[1] mx-auto max-w-4xl px-6 animate-hero-stagger">
     <!-- Tags -->
     {tags.length > 0 && (

--- a/src/components/patterns/LetterGlitchBand.astro
+++ b/src/components/patterns/LetterGlitchBand.astro
@@ -3,13 +3,19 @@ import LetterGlitch from '@/components/effects/LetterGlitch';
 ---
 
 <div class="hidden glitch:block mx-auto max-w-6xl px-6">
-  <div class="invert-section relative overflow-hidden rounded-3xl border border-white/10">
-    <div class="absolute inset-0" aria-hidden="true">
-      <LetterGlitch client:visible outerVignette />
-    </div>
-    <div class="relative z-10 px-6 py-16 sm:py-24" data-reveal>
-      <div class="mx-auto max-w-2xl rounded-2xl border border-white/10 bg-brand-900/85 px-6 py-10 sm:px-10 text-center shadow-xl backdrop-blur-md">
-        <slot />
+  <div class="relative isolate">
+    <div
+      class="pointer-events-none absolute inset-0 -z-10 rounded-3xl blur-3xl dark:bg-brand-500/25"
+      aria-hidden="true"
+    ></div>
+    <div class="invert-section relative overflow-hidden rounded-3xl border border-white/10">
+      <div class="absolute inset-0" aria-hidden="true">
+        <LetterGlitch client:visible outerVignette />
+      </div>
+      <div class="relative z-10 px-6 py-16 sm:py-24" data-reveal>
+        <div class="mx-auto max-w-2xl rounded-2xl border border-white/10 bg-brand-900/85 px-6 py-10 sm:px-10 text-center shadow-xl backdrop-blur-md">
+          <slot />
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/projects/ProjectCarousel.astro
+++ b/src/components/projects/ProjectCarousel.astro
@@ -34,9 +34,8 @@ const hasMultiple = slides.length > 1;
   aria-roledescription="carousel"
   aria-label={label}
 >
-  <!-- Decorative brand glow behind the frame -->
   <div
-    class="pointer-events-none absolute -inset-4 -z-10 rounded-2xl bg-brand-500/10 blur-2xl dark:bg-brand-500/15"
+    class="pointer-events-none absolute -inset-4 -z-10 rounded-2xl blur-2xl dark:bg-brand-500/15"
     aria-hidden="true"
   ></div>
 

--- a/src/components/projects/ProjectHero.astro
+++ b/src/components/projects/ProjectHero.astro
@@ -54,11 +54,8 @@ const hasMedia = slides.length > 0;
 ---
 
 <header class="relative overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section-md)]">
-  <!-- Soft brand wash behind the hero -->
   <div
-    class="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[60%]
-           bg-[radial-gradient(ellipse_at_top,var(--color-brand-500)/8%,transparent_70%)]
-           dark:bg-[radial-gradient(ellipse_at_top,var(--color-brand-500)/12%,transparent_70%)]"
+    class="pointer-events-none absolute left-1/2 -top-40 -z-10 h-[36rem] w-[180vw] max-w-none -translate-x-1/2 rounded-[50%] blur-3xl dark:bg-brand-500/20"
     aria-hidden="true"
   ></div>
 


### PR DESCRIPTION
Add subtle, dark-mode-only brand-tinted glow blobs to the blog article hero, project hero, project carousel, and LetterGlitch CTA band. Each glow renders nothing in light mode and uses only the dark: variant.

Replaces the invalid var()/alpha% radial-gradient wash on ProjectHero with the wide, blurred ellipse blob, and removes the light-mode base tint from the carousel glow.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
