### PR TITLE
Balance services cards: extend bullets and center content vertically

### DIFF
--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -73,7 +73,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
         </div>
         <!-- Card -->
         <div data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
-          <Card variant="elevated" padding="lg" class="h-full">
+          <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
             <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
                 <Icon name="layout" size="md" />
@@ -84,37 +84,37 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Bespoke layouts</span> — built for your content, not from a template.
+                  <span class="font-semibold text-foreground">Bespoke layouts</span> — built for your content, not from a template. Every section earns its place by serving the page's goal.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Responsive across breakpoints</span> — phone, tablet, desktop, ultrawide.
+                  <span class="font-semibold text-foreground">Responsive across breakpoints</span> — phone, tablet, desktop, ultrawide. Layouts reflow with intent, not just shrink to fit.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Typography systems</span> — readable, scaleable, on-brand.
+                  <span class="font-semibold text-foreground">Typography systems</span> — readable, scaleable, on-brand. A clear hierarchy from page title down to caption, tuned for long-form reading.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Light & dark themes</span> — one design, two moods, user's choice.
+                  <span class="font-semibold text-foreground">Light & dark themes</span> — one design, two moods, user's choice. Both modes are checked at every step, not retrofitted at the end.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Considered motion</span> — interactions that guide, never distract.
+                  <span class="font-semibold text-foreground">Considered motion</span> — interactions that guide, never distract. Reduced-motion preferences are respected without exception.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Accessibility baked in</span> — contrast, focus, semantic structure.
+                  <span class="font-semibold text-foreground">Accessibility baked in</span> — contrast, focus, semantic structure. Keyboard paths and screen-reader output are verified before launch.
                 </p>
               </li>
             </ul>
@@ -150,7 +150,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
         </div>
         <!-- Card -->
         <div class="lg:order-2" data-reveal="right" data-reveal-delay="1" data-reveal-ease="smooth">
-          <Card variant="elevated" padding="lg" class="h-full">
+          <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
             <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
                 <Icon name="code" size="md" />
@@ -161,37 +161,37 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Astro + Tailwind</span> — modern stack, minimal JavaScript, clean HTML.
+                  <span class="font-semibold text-foreground">Astro + Tailwind</span> — modern stack, minimal JavaScript, clean HTML. The browser renders the page almost instantly, with no hydration tax.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Typed content collections</span> — structured blog, projects, and data.
+                  <span class="font-semibold text-foreground">Typed content collections</span> — structured blog, projects, and data. Schema validation runs at build time, so broken content never ships.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Forms & integrations</span> — protected, GDPR-aware, hooked into your tools.
+                  <span class="font-semibold text-foreground">Forms & integrations</span> — protected, GDPR-aware, hooked into your tools. Submissions reach your inbox or CRM without leaking client-side.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Hosting & deploy</span> — Netlify, Vercel, Cloudflare, or your own infra.
+                  <span class="font-semibold text-foreground">Hosting & deploy</span> — Netlify, Vercel, Cloudflare, or your own infra. Preview deploys for every branch, so changes can be reviewed before they go live.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Version control & CI</span> — git-based workflow, repeatable deploys.
+                  <span class="font-semibold text-foreground">Version control & CI</span> — git-based workflow, repeatable deploys. Automated checks gate every pull request before merge.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Handover documentation</span> — code, keys, and a README you can actually read.
+                  <span class="font-semibold text-foreground">Handover documentation</span> — code, keys, and a README you can actually read. Written so a future developer (or future you) can pick the project up without a tour.
                 </p>
               </li>
             </ul>
@@ -227,7 +227,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
         </div>
         <!-- Card -->
         <div data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
-          <Card variant="elevated" padding="lg" class="h-full">
+          <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
             <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
                 <Icon name="zap" size="md" />
@@ -238,37 +238,37 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Core Web Vitals</span> — LCP, INP, and CLS held to Google's thresholds.
+                  <span class="font-semibold text-foreground">Core Web Vitals</span> — LCP, INP, and CLS held to Google's thresholds. Measured on real devices, not just synthetic tests.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Image pipeline</span> — modern formats, responsive sizes, lazy loading.
+                  <span class="font-semibold text-foreground">Image pipeline</span> — modern formats, responsive sizes, lazy loading. Hero images art-directed so they look right on every screen.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Technical SEO</span> — metadata, sitemaps, structured data, OG images.
+                  <span class="font-semibold text-foreground">Technical SEO</span> — metadata, sitemaps, structured data, OG images. All wired up and validated before the first crawl.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Accessibility</span> — WCAG-aware markup and verified focus order.
+                  <span class="font-semibold text-foreground">Accessibility</span> — WCAG-aware markup and verified focus order. Tested with a screen reader and the keyboard alone, not just a contrast checker.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Lighthouse audits</span> — measurable scores delivered with the site.
+                  <span class="font-semibold text-foreground">Lighthouse audits</span> — measurable scores delivered with the site. Repeatable in CI so they don't quietly drift after launch.
                 </p>
               </li>
               <li class="flex items-start gap-3">
                 <Icon name="check" size="sm" class="text-brand-500 shrink-0 mt-1" />
                 <p class="text-sm text-foreground-muted leading-relaxed">
-                  <span class="font-semibold text-foreground">Privacy-friendly analytics</span> — useful data, no cookie banner.
+                  <span class="font-semibold text-foreground">Privacy-friendly analytics</span> — useful data, no cookie banner. Self-hosted or vendor-anonymised, never sold on.
                 </p>
               </li>
             </ul>


### PR DESCRIPTION
- Add a second clause to every 'What's included' bullet across all three sections so each card carries similar copy density.
- Add 'flex flex-col justify-center' to the cards so any leftover height (from h-full matching the text column) distributes evenly above and below the content, giving visually equal top/bottom padding.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
