### PR TITLE
Move pull-quote icon inside Callout card

### DIFF
--- a/src/components/patterns/Callout.astro
+++ b/src/components/patterns/Callout.astro
@@ -27,12 +27,12 @@ const { variant = 'quote', title, class: className } = Astro.props;
 {variant === 'quote' ? (
   <figure
     class:list={[
-      'not-prose my-10 relative rounded-2xl border-l-4 border-brand-500 bg-background-secondary/60 px-6 py-6 md:px-8 md:py-8 shadow-sm',
+      'not-prose my-10 rounded-2xl border-l-4 border-brand-500 bg-background-secondary/60 px-6 py-6 md:px-8 md:py-8 shadow-sm',
       className,
     ]}
   >
     <svg
-      class="absolute -top-3 left-6 h-8 w-8 text-brand-500/80"
+      class="mb-3 h-7 w-7 text-brand-500/80"
       viewBox="0 0 24 24"
       fill="currentColor"
       aria-hidden="true"


### PR DESCRIPTION
The quote SVG was absolutely positioned at -top-3 left-6, leaving it straddling the top border of the card on the Astro Rocket and Hans Martens Dev project pages. Place it inline at the top of the card so it sits cleanly inside the border.

https://claude.ai/code/session_01LjFCP5Zyo6vNpwNyTeakfq

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
