### PR TITLE
Tighten mobile sizes hint on project card images

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -153,7 +153,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
                   src={project.data.image}
                   alt={project.data.imageAlt || project.data.title}
                   widths={[640, 960, 1200]}
-                  sizes="(max-width: 1024px) 100vw, 480px"
+                  sizes="(max-width: 1024px) calc(100vw - 96px), 480px"
                   class="block w-full h-auto rounded-md shadow-md ring-1 ring-border/60 lg:max-h-full lg:max-w-full lg:w-auto lg:rounded-lg lg:ring-0 lg:shadow-none lg:object-contain transition-transform duration-300 group-hover:scale-[1.02]"
                   loading="lazy"
                 />

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -56,7 +56,7 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
                     src={project.data.image}
                     alt={project.data.imageAlt || project.data.title}
                     widths={[640, 960, 1200]}
-                    sizes="(max-width: 1024px) 100vw, 480px"
+                    sizes="(max-width: 1024px) calc(100vw - 96px), 480px"
                     class="block w-full h-auto rounded-md shadow-md ring-1 ring-border/60 lg:max-h-full lg:max-w-full lg:w-auto lg:rounded-lg lg:ring-0 lg:shadow-none lg:object-contain transition-transform duration-300 group-hover:scale-[1.02]"
                     loading="lazy"
                   />


### PR DESCRIPTION
The two project card <Image /> tags (homepage featured projects and projects index) declared sizes="(max-width: 1024px) 100vw, 480px", but each card sits inside section px-6 plus card p-6, so the actual rendered width on mobile is 100vw - 96px. The over-reported hint caused the browser to pick the 960w srcset candidate when the 640w candidate already covers the render area, costing ~26 KiB on a Moto G Power per the mobile Lighthouse report.

Update the mobile branch of the sizes attribute to calc(100vw - 96px) so the picker matches the real layout. widths, desktop 480px branch, classes, and layout are unchanged.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
