### PR TITLE
Restore image-less project card grid and starter placeholders

### DIFF
--- a/src/content/projects/blog-starter.mdx
+++ b/src/content/projects/blog-starter.mdx
@@ -1,0 +1,34 @@
+---
+title: "Blog Starter"
+description: "A minimal, opinionated blog starter built on Astro — fast by default, with MDX support, RSS, dark mode, and a clean reading experience."
+tags: ["Astro", "MDX", "Tailwind CSS", "Open Source"]
+featured: false
+order: 5
+year: 2025
+role: "Designer & Developer"
+services: ["Design", "Development", "Open Source"]
+placeholder: true
+---
+
+## The Brief
+
+Most blog starters come with too much — heavy frameworks, complex setups, and styling opinions baked so deep they're impossible to change. I wanted something that got out of the way. A starting point that was genuinely minimal, genuinely fast, and opinionated only where it counts: the reading experience.
+
+## What I Built
+
+A lean Astro-based blog starter with everything needed to write and nothing extra.
+
+- MDX support with component embedding
+- RSS feed included by default
+- Dark mode with no flash on load
+- Responsive, well-spaced typography tuned for reading
+- Sitemap and SEO meta tags out of the box
+- Zero client-side JavaScript on static pages
+
+## Typography & Reading Experience
+
+The reading experience was the primary constraint. Every decision — from line length to spacing to code block contrast — was made to keep the reader focused on the content. Body text is set at a comfortable measure, headings are restrained, and the layout collapses cleanly on small screens without losing hierarchy.
+
+## Results
+
+Used as a starting point for several client projects and available as a free open-source template. Feedback from developers has been consistent: it's easy to understand, easy to extend, and doesn't fight back.

--- a/src/content/projects/component-library.mdx
+++ b/src/content/projects/component-library.mdx
@@ -1,0 +1,34 @@
+---
+title: "Component Library"
+description: "An open-source set of accessible, themeable UI components — built with Astro and Tailwind CSS, documented with live examples."
+tags: ["Astro", "TypeScript", "Tailwind CSS", "Open Source"]
+featured: false
+order: 4
+year: 2025
+role: "Designer & Developer"
+services: ["Design System", "Component Library", "Documentation", "Open Source"]
+placeholder: true
+---
+
+## The Brief
+
+Replace this with your actual motivation for building this. Why did you start it? What problem were you solving — for yourself or for others?
+
+*Example: Every project I built was repeating the same components from scratch. I needed a library that was opinionated enough to be useful but flexible enough to adapt to any brand.*
+
+## What I Built
+
+Describe the scope of the library. How many components? What categories? What design decisions underpinned the whole system?
+
+- Component categories and count
+- Theming system
+- Accessibility approach
+- Documentation approach
+
+## Design System Approach
+
+Walk through how the design tokens, variants, and documentation were structured. This is where designers and developers reading your portfolio will pay attention.
+
+## Results
+
+Downloads, GitHub stars, community adoption, or how it's saved time across your own projects.

--- a/src/content/projects/docs-site.mdx
+++ b/src/content/projects/docs-site.mdx
@@ -1,0 +1,35 @@
+---
+title: "Documentation Site"
+description: "Developer docs for an open-source CLI tool — versioned content, full-text search, and a clean reading experience across all screen sizes."
+tags: ["Astro", "MDX", "Tailwind CSS", "Open Source"]
+featured: false
+order: 7
+year: 2025
+role: "Designer & Developer"
+services: ["Design", "Development", "Technical Writing Support"]
+placeholder: true
+---
+
+## The Brief
+
+Replace this with the actual context. What was being documented? Who were the readers? What did the old docs look like?
+
+*Example: An open-source CLI tool had docs scattered across a README and a GitHub wiki. Contributors were confused, new users dropped off during setup, and there was no search. It needed a real documentation site.*
+
+## What I Built
+
+Describe the structure and features of the documentation site.
+
+- Versioned content structure
+- Full-text search
+- Code blocks with syntax highlighting and copy button
+- Navigation that scales across a large content tree
+- Mobile-friendly reading experience
+
+## Content Architecture
+
+Good documentation is as much about structure as it is about writing. Walk through how you organised the content — guides vs. reference vs. tutorials, versioning strategy, URL structure.
+
+## Results
+
+Time-to-first-success for new users, contribution rate, search traffic, or maintainer feedback. Replace with your real outcome.

--- a/src/content/projects/ecommerce-store.mdx
+++ b/src/content/projects/ecommerce-store.mdx
@@ -1,0 +1,35 @@
+---
+title: "E-Commerce Store"
+description: "Custom storefront for an independent fashion brand — product pages, cart, and checkout built for performance and a smooth mobile experience."
+tags: ["Astro", "TypeScript", "Tailwind CSS", "Client Work"]
+featured: false
+order: 6
+year: 2025
+client: "Your Client Name"
+role: "Designer & Developer"
+services: ["Web Design", "Web Development", "E-Commerce"]
+placeholder: true
+---
+
+## The Brief
+
+Replace this with the actual client brief. What was the brand? What did their old shop look like? What were the conversion problems they were trying to solve?
+
+*Example: An independent fashion label was losing sales to a slow, poorly structured Shopify theme. They wanted a custom storefront that reflected their aesthetic and loaded instantly on mobile.*
+
+## What I Built
+
+Describe the store's structure and what made it technically interesting.
+
+- Product listing and detail pages
+- Cart and checkout flow
+- Mobile-first design
+- Performance optimisation strategy
+
+## Mobile-First Approach
+
+E-commerce lives on mobile. Describe the specific decisions you made to serve mobile shoppers — touch targets, image loading, checkout simplification.
+
+## Results
+
+Conversion rate change, page speed improvements, revenue impact, or client feedback. Replace with your real outcome.

--- a/src/content/projects/saas-landing.mdx
+++ b/src/content/projects/saas-landing.mdx
@@ -1,0 +1,36 @@
+---
+title: "SaaS Landing Page"
+description: "Marketing site for a B2B analytics platform — clear messaging, fast load times, and a conversion-focused layout."
+tags: ["Astro", "TypeScript", "Tailwind CSS", "Client Work"]
+featured: false
+order: 3
+year: 2025
+client: "Your Client Name"
+role: "Designer & Developer"
+services: ["Web Design", "Web Development", "Copywriting Support"]
+placeholder: true
+---
+
+## The Brief
+
+Replace this with your actual project brief. What was the client trying to achieve? What did the old site lack? What did a successful launch look like?
+
+*Example: A B2B analytics startup had a product that was ahead of competitors but a site that didn't reflect it. They needed a marketing site that could explain a complex product simply, rank on search, and convert trial sign-ups.*
+
+## What I Built
+
+Describe the pages, sections, and components you built. What made this project interesting from a design or development perspective?
+
+- Hero section with clear value proposition
+- Feature sections with interactive demos
+- Pricing table
+- Trust signals and social proof
+- Optimised for conversion
+
+## Key Decisions
+
+Walk through the decisions that shaped the project. Copywriting approach, layout choices, performance trade-offs, animation decisions.
+
+## Results
+
+Share what happened after launch — trial sign-ups, bounce rate, page speed scores, or client feedback. Replace with your actual numbers.

--- a/src/content/projects/studio-portfolio.mdx
+++ b/src/content/projects/studio-portfolio.mdx
@@ -1,0 +1,34 @@
+---
+title: "Studio Portfolio"
+description: "Complete redesign of a creative studio's portfolio — fast, focused, and built to convert visitors into clients."
+tags: ["Astro", "Tailwind CSS", "Design", "Client Work"]
+featured: false
+order: 2
+year: 2025
+client: "Your Client Name"
+role: "Designer & Developer"
+services: ["Web Design", "Web Development", "Performance Optimisation"]
+placeholder: true
+---
+
+## The Brief
+
+Replace this with your actual project brief. Describe what the client came to you with — their goals, their existing site's problems, and what success would look like.
+
+*Example: The studio had been running on a WordPress theme for six years. It was slow, hard to maintain, and no longer reflected the quality of their work. They needed a site that felt as considered as the projects they put on it.*
+
+## What I Built
+
+Describe what you built. Walk through the key decisions — layout, structure, technology choices, and anything that makes this project worth showing.
+
+- What pages were built?
+- What was technically interesting about it?
+- What design decisions did you make and why?
+
+## The Process
+
+Walk through how you worked. Discovery, wireframes, design, build, feedback, launch. This is where you show how you think.
+
+## Results
+
+Share the outcome. Metrics, client feedback, what changed after launch.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,4 @@
 ---
-import { Image } from 'astro:assets';
 import LandingLayout from '@/layouts/LandingLayout.astro';
 import { Hero } from '@/components/hero';
 import Button from '@/components/ui/form/Button/Button.astro';
@@ -14,6 +13,7 @@ import siteConfig from '@/config/site.config';
 
 const projectItems = await getCollection('projects');
 const featuredProjects = projectItems
+  .filter((p) => p.data.featured)
   .sort((a, b) => a.data.order - b.data.order)
   .slice(0, 4);
 
@@ -137,55 +137,39 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </p>
       </div>
 
-      <div class="flex flex-col gap-6">
+      <div class="grid gap-6 md:grid-cols-2">
         {featuredProjects.map((project) => (
           <Card
             variant="elevated"
             hover
             padding="none"
             href={project.data.placeholder ? undefined : `/projects/${project.id.replace(/\.mdx?$/, '')}`}
-            class="group overflow-hidden flex flex-col lg:grid lg:grid-cols-2"
+            class="group flex flex-col"
             data-reveal
           >
-            {project.data.image && (
-              <div class="overflow-hidden p-6 pb-0 lg:bg-background-secondary lg:p-6 lg:aspect-auto lg:h-full lg:flex lg:items-center lg:justify-center">
-                <Image
-                  src={project.data.image}
-                  alt={project.data.imageAlt || project.data.title}
-                  widths={[640, 960, 1200]}
-                  sizes="(max-width: 1024px) calc(100vw - 96px), 480px"
-                  class="block w-full h-auto rounded-md shadow-md ring-1 ring-border/60 lg:max-h-full lg:max-w-full lg:w-auto lg:rounded-lg lg:ring-0 lg:shadow-none lg:object-contain transition-transform duration-300 group-hover:scale-[1.02]"
-                  loading="lazy"
-                />
-              </div>
-            )}
             <div class="flex flex-1 flex-col p-6">
-              {!project.data.image && (
-                <div class="mb-3 w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
+              <div class="mb-3 flex items-start justify-between gap-4">
+                <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
                   <Icon name="layers" size="sm" />
                 </div>
-              )}
+                {!project.data.placeholder && (
+                  <Icon name="arrow-up-right" size="sm" class="text-foreground-muted group-hover:text-brand-500 transition-colors shrink-0 ml-auto" />
+                )}
+              </div>
               <div class="mb-2 flex items-baseline gap-2">
                 <h3 class="font-display text-lg font-bold text-foreground">{project.data.title}</h3>
                 {project.data.year && (
                   <span class="text-xs text-foreground-muted">{project.data.year}</span>
                 )}
               </div>
-              <p class="text-sm text-foreground-muted leading-relaxed mb-4">{project.data.description}</p>
-              {project.data.meta && project.data.meta.length > 0 && (
-                <p class="mb-4 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-foreground-muted">
-                  {project.data.meta.map((item, i) => (
-                    <>
-                      {i > 0 && <span class="text-brand-500" aria-hidden="true">·</span>}
-                      <span>{item}</span>
-                    </>
+              <p class="text-sm text-foreground-muted leading-relaxed mb-4 flex-1">{project.data.description}</p>
+              {project.data.tags && project.data.tags.length > 0 && (
+                <div class="flex flex-wrap gap-1.5">
+                  {project.data.tags.map((tag) => (
+                    <Badge variant="brand">{tag}</Badge>
                   ))}
-                </p>
+                </div>
               )}
-              <span class="inline-flex items-center gap-1.5 text-sm font-medium text-brand-500">
-                View project
-                <Icon name="arrow-right" size="sm" />
-              </span>
             </div>
           </Card>
         ))}

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -3,7 +3,6 @@
  * Projects page
  * URL: /projects
  */
-import { Image } from 'astro:assets';
 import PageLayout from '@/layouts/PageLayout.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
@@ -40,55 +39,39 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
     <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
       <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
 
-        <div class="flex flex-col gap-6">
+        <div class="grid gap-6 md:grid-cols-2">
           {projects.map((project) => (
             <Card
               variant="elevated"
               hover
               padding="none"
               href={project.data.placeholder ? undefined : `/projects/${project.id.replace(/\.mdx?$/, '')}`}
-              class="group overflow-hidden flex flex-col lg:grid lg:grid-cols-2"
+              class="group flex flex-col"
               data-reveal
             >
-              {project.data.image && (
-                <div class="overflow-hidden p-6 pb-0 lg:bg-background-secondary lg:p-6 lg:aspect-auto lg:h-full lg:flex lg:items-center lg:justify-center">
-                  <Image
-                    src={project.data.image}
-                    alt={project.data.imageAlt || project.data.title}
-                    widths={[640, 960, 1200]}
-                    sizes="(max-width: 1024px) calc(100vw - 96px), 480px"
-                    class="block w-full h-auto rounded-md shadow-md ring-1 ring-border/60 lg:max-h-full lg:max-w-full lg:w-auto lg:rounded-lg lg:ring-0 lg:shadow-none lg:object-contain transition-transform duration-300 group-hover:scale-[1.02]"
-                    loading="lazy"
-                  />
-                </div>
-              )}
               <div class="flex flex-1 flex-col p-6">
-                {!project.data.image && (
-                  <div class="mb-3 w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
+                <div class="mb-3 flex items-start justify-between gap-4">
+                  <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
                     <Icon name="layers" size="sm" />
                   </div>
-                )}
+                  {!project.data.placeholder && (
+                    <Icon name="arrow-up-right" size="sm" class="text-foreground-muted group-hover:text-brand-500 transition-colors shrink-0 ml-auto" />
+                  )}
+                </div>
                 <div class="mb-2 flex items-baseline gap-2">
                   <h3 class="font-display text-lg font-bold text-foreground">{project.data.title}</h3>
                   {project.data.year && (
                     <span class="text-xs text-foreground-muted">{project.data.year}</span>
                   )}
                 </div>
-                <p class="text-sm text-foreground-muted leading-relaxed mb-4">{project.data.description}</p>
-                {project.data.meta && project.data.meta.length > 0 && (
-                  <p class="mb-4 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-foreground-muted">
-                    {project.data.meta.map((item, i) => (
-                      <>
-                        {i > 0 && <span class="text-brand-500" aria-hidden="true">·</span>}
-                        <span>{item}</span>
-                      </>
+                <p class="text-sm text-foreground-muted leading-relaxed mb-4 flex-1">{project.data.description}</p>
+                {project.data.tags && project.data.tags.length > 0 && (
+                  <div class="flex flex-wrap gap-1.5">
+                    {project.data.tags.map((tag) => (
+                      <Badge variant="brand">{tag}</Badge>
                     ))}
-                  </p>
+                  </div>
                 )}
-                <span class="inline-flex items-center gap-1.5 text-sm font-medium text-brand-500">
-                  View project
-                  <Icon name="arrow-right" size="sm" />
-                </span>
               </div>
             </Card>
           ))}


### PR DESCRIPTION
Switch /projects and the homepage Selected work section back to a simple 2-column grid of text-only cards — no cover image, no internal image/text split. Each card uses a single hardcoded layers tile and shows an arrow-up-right affordance in the top-right only for real linked projects.

Filter the homepage featured slice by featured: true so the restored placeholder projects never leak into the Selected work section.

Restore the six original Astro Rocket starter placeholders (blog-starter, component-library, docs-site, ecommerce-store, saas-landing, studio-portfolio) with placeholder: true so their cards do not link to a detail page.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
