### PR TITLE
Neutralize brand-colored header chrome in light mode

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -331,7 +331,7 @@ const buttonId = `${menuId}-button`;
             id={buttonId}
             class={cn(
               'hdr-hamburger inline-flex items-center justify-center rounded-md p-2 lg:hidden',
-              'text-brand-600 dark:text-foreground',
+              'text-foreground',
               'transition-colors',
               'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
               isFloating ? 'hover:bg-secondary/40' : 'hover:bg-secondary'
@@ -1141,13 +1141,10 @@ const buttonId = `${menuId}-button`;
   .mobile-menu-social {
     border-color: var(--color-border-strong);
   }
-  html:not(.dark) .mobile-menu-social {
-    border-color: color-mix(in oklch, var(--color-brand-500) 30%, transparent);
-  }
-  .mobile-menu-social:hover {
-    color: var(--color-brand-600);
-    border-color: var(--color-brand-500);
-    background-color: color-mix(in oklch, var(--color-brand-500) 8%, transparent);
+  html:not(.dark) .mobile-menu-social:hover {
+    color: var(--color-foreground);
+    border-color: var(--color-border-strong);
+    background-color: color-mix(in oklch, var(--color-secondary) 60%, transparent);
   }
   html.dark .mobile-menu-social:hover {
     color: var(--color-brand-300);


### PR DESCRIPTION
The hamburger and close-X were using text-brand-600 in light mode, and the mobile-menu social pills had a brand-500 border at rest plus a fully brand-colored hover. In light mode these now use the standard foreground/border-strong palette so the header chrome reads as quiet frame instead of pulling brand attention. Dark mode hover (brand-400) and the existing floating-on-hero hamburger tint are untouched.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
