### PR TITLE
Align single project and blog page sections to max-w-7xl

### DIFF
--- a/src/components/patterns/LetterGlitchBand.astro
+++ b/src/components/patterns/LetterGlitchBand.astro
@@ -1,8 +1,16 @@
 ---
 import LetterGlitch from '@/components/effects/LetterGlitch';
+
+interface Props {
+  maxWidth?: '6xl' | '7xl';
+}
+
+const { maxWidth = '6xl' } = Astro.props;
+
+const maxWidthClass = maxWidth === '7xl' ? 'max-w-7xl' : 'max-w-6xl';
 ---
 
-<div class="hidden glitch:block mx-auto max-w-6xl px-6">
+<div class:list={['hidden glitch:block mx-auto px-6', maxWidthClass]}>
   <div class="relative isolate">
     <div
       class="pointer-events-none absolute inset-0 -z-10 rounded-3xl blur-3xl dark:bg-brand-500/25"

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -116,7 +116,7 @@ const blogPostingSchema = createBlogPostSchema({
     size="lg"
     showCta={false}
     showScrollProgress
-    maxWidth={sidebarActive ? '7xl' : '6xl'}
+    maxWidth="7xl"
   />
 
   <div class="min-h-screen pt-16">
@@ -135,11 +135,10 @@ const blogPostingSchema = createBlogPostSchema({
 
   <article class="pt-8 pb-[var(--space-section-md)]">
     <div class:list={[
-      'mx-auto px-6',
+      'mx-auto px-6 max-w-7xl',
       sidebarActive && (sidebarOnLeft
-        ? 'max-w-7xl xl:grid xl:grid-cols-[15rem_minmax(0,1fr)] xl:gap-10'
-        : 'max-w-7xl xl:grid xl:grid-cols-[minmax(0,1fr)_15rem] xl:gap-10'),
-      !sidebarActive && 'max-w-4xl',
+        ? 'xl:grid xl:grid-cols-[15rem_minmax(0,1fr)] xl:gap-10'
+        : 'xl:grid xl:grid-cols-[minmax(0,1fr)_15rem] xl:gap-10'),
     ]}>
       {sidebarActive && sidebarOnLeft && (
         <aside class="hidden xl:block" aria-label="Table of contents">
@@ -152,7 +151,7 @@ const blogPostingSchema = createBlogPostSchema({
         </aside>
       )}
 
-      <div class:list={[sidebarActive && 'min-w-0 max-w-4xl w-full mx-auto xl:mx-0']}>
+      <div class:list={['min-w-0 max-w-4xl w-full mx-auto', sidebarActive && 'xl:mx-0']}>
       <!-- Breadcrumbs -->
       <Breadcrumbs items={breadcrumbs} class="mb-8" />
 
@@ -224,7 +223,7 @@ const blogPostingSchema = createBlogPostSchema({
 
   <!-- Related Posts -->
   {tags.length > 0 && (
-    <div class="mx-auto max-w-screen-xl px-6" data-reveal>
+    <div class="mx-auto max-w-7xl px-6" data-reveal>
       <RelatedPosts currentSlug={slug} tags={tags} locale="en" maxPosts={3} />
     </div>
   )}
@@ -266,7 +265,7 @@ const blogPostingSchema = createBlogPostSchema({
 
   <!-- Desktop: contained LetterGlitch band with glass card -->
   <section class="hidden glitch:block relative z-10 py-[var(--space-section-md)] bg-background-secondary">
-    <LetterGlitchBand>
+    <LetterGlitchBand maxWidth="7xl">
       <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">Follow along</h2>
       <p class="text-lg text-foreground-muted mb-8 text-balance">Stay in the loop — new articles, thoughts, and updates.</p>
 
@@ -301,5 +300,5 @@ const blogPostingSchema = createBlogPostSchema({
   </section>
   </div>
 
-  <Footer slot="footer" layout="simple" background="secondary" maxWidth={sidebarActive ? '7xl' : '6xl'} />
+  <Footer slot="footer" layout="simple" background="secondary" maxWidth="7xl" />
 </BaseLayout>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -99,7 +99,7 @@ const breadcrumbs = [
     size="lg"
     showCta={false}
     showScrollProgress
-    maxWidth={sidebarActive ? '7xl' : '6xl'}
+    maxWidth="7xl"
   />
 
   <div class="min-h-screen pt-16">
@@ -121,11 +121,10 @@ const breadcrumbs = [
 
     <article class="pt-8 pb-[var(--space-section-md)]">
       <div class:list={[
-        'mx-auto px-6',
+        'mx-auto px-6 max-w-7xl',
         sidebarActive && (sidebarOnLeft
-          ? 'max-w-7xl xl:grid xl:grid-cols-[15rem_minmax(0,1fr)] xl:gap-10'
-          : 'max-w-7xl xl:grid xl:grid-cols-[minmax(0,1fr)_15rem] xl:gap-10'),
-        !sidebarActive && 'max-w-4xl',
+          ? 'xl:grid xl:grid-cols-[15rem_minmax(0,1fr)] xl:gap-10'
+          : 'xl:grid xl:grid-cols-[minmax(0,1fr)_15rem] xl:gap-10'),
       ]}>
         {sidebarActive && sidebarOnLeft && (
           <aside class="hidden xl:block" aria-label="Table of contents">
@@ -138,7 +137,7 @@ const breadcrumbs = [
           </aside>
         )}
 
-        <div class:list={[sidebarActive && 'min-w-0 max-w-4xl w-full mx-auto xl:mx-0']}>
+        <div class:list={['min-w-0 max-w-4xl w-full mx-auto', sidebarActive && 'xl:mx-0']}>
           <Breadcrumbs items={breadcrumbs} class="mb-8" />
 
           {inlineActive && (
@@ -183,7 +182,7 @@ const breadcrumbs = [
 
     {related.length > 0 && (
       <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border" data-reveal>
-        <div class="mx-auto max-w-6xl px-6">
+        <div class="mx-auto max-w-7xl px-6">
           <h2 class="font-display text-2xl md:text-3xl font-bold text-foreground mb-8">More projects</h2>
           <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {related.map((project) => (
@@ -247,7 +246,7 @@ const breadcrumbs = [
       </div>
 
       <!-- Desktop: LetterGlitch band with glass card -->
-      <LetterGlitchBand>
+      <LetterGlitchBand maxWidth="7xl">
         <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
           Have a project in mind?
         </h2>
@@ -272,6 +271,6 @@ const breadcrumbs = [
     slot="footer"
     layout="simple"
     background="secondary"
-    maxWidth={sidebarActive ? '7xl' : '6xl'}
+    maxWidth="7xl"
   />
 </BaseLayout>


### PR DESCRIPTION
So the LetterGlitch band, related items, header, and footer line up vertically with the hero on the single project and single blog pages. The article prose stays clamped to max-w-4xl. LetterGlitchBand gets an opt-in maxWidth prop so the index pages keep their max-w-6xl rhythm.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
