### PR TITLE
fix(i18n): resolve `<html lang>` and related-posts locale from URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **i18n: `<html lang>` and related-posts locale no longer hardcoded to `en`** — `src/layouts/BaseLayout.astro` and `src/layouts/BlogLayout.astro` now resolve the active locale from the URL via `getLocaleFromPath(Astro.url.pathname)`, so sites with i18n enabled emit the correct `lang` attribute and pull related posts from the matching content folder. Thanks @vespeng for the report (#323).
+
+### Added
+
+- **i18n README note** — clarified that `defaultLocale` is a routing label and that the content folder name under `src/content/blog/` must match for the root URL to serve a different default language.
+- **i18n tests** — added unit-test coverage for `getLocaleFromPath`, `stripLocaleFromPath`, and `swapLocaleInPath` to prevent regressions on locale resolution.
+
+---
+
 ## [1.4.0] — 2026-05-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ src/content/blog/en/hello-world.mdx
 src/content/blog/nl/hallo-wereld.mdx
 ```
 
+> **Switching the default locale.** Changing `defaultLocale` in `i18n.config.ts` is a routing label — it controls which locale serves at the site root, not which content folder gets read. To make a different language the default, also rename the matching content folder (e.g. `src/content/blog/en/` → `src/content/blog/zh-CN/`) so the root URL resolves to the right posts. The locale code in `i18n.config.ts` and the folder name under `src/content/blog/` must match.
+
 #### Performance
 
 The whole system is build-time. No client-side routing, no framework hydration for the `LanguageSwitcher` — just static HTML and a tiny vanilla-JS open/close handler for the dropdown panel. Verified zero output-size delta on the disabled path between 1.2.1 and 1.3.0.

--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { t, localizedPath, resolveLocale, isValidLocale, getLocaleName } from '../i18n';
+import {
+  t,
+  localizedPath,
+  resolveLocale,
+  isValidLocale,
+  getLocaleName,
+  getLocaleFromPath,
+  stripLocaleFromPath,
+  swapLocaleInPath,
+} from '../i18n';
 
 describe('i18n t() helper', () => {
   it('returns a translation for a valid dotted key', () => {
@@ -55,5 +64,48 @@ describe('i18n locale helpers', () => {
     // 'nl' is in localeNames even though it's not in the active locales list
     expect(getLocaleName('nl')).toBe('Nederlands');
     expect(getLocaleName('xx')).toBe('xx');
+  });
+});
+
+describe('i18n getLocaleFromPath()', () => {
+  it('returns the default locale for the root path', () => {
+    expect(getLocaleFromPath('/')).toBe('en');
+  });
+
+  it('returns the default locale when no recognized prefix is present', () => {
+    expect(getLocaleFromPath('/about')).toBe('en');
+    expect(getLocaleFromPath('/blog/hello-world')).toBe('en');
+  });
+
+  it('returns the default locale when the first segment is not a configured locale', () => {
+    // Default config only has 'en' active — 'nl' is not recognized
+    expect(getLocaleFromPath('/nl/about')).toBe('en');
+    expect(getLocaleFromPath('/zh-cn/blog')).toBe('en');
+  });
+
+  it('normalizes paths without a leading slash', () => {
+    expect(getLocaleFromPath('about')).toBe('en');
+  });
+});
+
+describe('i18n stripLocaleFromPath()', () => {
+  it('leaves a path unchanged when the first segment is not a configured locale', () => {
+    expect(stripLocaleFromPath('/about')).toBe('/about');
+    expect(stripLocaleFromPath('/nl/about')).toBe('/nl/about');
+  });
+
+  it('returns "/" for the root path', () => {
+    expect(stripLocaleFromPath('/')).toBe('/');
+  });
+});
+
+describe('i18n swapLocaleInPath()', () => {
+  it('returns the path unchanged when targeting the default locale (no prefix added)', () => {
+    expect(swapLocaleInPath('/about', 'en')).toBe('/about');
+  });
+
+  it('returns the same path when i18n is disabled, regardless of target', () => {
+    // With default config (single locale), localizedPath is a no-op
+    expect(swapLocaleInPath('/about', 'nl')).toBe('/about');
   });
 });

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,6 +10,7 @@ import CursorTrail from '@/components/effects/CursorTrail.astro';
 import { createWebsiteSchema, createOrganizationSchema, createPersonSchema, createProfessionalServiceSchema } from '@/lib/schema';
 import type { Thing, WithContext } from 'schema-dts';
 import siteConfig from '@/config/site.config';
+import { getLocaleFromPath } from '@/i18n';
 
 interface Props {
   title?: string;
@@ -58,10 +59,12 @@ if (includeProfessionalServiceSchema) {
   schemas.push(createProfessionalServiceSchema());
 }
 schemas.push(...extraSchemas);
+
+const locale = getLocaleFromPath(Astro.url.pathname);
 ---
 
 <!doctype html>
-<html lang="en" class="scroll-smooth dark" data-theme="blue" data-theme-mode="system">
+<html lang={locale} class="scroll-smooth dark" data-theme="blue" data-theme-mode="system">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -17,6 +17,9 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 import { resolveSocialLinks } from '@/lib/utils';
 import { createBlogPostSchema, createFAQSchema } from '@/lib/schema';
 import { getBlogOgPath } from '@/lib/og';
+import { getLocaleFromPath } from '@/i18n';
+
+const locale = getLocaleFromPath(Astro.url.pathname);
 
 const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
 
@@ -218,7 +221,7 @@ const schemas = faqSchema ? [blogPostingSchema, faqSchema] : [blogPostingSchema]
   <!-- Related Posts -->
   {tags.length > 0 && (
     <div class="mx-auto max-w-7xl px-6" data-reveal>
-      <RelatedPosts currentSlug={slug} tags={tags} locale="en" maxPosts={3} />
+      <RelatedPosts currentSlug={slug} tags={tags} locale={locale} maxPosts={3} />
     </div>
   )}
 


### PR DESCRIPTION
## Summary

Fixes a bug reported by @vespeng in #323. Two layouts hardcoded `en`, so sites with i18n enabled emitted the wrong `<html lang>` and pulled related posts from the English content folder regardless of the active route.

- `src/layouts/BaseLayout.astro` — `<html lang="en">` now resolves via `getLocaleFromPath(Astro.url.pathname)`.
- `src/layouts/BlogLayout.astro` — `locale="en"` passed to `<RelatedPosts>` now uses the same helper.

Both layouts use the existing helper from `src/i18n/index.ts` — no new API surface.

## Also included

- **README note** clarifying that `defaultLocale` in `i18n.config.ts` is a routing label, and that the content folder name under `src/content/blog/` must match for the root URL to serve a different default language. This is the gap that confused @vespeng and would have confused the next person too.
- **Unit tests** for `getLocaleFromPath`, `stripLocaleFromPath`, and `swapLocaleInPath` (11 new cases) to prevent regression.
- **CHANGELOG** entry under `[Unreleased]` crediting @vespeng.

## Test plan

- [x] `pnpm test` — 31 passed (3 files), including the 11 new i18n cases
- [x] `pnpm exec astro check` — 0 errors, 0 warnings (only pre-existing hints)
- [ ] Manual: enable i18n with `['en', 'nl']`, load `/` and `/nl/`, confirm `<html lang>` matches the URL and related posts on a Dutch blog page pull from `nl/`

Closes #323 once vespeng's follow-up branch is delivered separately (region-specific content stays out of upstream).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q13cnXEQfApBByheA3o3AF)_