### PR TITLE
Update homepage CTA and contact hero to clarify new-builds-only scope

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -36,7 +36,7 @@ const channels = [
 
 <PageLayout
   title="Contact — Astro Rocket"
-  description="Get in touch"
+  description="Starting something new? I design and build new websites from scratch — tell me about your project and I'll get back to you within 1 business day."
   eagerReveal
 >
   <Hero layout="centered" size="sm">
@@ -46,11 +46,11 @@ const channels = [
     </Badge>
 
     <h1 slot="title">
-      Tell me about your <span class="text-brand-500">project</span>
+      Tell me about your <span class="text-brand-500">new project</span>
     </h1>
 
     <p slot="description">
-      Share a few details below and I'll get back to you within 1 business day. Prefer a different channel? Pick whichever works&nbsp;best.
+      I design and build new websites from scratch — every project, start to finish, by me. Share a few details below and I'll get back to you within 1 business day.
     </p>
   </Hero>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -363,10 +363,10 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
     <div class="glitch:hidden mx-auto max-w-2xl px-6 text-center" data-reveal>
       <Badge variant="brand" pill class="mb-6">Let's talk</Badge>
       <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
-        Have a project in mind?
+        Starting something new?
       </h2>
       <p class="text-lg text-foreground-muted mb-8 text-balance">
-        Whether it's a new build or something that needs a fresh perspective — I'd love to hear about it.
+        I design and build new websites from scratch — every project, start to finish, by me. Tell me what you have in mind.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <Button size="lg" href="/contact" class="cta-btn-brand">
@@ -383,10 +383,10 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
     <!-- Desktop: contained LetterGlitch band with glass card -->
     <LetterGlitchBand>
       <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
-        Have a project in mind?
+        Starting something new?
       </h2>
       <p class="text-lg text-foreground-muted mb-8 text-balance">
-        Whether it's a new build or something that needs a fresh perspective — I'd love to hear about it.
+        I design and build new websites from scratch — every project, start to finish, by me. Tell me what you have in mind.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <Button size="lg" href="/contact" class="hero-btn-brand">


### PR DESCRIPTION
Replaces the "fresh perspective" wording (which implied redesign work) with copy that makes clear every project is a new website built from scratch by me. Aligns the contact page hero so the two pages read as one consistent message.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
