### PR TITLE
fix: remove overshoot on contact page slide-in reveal

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -60,7 +60,7 @@ const channels = [
       <div class="grid grid-cols-1 lg:grid-cols-5 gap-10 lg:gap-16 items-stretch">
 
         <!-- Left column: contact form -->
-        <div class="lg:col-span-3 h-full" data-reveal="right">
+        <div class="lg:col-span-3 h-full" data-reveal="right" data-reveal-ease="smooth">
           <Card padding="lg" class="h-full flex flex-col justify-center">
             <h2 class="font-display text-xl font-bold text-foreground mb-6">Send a message</h2>
             <ContactForm />
@@ -68,7 +68,7 @@ const channels = [
         </div>
 
         <!-- Right column: contact channels -->
-        <div class="lg:col-span-2 space-y-4" data-reveal="left" data-reveal-delay="1">
+        <div class="lg:col-span-2 space-y-4" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
           <div>
             <h2 class="font-display text-lg font-bold text-foreground mb-1">Other channels</h2>
             <p class="text-sm text-foreground-muted">Prefer a direct channel? Pick whichever works best.</p>


### PR DESCRIPTION
Same horizontal-slide overshoot as the homepage and about page sections. Apply the data-reveal-ease="smooth" opt-in to the contact form column and the contact channels column.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
