### PR TITLE
Promote theme-mode toggle to header on all breakpoints

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -249,7 +249,7 @@ const buttonId = `${menuId}-button`;
         ) : (
           <>
             {showThemeToggle && (
-              <div class="hidden lg:flex">
+              <div class="flex">
                 <ThemeModeDropdown class={isFloating ? 'hdr-invert-text' : undefined} />
               </div>
             )}
@@ -436,25 +436,12 @@ const buttonId = `${menuId}-button`;
               </ul>
             </section>
 
-            {showThemeToggle && (
-              <section class="mobile-menu-section">
-                <p class="mobile-menu-label">Appearance</p>
-                <div
-                  class="mobile-menu-stagger flex items-center justify-between rounded-xl px-3 py-2.5"
-                  style={`--stagger-index: ${navItems.length}`}
-                >
-                  <span class="text-sm text-foreground-muted">Theme mode</span>
-                  <ThemeModeDropdown />
-                </div>
-              </section>
-            )}
-
             {showThemeSelector && (
               <section class="mobile-menu-section">
                 <p class="mobile-menu-label">Theme</p>
                 <div
                   class="mobile-menu-stagger flex items-center justify-between rounded-xl px-3 py-2.5"
-                  style={`--stagger-index: ${navItems.length + (showThemeToggle ? 1 : 0)}`}
+                  style={`--stagger-index: ${navItems.length}`}
                 >
                   <span class="text-sm text-foreground-muted">Colour theme</span>
                   <ThemeSelector />
@@ -467,7 +454,7 @@ const buttonId = `${menuId}-button`;
                 <p class="mobile-menu-label">Language</p>
                 <div
                   class="mobile-menu-stagger flex items-center justify-between rounded-xl px-3 py-2.5"
-                  style={`--stagger-index: ${navItems.length + (showThemeToggle ? 1 : 0) + (showThemeSelector ? 1 : 0)}`}
+                  style={`--stagger-index: ${navItems.length + (showThemeSelector ? 1 : 0)}`}
                 >
                   <span class="text-sm text-foreground-muted">Language</span>
                   <LanguageSwitcher />
@@ -489,7 +476,7 @@ const buttonId = `${menuId}-button`;
                         aria-label={label}
                         title={label}
                         class="mobile-menu-social mobile-menu-stagger inline-flex h-11 w-11 items-center justify-center rounded-full border border-border-strong text-foreground-muted transition-colors"
-                        style={`--stagger-index: ${navItems.length + (showThemeToggle ? 1 : 0) + (showThemeSelector ? 1 : 0) + (showLanguageSwitcher ? 1 : 0) + sIdx}`}
+                        style={`--stagger-index: ${navItems.length + (showThemeSelector ? 1 : 0) + (showLanguageSwitcher ? 1 : 0) + sIdx}`}
                       >
                         <Icon name={icon} size="md" />
                       </a>
@@ -502,7 +489,7 @@ const buttonId = `${menuId}-button`;
             {showCta && (
               <div
                 class="mobile-menu-stagger mobile-menu-cta-wrap pt-2"
-                style={`--stagger-index: ${navItems.length + (showThemeToggle ? 1 : 0) + (showThemeSelector ? 1 : 0) + (showLanguageSwitcher ? 1 : 0) + mobileSocialLinks.length}`}
+                style={`--stagger-index: ${navItems.length + (showThemeSelector ? 1 : 0) + (showLanguageSwitcher ? 1 : 0) + mobileSocialLinks.length}`}
               >
                 <Button fullWidth href={ctaHref} target={ctaHref?.startsWith('http') ? '_blank' : undefined}>
                   {cta.icon && <Icon name={cta.icon} size="sm" />}


### PR DESCRIPTION
The system/light/dark mode pill was visible in the header only at lg+ and otherwise lived inside the mobile dropdown menu. Surface it directly in the header at every breakpoint so it's reachable in one tap from mobile and tablet without opening the menu. Drop the "Appearance / Theme mode" section from the mobile menu and shift the remaining stagger indexes down accordingly.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
