### PR TITLE
Add dark-mode glow halo around blog hero cover frame

### DIFF
--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -112,23 +112,51 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
   {(svgSlug || image) && (
     <div class="relative z-[1] mx-auto max-w-5xl px-6 mt-[var(--space-section)] animate-hero-slide-up [animation-delay:450ms]">
       {svgSlug ? (
-        <div
-          class="relative overflow-hidden rounded-xl border border-border shadow-lg"
-          style="color: var(--brand-500);"
-        >
-          <BlogImageSVG slug={svgSlug} title={imageAlt || title} />
+        <div class="relative">
+          <div
+            class="pointer-events-none absolute -inset-x-16 -inset-y-12 -z-10 rounded-[3rem] blur-3xl dark:bg-brand-500/25"
+            aria-hidden="true"
+          ></div>
+          <div
+            class="pointer-events-none absolute -left-24 -top-16 -z-10 h-72 w-72 rounded-full blur-3xl dark:bg-brand-400/30"
+            aria-hidden="true"
+          ></div>
+          <div
+            class="pointer-events-none absolute -right-24 -bottom-16 -z-10 h-72 w-72 rounded-full blur-3xl dark:bg-brand-600/30"
+            aria-hidden="true"
+          ></div>
+          <div
+            class="relative overflow-hidden rounded-xl border border-border shadow-lg"
+            style="color: var(--brand-500);"
+          >
+            <BlogImageSVG slug={svgSlug} title={imageAlt || title} />
+          </div>
         </div>
       ) : image ? (
-        <div class="relative overflow-hidden rounded-xl border border-border shadow-lg">
-          <Image
-            src={image}
-            alt={imageAlt || title}
-            layout="full-width"
-            widths={[640, 960, 1280, 1920]}
-            sizes="100vw"
-            class="aspect-video w-full object-cover"
-            loading="eager"
-          />
+        <div class="relative">
+          <div
+            class="pointer-events-none absolute -inset-x-16 -inset-y-12 -z-10 rounded-[3rem] blur-3xl dark:bg-brand-500/25"
+            aria-hidden="true"
+          ></div>
+          <div
+            class="pointer-events-none absolute -left-24 -top-16 -z-10 h-72 w-72 rounded-full blur-3xl dark:bg-brand-400/30"
+            aria-hidden="true"
+          ></div>
+          <div
+            class="pointer-events-none absolute -right-24 -bottom-16 -z-10 h-72 w-72 rounded-full blur-3xl dark:bg-brand-600/30"
+            aria-hidden="true"
+          ></div>
+          <div class="relative overflow-hidden rounded-xl border border-border shadow-lg">
+            <Image
+              src={image}
+              alt={imageAlt || title}
+              layout="full-width"
+              widths={[640, 960, 1280, 1920]}
+              sizes="100vw"
+              class="aspect-video w-full object-cover"
+              loading="eager"
+            />
+          </div>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
Wrap the article hero cover-image/SVG frame in a relative container and add three dark-mode-only brand glows (wide soft halo, top-left brand-400, bottom-right brand-600) for a richer accent behind the cover.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
