### PR TITLE
style(article): center end-of-article elements and move share row above divider

### DIFF
--- a/src/components/blog/RelatedPosts.astro
+++ b/src/components/blog/RelatedPosts.astro
@@ -45,7 +45,7 @@ const getPostUrl = (postId: string) => {
 
 {relatedPosts.length > 0 && (
   <section class="border-t border-border py-[var(--space-section-sm)]">
-    <h2 class="font-display text-2xl font-bold text-foreground mb-[var(--space-stack-lg)]">
+    <h2 class="font-display text-2xl font-bold text-foreground mb-[var(--space-stack-lg)] text-center">
       Related Posts
     </h2>
 

--- a/src/components/blog/ShareButtons.astro
+++ b/src/components/blog/ShareButtons.astro
@@ -16,7 +16,7 @@ const shareLinks = {
 };
 ---
 
-<div class="flex items-center gap-4">
+<div class="flex flex-col items-center gap-3">
   <span class="text-sm font-medium text-foreground-muted">Share:</span>
 
   <div class="flex items-center gap-2">

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -186,18 +186,17 @@ const schemas = faqSchema ? [blogPostingSchema, faqSchema] : [blogPostingSchema]
         <slot />
       </div>
 
-      <!-- Article Footer -->
-      <footer class="border-border mt-12 border-t pt-8" data-reveal>
-        <div class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
-          <!-- Back link -->
-          <Button href="/blog" variant="secondary" size="sm">
-            <Icon name="arrow-left" size="sm" />
-            Back to Blog
-          </Button>
+      <!-- Share buttons (centered, above the divider) -->
+      <div class="mt-12 flex justify-center" data-reveal>
+        <ShareButtons title={title} url={fullUrl} />
+      </div>
 
-          <!-- Share buttons -->
-          <ShareButtons title={title} url={fullUrl} />
-        </div>
+      <!-- Article Footer -->
+      <footer class="border-border mt-12 border-t pt-8 flex justify-center" data-reveal>
+        <Button href="/blog" variant="secondary" size="sm">
+          <Icon name="arrow-left" size="sm" />
+          Back to Blog
+        </Button>
       </footer>
       </div>
 

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -154,7 +154,7 @@ const breadcrumbs = [
             <slot />
           </div>
 
-          <footer class="border-border mt-12 border-t pt-8" data-reveal>
+          <footer class="border-border mt-12 border-t pt-8 flex justify-center" data-reveal>
             <Button href="/projects" variant="secondary" size="sm">
               <Icon name="arrow-left" size="sm" />
               Back to Projects
@@ -178,7 +178,7 @@ const breadcrumbs = [
     {related.length > 0 && (
       <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border" data-reveal>
         <div class="mx-auto max-w-7xl px-6">
-          <h2 class="font-display text-2xl md:text-3xl font-bold text-foreground mb-8">More projects</h2>
+          <h2 class="font-display text-2xl md:text-3xl font-bold text-foreground mb-8 text-center">More projects</h2>
           <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {related.map((project) => (
               <Card


### PR DESCRIPTION
## Summary

- Center the "More projects" and "Related Posts" headings on all breakpoints.
- Center the "Back to Projects" / "Back to Blog" footer buttons and stop them from stretching to full width on mobile.
- On single blog posts, move the share buttons above the divider (centered) and put the "Back to Blog" button below the divider (centered).
- Stack the share row vertically on every screen size so the "Share:" label sits above the icons on both mobile and desktop.

## Files touched

- `src/layouts/ProjectLayout.astro`
- `src/components/blog/RelatedPosts.astro`
- `src/layouts/BlogLayout.astro`
- `src/components/blog/ShareButtons.astro`

## Test plan

- [ ] Visit a single project page and confirm the "More projects" heading is centered and the "Back to Projects" button is centered and not full-width on mobile.
- [ ] Visit a single blog post and confirm the "Related Posts" heading is centered.
- [ ] On a single blog post, confirm the share buttons sit centered above the divider and the "Back to Blog" button sits centered below the divider, not full-width on mobile.
- [ ] Confirm the "Share:" label sits above the icon row on both mobile and desktop.
- [ ] `pnpm astro check` reports no new errors (two pre-existing `tocLayout === 'auto'` notices are unrelated).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJCEWUDWiKsb84fa1Vpnsc)_