### PR TITLE
perf: paint hero LCP heading opaque on first frame

### DIFF
--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -49,7 +49,7 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
     )}
 
     <!-- Title -->
-    <h1 class="font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl lg:text-6xl mb-[var(--space-heading-gap)]">
+    <h1 class="hero-lcp-title font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl lg:text-6xl mb-[var(--space-heading-gap)]">
       {title}
     </h1>
 

--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -121,7 +121,7 @@ const gridClasses = cn(
       {/* Title Slot */}
       {hasTitleSlot && (
         <div class={cn(
-          'hero-title-slot mb-[var(--space-heading-gap)]',
+          'hero-title-slot hero-lcp-title mb-[var(--space-heading-gap)]',
           '[&>h1]:font-display [&>h1]:text-5xl [&>h1]:leading-[1.1] [&>h1]:font-bold [&>h1]:tracking-tight [&>h1]:text-balance [&>h1]:text-foreground md:[&>h1]:text-6xl lg:[&>h1]:text-7xl',
           '[&>h2]:font-display [&>h2]:text-4xl [&>h2]:leading-[1.1] [&>h2]:font-bold [&>h2]:tracking-tight [&>h2]:text-balance [&>h2]:text-foreground md:[&>h2]:text-5xl lg:[&>h2]:text-6xl'
         )}>

--- a/src/components/projects/ProjectHero.astro
+++ b/src/components/projects/ProjectHero.astro
@@ -52,7 +52,7 @@ const hasMedia = slides.length > 0;
     >
       <!-- Text column -->
       <div class="animate-hero-stagger min-w-0">
-        <h1 class="font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl lg:text-6xl mb-[var(--space-heading-gap)] text-balance">
+        <h1 class="hero-lcp-title font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl lg:text-6xl mb-[var(--space-heading-gap)] text-balance">
           {title}
         </h1>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1042,17 +1042,27 @@
    ------------------------------------------------------------------------- */
 
 /* Spring curve approximating Framer Motion's spring(stiffness:100, damping:15).
-   Pronounced overshoot gives elements a "settle" feel on entrance.
-   Initial opacity is 0.01 (not 0) so the LCP element registers as a paint
-   candidate; the value is imperceptible to humans but visible to the
-   browser's LCP observer. */
+   Pronounced overshoot gives elements a "settle" feel on entrance. */
 @keyframes hero-slide-up {
   from {
-    opacity: 0.01;
+    opacity: 0;
     transform: translateY(40px);
   }
   to {
     opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Transform-only variant for the hero heading. The heading is the LCP
+   element, so it must never fade in: an element below full opacity can be
+   deferred or skipped as an LCP paint candidate. It slides up like the rest
+   of the hero but stays fully opaque from the first painted frame. */
+@keyframes hero-slide-up-solid {
+  from {
+    transform: translateY(40px);
+  }
+  to {
     transform: translateY(0);
   }
 }
@@ -1073,6 +1083,14 @@
 .animate-hero-stagger > *:nth-child(4)   { animation-delay: 270ms; }
 .animate-hero-stagger > *:nth-child(5)   { animation-delay: 360ms; }
 .animate-hero-stagger > *:nth-child(n+6) { animation-delay: 450ms; }
+
+/* The hero heading opts into the transform-only keyframe so it paints opaque
+   on frame 1. This selector outranks the `> *` rule above, so it overrides
+   only animation-name — duration, easing, fill mode and the per-position
+   animation-delay are all inherited unchanged. */
+.animate-hero-stagger > .hero-lcp-title {
+  animation-name: hero-slide-up-solid;
+}
 
 /* Floating header drop-in: lands from above as the hero rises from below.
    The translate values mirror the auto-hide hidden state so the entrance
@@ -1187,6 +1205,7 @@
 @media (prefers-reduced-motion: reduce) {
   .animate-hero-slide-up,
   .animate-hero-stagger > *,
+  .animate-hero-stagger > .hero-lcp-title,
   .animate-header-drop {
     animation: none;
   }


### PR DESCRIPTION
The hero heading is the LCP element on the home, project and blog pages, but it shared the hero entrance keyframe that fades in from near-zero opacity. An element below full opacity can be deferred or skipped as an LCP paint candidate. Add a transform-only keyframe scoped to the heading so it slides up like the rest of the hero while staying fully opaque from the first painted frame; non-heading elements keep their fade.

https://claude.ai/code/session_01HFwpriyXqoM9DgAKLH9eGB

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
