### PR TITLE
Port back-nav buttons, More projects card tweaks, and optional FAQ sc…

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -19,6 +19,15 @@ const blog = defineCollection({
       draft: z.boolean().default(false),
       featured: z.boolean().default(false),
       locale: z.enum(['en', 'es', 'fr']).default('en'),
+      /** Optional FAQs — when set, emit FAQ JSON-LD alongside the BlogPosting schema. */
+      faqs: z
+        .array(
+          z.object({
+            question: z.string(),
+            answer: z.string(),
+          })
+        )
+        .optional(),
       /** Per-post override: hide table of contents on this post */
       toc: z.boolean().optional(),
       /** Per-post override: hide comments on this post */

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -11,10 +11,11 @@ import RelatedPosts from '@/components/blog/RelatedPosts.astro';
 import TableOfContents from '@/components/blog/TableOfContents.astro';
 import Comments from '@/components/blog/Comments.astro';
 import CTA from '@/components/ui/marketing/CTA/CTA.astro';
+import Button from '@/components/ui/form/Button/Button.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 import { resolveSocialLinks } from '@/lib/utils';
-import { createBlogPostSchema } from '@/lib/schema';
+import { createBlogPostSchema, createFAQSchema } from '@/lib/schema';
 import { getBlogOgPath } from '@/lib/og';
 
 const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
@@ -30,6 +31,8 @@ interface Props {
   svgSlug?: string;
   tags?: string[];
   slug?: string;
+  /** Optional FAQs — when provided, an FAQ JSON-LD schema is emitted alongside the BlogPosting schema. */
+  faqs?: Array<{ question: string; answer: string }>;
   /** MDX headings — used by the optional table of contents */
   headings?: MarkdownHeading[];
   /** Per-post override: hide table of contents on this post */
@@ -49,6 +52,7 @@ const {
   svgSlug,
   tags = [],
   slug = '',
+  faqs,
   headings = [],
   toc: tocOverride,
   comments: commentsOverride,
@@ -93,6 +97,9 @@ const blogPostingSchema = createBlogPostSchema({
   dateModified: updatedAt,
   author: { name: author, url: siteConfig.url },
 });
+
+const faqSchema = faqs && faqs.length > 0 ? createFAQSchema(faqs) : null;
+const schemas = faqSchema ? [blogPostingSchema, faqSchema] : [blogPostingSchema];
 ---
 
 <BaseLayout
@@ -106,7 +113,7 @@ const blogPostingSchema = createBlogPostSchema({
     authors: [author],
     tags,
   }}
-  extraSchemas={[blogPostingSchema]}
+  extraSchemas={schemas}
 >
   <Header
     slot="header"
@@ -180,23 +187,10 @@ const blogPostingSchema = createBlogPostSchema({
       <footer class="border-border mt-12 border-t pt-8" data-reveal>
         <div class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
           <!-- Back link -->
-          <a
-            href="/blog"
-            class="text-brand-600 hover:text-brand-500 dark:text-brand-400 dark:hover:text-brand-300 inline-flex items-center gap-2 text-sm font-medium transition-colors"
-          >
-            <svg
-              class="h-4 w-4"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18"
-              ></path>
-            </svg>
+          <Button href="/blog" variant="secondary" size="sm">
+            <Icon name="arrow-left" size="sm" />
             Back to Blog
-          </a>
+          </Button>
 
           <!-- Share buttons -->
           <ShareButtons title={title} url={fullUrl} />

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -155,15 +155,10 @@ const breadcrumbs = [
           </div>
 
           <footer class="border-border mt-12 border-t pt-8" data-reveal>
-            <a
-              href="/projects"
-              class="text-brand-600 hover:text-brand-500 dark:text-brand-400 dark:hover:text-brand-300 inline-flex items-center gap-2 text-sm font-medium transition-colors"
-            >
-              <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-              </svg>
+            <Button href="/projects" variant="secondary" size="sm">
+              <Icon name="arrow-left" size="sm" />
               Back to Projects
-            </a>
+            </Button>
           </footer>
         </div>
 
@@ -201,16 +196,19 @@ const breadcrumbs = [
                     <Icon name="arrow-up-right" size="sm" class="text-foreground-muted group-hover:text-brand-500 transition-colors shrink-0 ml-auto" />
                   </div>
                   <div class="mb-2 flex items-baseline gap-2">
-                    <h3 class="font-display text-lg font-bold text-foreground line-clamp-1">{project.data.title}</h3>
+                    <h3 class="font-display text-lg font-bold text-foreground">{project.data.title}</h3>
                     {project.data.year && (
-                      <span class="text-xs text-foreground-muted shrink-0">{project.data.year}</span>
+                      <span class="text-xs text-foreground-muted">{project.data.year}</span>
                     )}
                   </div>
-                  <p class="text-sm text-foreground-muted leading-relaxed mb-4 line-clamp-3">{project.data.description}</p>
+                  <p class="text-sm text-foreground-muted leading-relaxed mb-4 flex-1 line-clamp-3">{project.data.description}</p>
                   {project.data.tags && project.data.tags.length > 0 && (
-                    <div class="mt-auto flex flex-wrap gap-1.5">
-                      {project.data.tags.map((tag) => (
-                        <Badge variant="brand">{tag}</Badge>
+                    <div class="flex flex-wrap gap-1.5">
+                      {project.data.tags.map((tag, i) => (
+                        <>
+                          {i === 3 && <div class="basis-full" aria-hidden="true"></div>}
+                          <Badge variant="brand">{tag}</Badge>
+                        </>
                       ))}
                     </div>
                   )}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -28,6 +28,7 @@ const { Content, headings } = await render(post);
   svgSlug={post.data.svgSlug}
   tags={post.data.tags}
   slug={post.id}
+  faqs={post.data.faqs}
   headings={headings}
   toc={post.data.toc}
   comments={post.data.comments}


### PR DESCRIPTION
…hema

- Replace the back-to-blog and back-to-projects inline anchors with the secondary Button + arrow-left Icon used elsewhere in the theme.
- More projects cards: drop title line-clamp, let the description grow via flex-1, and force a 4th tag onto its own row with a basis-full break so the badge row stays tidy.
- Add an optional `faqs` field on the blog content schema. When set, BlogLayout emits an FAQ JSON-LD schema alongside the BlogPosting schema. Comments behaviour and the per-post/per-project dynamic OG image generation are intentionally left in place.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
