### PR TITLE
refactor(projects): drop dead per-field hero props after meta-row ref…

### DIFF
--- a/src/components/projects/ProjectHero.astro
+++ b/src/components/projects/ProjectHero.astro
@@ -1,5 +1,4 @@
 ---
-import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
@@ -13,11 +12,6 @@ interface GallerySlide {
 interface Props {
   title: string;
   description: string;
-  tags?: string[];
-  year?: number;
-  client?: string;
-  role?: string;
-  services?: string[];
   meta?: string[];
   url?: string;
   repo?: string;
@@ -29,11 +23,6 @@ interface Props {
 const {
   title,
   description,
-  tags = [],
-  year,
-  client,
-  role,
-  services = [],
   meta = [],
   url,
   repo,

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -23,14 +23,9 @@ import { getProjectOgPath } from '@/lib/og';
 interface Props {
   title: string;
   description: string;
-  year?: number;
-  client?: string;
-  role?: string;
-  services?: string[];
   meta?: string[];
   url?: string;
   repo?: string;
-  tags?: string[];
   image?: ImageMetadata;
   imageAlt?: string;
   gallery?: GallerySlide[];
@@ -45,14 +40,9 @@ interface Props {
 const {
   title,
   description,
-  year,
-  client,
-  role,
-  services = [],
   meta = [],
   url,
   repo,
-  tags = [],
   image,
   imageAlt,
   gallery = [],
@@ -106,11 +96,6 @@ const breadcrumbs = [
     <ProjectHero
       title={title}
       description={description}
-      tags={tags}
-      year={year}
-      client={client}
-      role={role}
-      services={services}
       meta={meta}
       url={url}
       repo={repo}

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -28,14 +28,9 @@ const { Content, headings } = await render(project);
 <ProjectLayout
   title={project.data.title}
   description={project.data.description}
-  year={project.data.year}
-  client={project.data.client}
-  role={project.data.role}
-  services={project.data.services}
   meta={project.data.meta}
   url={project.data.url}
   repo={project.data.repo}
-  tags={project.data.tags}
   image={project.data.image}
   imageAlt={project.data.imageAlt}
   gallery={project.data.gallery}


### PR DESCRIPTION
…actor

ProjectHero stopped rendering tags/year/client/role/services as separate elements when it switched to a unified meta strip; the props were left behind in the component, layout, and page. Remove them from the chain.

https://claude.ai/code/session_01BPMtYid7EWwNTBeoAvj15S

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
