### PR TITLE
docs(blog): clarify `defaultLocale` + content-folder convention in i18n post

### DIFF
--- a/src/content/blog/en/i18n-in-astro-rocket.mdx
+++ b/src/content/blog/en/i18n-in-astro-rocket.mdx
@@ -62,7 +62,7 @@ const i18nConfig: I18nConfig = {
 
 Three things to know:
 
-- **`defaultLocale`** is the locale served at the site root. If you keep it at `'en'`, English visitors keep landing at `/`, `/about`, `/blog`. Set it to `'nl'` instead and Dutch becomes the root locale — English would move to `/en/...`. Most multilingual sites pick the language of their largest audience as the default.
+- **`defaultLocale`** is the locale served at the site root. If you keep it at `'en'`, English visitors keep landing at `/`, `/about`, `/blog`. Set it to `'nl'` instead and Dutch becomes the root locale — English would move to `/en/...`. Most multilingual sites pick the language of their largest audience as the default. One caveat: `defaultLocale` is a routing label, not a content switch. If you flip it to a different language, also rename the matching content folder under `src/content/blog/` (e.g. `en/` → `nl/`) so the root URL resolves to the right posts. The locale code in `i18n.config.ts` and the folder name must match.
 - **`locales`** is the master list. Order doesn't matter for routing, but it controls the order of items in the `LanguageSwitcher` dropdown.
 - **`localeNames`** are the display labels in the dropdown. Use the language's own name (`Nederlands`, not "Dutch") — that's standard practice and respectful to visitors switching from a language they can read.
 
@@ -115,6 +115,8 @@ src/content/blog/nl/hallo-wereld.mdx
 ```
 
 In the Dutch post's frontmatter, set `locale: nl`. The collection schema currently accepts `en`, `es`, and `fr`; add your locale to the enum if you need other codes. The base theme is ready for this — the field, folder convention, and per-post type-safety are all in place.
+
+The folder name has to match the locale code you're using in `i18n.config.ts`. If you set `defaultLocale: 'zh-CN'`, the root posts have to live in `src/content/blog/zh-CN/`, not `src/content/blog/en/` — the folder name is what the route resolves to, not the config value alone.
 
 ## Step 3 — translate the built-in UI strings
 


### PR DESCRIPTION
## Summary

Follow-up to #336. After auditing the 1.3.0 i18n launch post in light of @vespeng's report (#323), one passage was misleading:

> Set [`defaultLocale`] to `'nl'` instead and Dutch becomes the root locale — English would move to `/en/...`.

That oversimplifies. `defaultLocale` is a routing label — the matching content folder under `src/content/blog/` also has to be renamed, because the folder name is what the route resolves to. This is exactly what @vespeng tripped on.

## Changes

Two minimal edits to `src/content/blog/en/i18n-in-astro-rocket.mdx`:

1. **Step 1 — `defaultLocale` bullet**: added a one-line caveat explaining the routing-label vs content-switch distinction.
2. **Content collections section**: added a matching note with a concrete `zh-CN` example, so a skimmer sees it in both places.

## What I deliberately did NOT change

- **Did not rewrite the post wholesale.** It's fundamentally accurate — the bug we fixed in #336 was an implementation oversight in two layouts, not a design flaw the post misrepresented.
- **Did not mention the bug fix.** This is a feature-launch post for 1.3.0, not a patch-notes post. Editing history to make it look like the bug never existed would be dishonest. CHANGELOG already credits @vespeng.

## Test plan

- [x] `pnpm exec astro check` — 0 errors, 0 warnings
- [ ] Read the rendered post on the Vercel preview to confirm the two new sentences flow with the surrounding copy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q13cnXEQfApBByheA3o3AF)_