### PR TITLE
feat(hero): add opt-in fullHeight prop for full-viewport homepage hero

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -20,6 +20,8 @@ interface Props extends HTMLAttributes<'section'> {
   bottomFade?: boolean;
   /** Show an animated scroll indicator at the bottom (desktop only, hides on scroll) */
   showScrollIndicator?: boolean;
+  /** Stretch the section to fill at least the full viewport height (min-h-[100dvh]) */
+  fullHeight?: boolean;
 }
 
 const {
@@ -31,6 +33,7 @@ const {
   showGlow = false,
   bottomFade = false,
   showScrollIndicator = false,
+  fullHeight = false,
   class: className,
   ...attrs
 } = Astro.props;
@@ -46,7 +49,7 @@ const hasAsideSlot = Astro.slots.has('aside');
 const alignment = layout === 'centered' ? 'text-center items-center' : 'text-left items-start';
 
 // Compute classes
-const sectionClasses = cn(heroSectionVariants({ size }), className);
+const sectionClasses = cn(heroSectionVariants({ size }), fullHeight && 'min-h-[100dvh]', className);
 
 const contentClasses = cn(
   'z-10 flex flex-col',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,7 +33,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   includeProfessionalServiceSchema={true}
 >
   <!-- Hero -->
-  <Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator>
+  <Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator fullHeight>
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">Available for new projects</Badge>
 
     <h1 slot="title" class="!text-[clamp(2rem,11.2vw,3rem)] sm:!text-5xl md:!text-6xl lg:!text-7xl">


### PR DESCRIPTION
Add a fullHeight boolean prop to the Hero component that appends min-h-[100dvh] via the cn/tailwind-merge helper, preserving the existing size padding. Enable it only on the homepage so the hero fills the viewport while keeping its content in place.

https://claude.ai/code/session_01TE2Afv2rbqpRHpNBPnqNt6

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
