### PR TITLE
fix(services): remove vestigial order classes on Web Development section

### DIFF
--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -129,7 +129,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-12 lg:grid-cols-2">
         <!-- Text -->
-        <div class="flex flex-col justify-center gap-4 lg:order-1" data-reveal="right" data-reveal-ease="smooth">
+        <div class="flex flex-col justify-center gap-4" data-reveal="right" data-reveal-ease="smooth">
           <Badge variant="brand" pill class="self-start">
             <Icon name="code" size="sm" />
             Web Development
@@ -149,7 +149,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
           </Button>
         </div>
         <!-- Card -->
-        <div class="lg:order-2" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+        <div data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
             <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">


### PR DESCRIPTION
The Web Development section carried lg:order-1 / lg:order-2 classes left over from an abandoned alternating-layout attempt. They reproduced DOM order on desktop (so they looked like no-ops) but caused the card to appear above the text on mobile in some viewports. Drop them so the section behaves identically to Design and Performance on every breakpoint: text first, card second.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
