### PR TITLE
Add light-grid / dark-halo hero backgrounds to non-homepage heroes

### DIFF
--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -4,6 +4,8 @@ import type { ImageMetadata } from 'astro';
 import { formatDate } from '@/lib/utils';
 import Logo from '@/components/ui/marketing/Logo/Logo.astro';
 import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
+import HeroGrid from '@/components/effects/HeroGrid.astro';
+import HeroBeam from '@/components/effects/HeroBeam.astro';
 
 interface Props {
   title: string;
@@ -35,7 +37,10 @@ const estimatedWords = description.split(' ').length * 15;
 const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
 ---
 
-<header class="relative overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section)]">
+<header class="article-hero relative isolate overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section)]">
+  <HeroGrid />
+  <HeroBeam />
+
   <div class="relative z-[1] mx-auto max-w-4xl px-6 animate-hero-stagger">
     <!-- Tags -->
     {tags.length > 0 && (
@@ -129,3 +134,37 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
     </div>
   )}
 </header>
+
+<style>
+  /* The hero grid/beam span the whole <header>, which on the blog post also
+     contains the large featured image below the intro — so the pattern runs
+     far too low. Cap both with a soft vertical fade measured from the header
+     top so they disappear just under the intro text: under the H1 on mobile,
+     under the lead paragraph on desktop. (The beam's top light sits above
+     this fade, so only the grid is trimmed.) */
+  .article-hero :global(.hero-grid),
+  .article-hero :global(.hero-beam) {
+    --grid-fade-start: 200px;
+    --grid-fade-end: 320px;
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      #000 0,
+      #000 var(--grid-fade-start),
+      transparent var(--grid-fade-end)
+    );
+    mask-image: linear-gradient(
+      to bottom,
+      #000 0,
+      #000 var(--grid-fade-start),
+      transparent var(--grid-fade-end)
+    );
+  }
+
+  @media (min-width: 1024px) {
+    .article-hero :global(.hero-grid),
+    .article-hero :global(.hero-beam) {
+      --grid-fade-start: 280px;
+      --grid-fade-end: 430px;
+    }
+  }
+</style>

--- a/src/components/effects/HeroBeam.astro
+++ b/src/components/effects/HeroBeam.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * HeroBeam
+ * Dark-mode-only hero backdrop: a brand-tinted line grid plus a soft brand
+ * "beam" of light spilling downward from the top edge.
+ *
+ * The top edge matters: on these pages <main> pads down by the fixed header's
+ * height (pt-16 === header h-16), so the hero section starts flush under the
+ * header. Anchoring the light to the hero's top therefore makes it read as
+ * light falling from the bottom of the fixed header.
+ *
+ * Adapted from a "meteor grid" effect, minus the meteors: the light is just
+ * the box-shadow of an off-screen ellipse, the grid is two linear-gradients.
+ * Pure CSS, static, no JS — no Lighthouse cost.
+ *
+ * Restrained ("option 1"): the beam fades out high, before the hero's badge
+ * and headline, so the centred brand pill / brand H1 stay clean on dark.
+ *
+ * Requirements:
+ *  - Parent must be `position: relative; overflow: hidden` (the Hero section
+ *    already is).
+ *  - Content must sit above the beam (give it z-10).
+ *
+ * Hidden in light mode, where HeroGrid does the work instead.
+ */
+interface Props {
+  /** Extra classes for the wrapper. */
+  class?: string;
+}
+
+const { class: className } = Astro.props;
+const classes = ['hero-beam pointer-events-none absolute inset-0 overflow-hidden', className]
+  .filter(Boolean)
+  .join(' ');
+---
+
+<div class={classes} aria-hidden="true">
+  <div class="hero-beam__grid"></div>
+  <div class="hero-beam__light"></div>
+</div>
+
+<style>
+  .hero-beam {
+    z-index: 0;
+    --beam-gap: 56px;
+    --beam-line: color-mix(in oklch, var(--color-brand-500) 14%, transparent);
+    --beam-glow: color-mix(in oklch, var(--color-brand-400) 50%, transparent);
+  }
+
+  /* Dark-mode only — the light-mode HeroGrid covers light pages. */
+  :global(html:not(.dark)) .hero-beam { display: none; }
+
+  .hero-beam > div { position: absolute; }
+
+  /* Brand grid — brightest just under the header, dissolving outward. */
+  .hero-beam__grid {
+    inset: 0;
+    background-image:
+      linear-gradient(to right, var(--beam-line) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--beam-line) 1px, transparent 1px);
+    background-size: var(--beam-gap) var(--beam-gap);
+    -webkit-mask-image: radial-gradient(75% 60% at 50% 0%, #000 0%, transparent 75%);
+    mask-image: radial-gradient(75% 60% at 50% 0%, #000 0%, transparent 75%);
+  }
+
+  /* The beam: an off-screen ellipse whose soft shadow spills down from the
+     top edge (= header bottom). Its own body sits above the wrapper and is
+     clipped by overflow-hidden; only the downward glow shows. */
+  .hero-beam__light {
+    left: 2.5rem;
+    right: 2.5rem;
+    top: -120px;
+    height: 120px;
+    border-radius: 50%;
+    box-shadow: 0 24px 52px -12px var(--beam-glow);
+  }
+</style>

--- a/src/components/effects/HeroGrid.astro
+++ b/src/components/effects/HeroGrid.astro
@@ -1,0 +1,88 @@
+---
+/**
+ * HeroGrid
+ * A faint architectural line grid behind the hero — light-mode only. Three
+ * layers:
+ *   1. base  — neutral grid, dissolving outward from the top-centre.
+ *   2. brand — the same grid tinted blue, masked to a tighter top-centre
+ *              bloom so the lines "light up" with brand colour.
+ *   3. edge  — a soft 1px blue hairline along the very top edge.
+ * Hidden in dark mode, where the `.hero-halo` glow does the work instead.
+ * Pure CSS, no JS, no animation. All viewports.
+ *
+ * Requirements:
+ *  - Parent must be `position: relative; overflow: hidden`.
+ *
+ * Usage:
+ *   <section class="relative isolate overflow-hidden">
+ *     <HeroGrid />
+ *     ...content (give it z-10 so it sits above the grid)...
+ *   </section>
+ */
+interface Props {
+  /** Extra classes for the wrapper. */
+  class?: string;
+}
+
+const { class: className } = Astro.props;
+const classes = ['hero-grid pointer-events-none absolute inset-0', className]
+  .filter(Boolean)
+  .join(' ');
+---
+
+<div class={classes} aria-hidden="true">
+  <div class="hero-grid__base"></div>
+  <div class="hero-grid__brand"></div>
+  <div class="hero-grid__edge"></div>
+</div>
+
+<style>
+  .hero-grid {
+    z-index: 0;
+    overflow: hidden;
+    --grid-gap: 56px;
+    --grid-line: color-mix(in oklch, var(--color-foreground) 7%, transparent);
+    --grid-brand: color-mix(in oklch, var(--color-brand-500) 70%, transparent);
+  }
+
+  .hero-grid > div {
+    position: absolute;
+    inset: 0;
+  }
+
+  /* Neutral grid — the structure, dissolving outward from the top-centre. */
+  .hero-grid__base {
+    background-image:
+      linear-gradient(to right, var(--grid-line) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--grid-line) 1px, transparent 1px);
+    background-size: var(--grid-gap) var(--grid-gap);
+    -webkit-mask-image: radial-gradient(62% 85% at 50% 0%, #000 0%, transparent 72%);
+    mask-image: radial-gradient(62% 85% at 50% 0%, #000 0%, transparent 72%);
+  }
+
+  /* Blue bloom — same grid, lit up in brand colour at the top-centre. */
+  .hero-grid__brand {
+    background-image:
+      linear-gradient(to right, var(--grid-brand) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--grid-brand) 1px, transparent 1px);
+    background-size: var(--grid-gap) var(--grid-gap);
+    opacity: 0.6;
+    -webkit-mask-image: radial-gradient(42% 56% at 50% 0%, #000 0%, transparent 70%);
+    mask-image: radial-gradient(42% 56% at 50% 0%, #000 0%, transparent 70%);
+  }
+
+  /* Lit top edge — soft blue hairline fading at the sides. */
+  .hero-grid__edge {
+    inset: 0 0 auto 0;
+    height: 1px;
+    background: linear-gradient(
+      to right,
+      transparent,
+      color-mix(in oklch, var(--color-brand-500) 60%, transparent) 50%,
+      transparent
+    );
+  }
+
+  /* Light-mode only — the grid is hidden on dark heroes. */
+  :global(html.dark) .hero-grid { display: none; }
+</style>

--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -2,6 +2,8 @@
 import type { HTMLAttributes } from 'astro/types';
 import { cn } from '@/lib/cn';
 import { heroSectionVariants } from './hero.variants';
+import HeroGrid from '@/components/effects/HeroGrid.astro';
+import HeroBeam from '@/components/effects/HeroBeam.astro';
 
 interface Props extends HTMLAttributes<'section'> {
   /** Layout mode: centered single column or split two-column */
@@ -14,6 +16,8 @@ interface Props extends HTMLAttributes<'section'> {
   showGlow?: boolean;
   /** Show decorative gradient blob */
   showBlob?: boolean;
+  /** Render the light-mode architectural grid + dark-mode halo behind the hero */
+  showHeroHalo?: boolean;
   /** Blob position (only applies when showBlob is true) */
   blobPosition?: 'left' | 'right' | 'center';
   /** Fade the bottom of the section into the next section's background */
@@ -31,6 +35,7 @@ const {
   showBlob = false,
   blobPosition: _blobPosition = 'center',
   showGlow = false,
+  showHeroHalo = false,
   bottomFade = false,
   showScrollIndicator = false,
   fullHeight = false,
@@ -57,12 +62,15 @@ const contentClasses = cn(
 );
 
 const gridClasses = cn(
-  'mx-auto grid max-w-6xl grid-cols-1 items-center gap-[var(--space-section-gap)] px-6',
+  'relative z-10 mx-auto grid max-w-6xl grid-cols-1 items-center gap-[var(--space-section-gap)] px-6',
   layout === 'split' && 'lg:grid-cols-2 lg:gap-[var(--space-section-gap)]'
 );
 ---
 
 <section class={sectionClasses} {...attrs}>
+  {showHeroHalo && <HeroGrid />}
+  {showHeroHalo && <HeroBeam />}
+
   {showGrid && (
     <div
       class="bg-grid-pattern pointer-events-none absolute inset-x-0 -inset-y-[20%] opacity-30 hidden md:dark:block"

--- a/src/components/projects/ProjectHero.astro
+++ b/src/components/projects/ProjectHero.astro
@@ -3,6 +3,8 @@ import type { ImageMetadata } from 'astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import ProjectCarousel from '@/components/projects/ProjectCarousel.astro';
+import HeroGrid from '@/components/effects/HeroGrid.astro';
+import HeroBeam from '@/components/effects/HeroBeam.astro';
 
 interface GallerySlide {
   src: ImageMetadata;
@@ -42,8 +44,11 @@ const slides: GallerySlide[] =
 const hasMedia = slides.length > 0;
 ---
 
-<header class="relative overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section-md)]">
-  <div class="mx-auto max-w-7xl px-6">
+<header class="relative isolate overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section-md)]">
+  <HeroGrid />
+  <HeroBeam />
+
+  <div class="relative z-10 mx-auto max-w-7xl px-6">
     <div
       class:list={[
         'grid items-center gap-10',

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -18,7 +18,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
   title="About Astro Rocket — Web Designer & Developer | Eindhoven"
   description="Designer & developer — Crafting modern web experiences shaped by clean design, solid structure, and attention to detail."
 >
-  <Hero layout="centered" size="sm">
+  <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>
       <Icon name="user" size="sm" />
       About me

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -38,7 +38,7 @@ const topTags = collectTopTags(posts, TAG_CLOUD_LIMIT);
 ---
 
 <PageLayout title="Blog — Astro Rocket" description="Articles on web design, development, and the web by Astro Rocket." showScrollProgress eagerReveal>
-  <Hero layout="centered" size="sm">
+  <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>
       <Icon name="book" size="sm" />
       All posts

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -39,7 +39,7 @@ const channels = [
   description="Starting something new? I design and build new websites from scratch — tell me about your project and I'll get back to you within 1 business day."
   eagerReveal
 >
-  <Hero layout="centered" size="sm">
+  <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>
       <Icon name="mail" size="sm" />
       Start a project

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -21,7 +21,7 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
   description="Selected work — websites, tools, and open-source projects built by Astro Rocket."
   eagerReveal
 >
-  <Hero layout="centered" size="sm">
+  <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>
       <Icon name="layers" size="sm" />
       Selected work

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -15,7 +15,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
   title="Services — Web Design, Development & Performance"
   description="Three core services for modern websites: thoughtful design, clean Astro development, and measurable performance & SEO."
 >
-  <Hero layout="centered" size="sm">
+  <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>
       <Icon name="sparkles" size="sm" />
       Services


### PR DESCRIPTION
Port HeroGrid (light-mode architectural grid) and HeroBeam (dark-mode brand grid + top-edge light beam) from the HansMartens site. Wire them into the project and article heroes, and add a showHeroHalo prop to the shared Hero so the about, contact, services, projects, and blog index pages render the same backdrop.

https://claude.ai/code/session_01Fv821hCFn2aweUJbUf4StT

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
