### PR TITLE
fix: remove overshoot on horizontal slide-in reveals

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -41,7 +41,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-12 lg:grid-cols-2">
         <!-- Left: text -->
-        <div class="flex flex-col gap-4" data-reveal="right">
+        <div class="flex flex-col gap-4" data-reveal="right" data-reveal-ease="smooth">
           <div class="flex flex-col gap-6">
             <Badge variant="brand" pill class="self-start">The partnership</Badge>
             <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
@@ -56,7 +56,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
           </p>
         </div>
         <!-- Right: two stacked partner cards -->
-        <div class="flex flex-col gap-4 h-full" data-reveal="left" data-reveal-delay="1">
+        <div class="flex flex-col gap-4 h-full" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
           <Card variant="elevated" hover class="flex-1 flex flex-col justify-center">
             <div class="flex items-start gap-4">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
@@ -304,7 +304,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-10 lg:grid-cols-2">
         <!-- Text -->
-        <div class="flex flex-col justify-center gap-4" data-reveal="right">
+        <div class="flex flex-col justify-center gap-4" data-reveal="right" data-reveal-ease="smooth">
           <Badge variant="brand" pill class="self-start">Backstory</Badge>
           <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
             The longer story
@@ -319,7 +319,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
         </div>
 
         <!-- Image -->
-        <div class="mx-auto w-full max-w-sm sm:max-w-md lg:max-w-none" data-reveal="left" data-reveal-delay="1">
+        <div class="mx-auto w-full max-w-sm sm:max-w-md lg:max-w-none" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
           <a
             href="https://hansmartens.dev/blog/hans-martens-web-designer-veghel"
             target="_blank"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -276,7 +276,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   <section class="relative z-10 py-[var(--space-section-md)] bg-background-secondary border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-12 lg:grid-cols-2">
-        <div class="flex flex-col justify-center" data-reveal="right">
+        <div class="flex flex-col justify-center" data-reveal="right" data-reveal-ease="smooth">
           <div class="flex flex-col gap-6 mb-6">
             <Badge variant="brand" pill class="self-start">About me</Badge>
             <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
@@ -295,7 +295,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
             <Icon name="arrow-right" size="sm" />
           </Button>
         </div>
-        <Card variant="elevated" padding="lg" class="h-full flex flex-col" data-reveal="left" data-reveal-delay="1">
+        <Card variant="elevated" padding="lg" class="h-full flex flex-col" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
           <p class="text-sm text-foreground mb-5 text-center">A few things about me.</p>
           <div class="grid grid-cols-2 gap-3 flex-1 auto-rows-fr">
             <div class="bg-background-tertiary rounded-xl p-5 flex flex-col items-center justify-center text-center gap-2 border-t-2 border-brand-500/40 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-md hover:border-brand-500 cursor-default h-full">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1101,6 +1101,12 @@
   will-change: opacity, transform;
 }
 
+[data-reveal][data-reveal-ease="smooth"] {
+  transition:
+    opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 1s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 [data-reveal="down"]  { transform: translateY(-56px) scale(0.94); }
 [data-reveal="left"]  { transform: translateX(56px) scale(0.94); }
 [data-reveal="right"] { transform: translateX(-56px) scale(0.94); }


### PR DESCRIPTION
The default [data-reveal] transform easing uses a cubic-bezier with a y-value above 1 (0.22, 1.6, 0.36, 1) which gives a nice spring on vertical fades but reads as a glitch on horizontal slides — the element slides past its endpoint and settles back.

Rather than weakening the global spring (it's correct for the vertical reveals everywhere else), add an opt-in variant
[data-reveal][data-reveal-ease="smooth"] that swaps the transform curve for (0.22, 1, 0.36, 1) — same duration, same opacity curve, no overshoot. Apply it to the six elements in the three sections where the glitch shows up:

- Homepage "About me" (left + right slide pair)
- About page "Partnership" (left + right slide pair)
- About page "Backstory" (left + right slide pair)

All other reveals keep the original spring.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
