### PR TITLE
chore(release): 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Unreleased]
+## [1.4.1] — 2026-05-20
 
 ### Fixed
 
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - **i18n README note** — clarified that `defaultLocale` is a routing label and that the content folder name under `src/content/blog/` must match for the root URL to serve a different default language.
+- **i18n blog post update** — added a matching caveat to the 1.3.0 i18n launch post (`src/content/blog/en/i18n-in-astro-rocket.mdx`) so the `defaultLocale` vs content-folder distinction is documented in two places.
 - **i18n tests** — added unit-test coverage for `getLocaleFromPath`, `stripLocaleFromPath`, and `swapLocaleInPath` to prevent regressions on locale resolution.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-rocket",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Astro Rocket — A production-ready Astro 6 theme built on Tailwind CSS v4",
   "type": "module",
   "author": "Hans Martens",


### PR DESCRIPTION
## Summary

Release prep for `1.4.1`. Bundles the two patches merged today:

- **#336** — fix(i18n): resolve `<html lang>` and related-posts locale from URL
- **#337** — docs(blog): clarify `defaultLocale` + content-folder convention in i18n post

## Changes

- `CHANGELOG.md` — renamed `[Unreleased]` heading to `[1.4.1] — 2026-05-20`, and added the blog post update from #337 to the `Added` section so it's credited in the release notes.
- `package.json` — bumped `version` from `1.4.0` to `1.4.1`.

## Next steps after merge

1. Create the GitHub release: https://github.com/hansmartensdev/Astro-Rocket/releases/new
   - Tag: `v1.4.1` (from `main`)
   - Title: `1.4.1`
   - Description: paste the `[1.4.1]` CHANGELOG section
   - "Set as latest release" checked
2. Reply on #323 with the release link so @vespeng can pull.

## Test plan

- [x] `astro check` was clean on both source PRs (#336, #337); no source-code changes in this release commit
- [ ] After merge, verify the tag points at the merge commit before publishing the release

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q13cnXEQfApBByheA3o3AF)_