### PR TITLE
Remove brand glow effect behind project carousel

### DIFF
--- a/src/components/projects/ProjectCarousel.astro
+++ b/src/components/projects/ProjectCarousel.astro
@@ -34,11 +34,6 @@ const hasMultiple = slides.length > 1;
   aria-roledescription="carousel"
   aria-label={label}
 >
-  <div
-    class="pointer-events-none absolute -inset-4 -z-10 rounded-2xl blur-2xl dark:bg-brand-500/15"
-    aria-hidden="true"
-  ></div>
-
   <div class="relative overflow-hidden rounded-xl border border-border shadow-xl ring-1 ring-black/5 dark:ring-white/10">
     <div
       class="carousel-track flex snap-x snap-mandatory overflow-x-auto scroll-smooth"


### PR DESCRIPTION
The blurred brand-tinted backdrop behind the carousel on the single project page added visual noise around the hero image in dark mode. Drop it so the carousel reads cleanly against the page background.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
