### PR TITLE
Unify mobile reveal direction to vertical below lg

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1112,6 +1112,15 @@
 [data-reveal="right"] { transform: translateX(-56px) scale(0.94); }
 [data-reveal="scale"] { transform: scale(0.88); }
 
+/* Below lg the two-column split sections stack vertically, so horizontal
+   left/right reveals slide sideways against the page's vertical flow — and
+   collide with the hero's slide-up on load. Redirect them to slide up too,
+   so all motion shares one direction on mobile. */
+@media (max-width: 1023.98px) {
+  [data-reveal="left"],
+  [data-reveal="right"] { transform: translateY(56px) scale(0.94); }
+}
+
 [data-reveal].is-visible {
   opacity: 1;
   transform: none;


### PR DESCRIPTION
Horizontal left/right reveals collided with the hero's slide-up on mobile, where two-column sections stack into one column. Redirect them to slide up below the lg breakpoint so all entrance motion shares one direction on small screens; desktop converging effect is unchanged.

https://claude.ai/code/session_01VNZP84NscxHHBB6zrhMYQ1

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
