### PR TITLE
Fix focus-ring contrast and wire up destructive colour tokens

### DIFF
--- a/src/components/ui/form/Button/button.variants.ts
+++ b/src/components/ui/form/Button/button.variants.ts
@@ -23,7 +23,7 @@ export const buttonVariants = cva(
           'text-foreground-secondary hover:text-foreground hover:bg-secondary active:scale-[0.98]',
         link: 'text-foreground-secondary hover:text-foreground underline-offset-4 hover:underline',
         destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90 active:scale-[0.98]',
+          'btn-destructive bg-destructive text-destructive-foreground hover:bg-destructive/90 active:scale-[0.98]',
       },
       size: {
         sm: 'h-8 px-3 text-xs [&_svg]:h-4 [&_svg]:w-4',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -68,6 +68,9 @@
   --color-accent: var(--accent);
   --color-accent-hover: var(--accent-hover);
 
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
 
@@ -1260,6 +1263,16 @@
 :root:not(.dark) .hdr-cta-brand:hover {
   background-color: var(--color-brand-800) !important;
   opacity: 1 !important;
+}
+
+/* Destructive button — fixed dark red in both modes so the white label clears
+   WCAG AA (white on oklch(53%) = 5.9:1). Decoupled from the --destructive token,
+   which is tuned lighter in dark mode to stay readable as inline error text. */
+.btn-destructive {
+  background-color: oklch(53% 0.2 25);
+}
+.btn-destructive:hover {
+  background-color: oklch(47% 0.18 25);
 }
 
 .hero-btn-learn {

--- a/src/styles/themes/amber.css
+++ b/src/styles/themes/amber.css
@@ -67,12 +67,12 @@ html[data-theme="amber"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
   /* Destructive */
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   /* Gradient colors */

--- a/src/styles/themes/blue.css
+++ b/src/styles/themes/blue.css
@@ -66,12 +66,12 @@ html[data-theme="blue"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
   /* Destructive */
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   /* Gradient colors */

--- a/src/styles/themes/cyan.css
+++ b/src/styles/themes/cyan.css
@@ -61,11 +61,11 @@ html[data-theme="cyan"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   --gradient-start: oklch(96.5% 0 0);

--- a/src/styles/themes/emerald.css
+++ b/src/styles/themes/emerald.css
@@ -66,12 +66,12 @@ html[data-theme="emerald"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
   /* Destructive */
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   /* Gradient colors */

--- a/src/styles/themes/green.css
+++ b/src/styles/themes/green.css
@@ -65,12 +65,12 @@ html[data-theme="green"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
   /* Destructive */
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   /* Gradient colors */

--- a/src/styles/themes/indigo.css
+++ b/src/styles/themes/indigo.css
@@ -62,11 +62,11 @@ html[data-theme="indigo"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   --gradient-start: oklch(96.5% 0 0);

--- a/src/styles/themes/lime.css
+++ b/src/styles/themes/lime.css
@@ -67,12 +67,12 @@ html[data-theme="lime"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
   /* Destructive */
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   /* Gradient colors */

--- a/src/styles/themes/magenta.css
+++ b/src/styles/themes/magenta.css
@@ -66,12 +66,12 @@ html[data-theme="magenta"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
   /* Destructive */
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   /* Gradient colors */

--- a/src/styles/themes/orange.css
+++ b/src/styles/themes/orange.css
@@ -58,12 +58,12 @@ html[data-theme="orange"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
   /* Destructive - for delete/remove actions */
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   /* Gradient colors - OKLCH */

--- a/src/styles/themes/purple.css
+++ b/src/styles/themes/purple.css
@@ -62,11 +62,11 @@ html[data-theme="purple"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   --gradient-start: oklch(96.5% 0 0);

--- a/src/styles/themes/sky.css
+++ b/src/styles/themes/sky.css
@@ -62,11 +62,11 @@ html[data-theme="sky"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   --gradient-start: oklch(96.5% 0 0);

--- a/src/styles/themes/teal.css
+++ b/src/styles/themes/teal.css
@@ -66,12 +66,12 @@ html[data-theme="teal"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
   /* Destructive */
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   /* Gradient colors */

--- a/src/styles/themes/violet.css
+++ b/src/styles/themes/violet.css
@@ -62,11 +62,11 @@ html[data-theme="violet"] {
 
   --input-bg: var(--gray-0);
   --input-border: var(--gray-300);
-  --input-focus: var(--brand-500);
+  --input-focus: var(--brand-600);
 
-  --ring: var(--brand-500);
+  --ring: var(--brand-600);
 
-  --destructive: var(--error);
+  --destructive: oklch(53% 0.2 25); /* darker red: WCAG AA as error text on white (5.9:1) */
   --destructive-foreground: var(--gray-0);
 
   --gradient-start: oklch(96.5% 0 0);


### PR DESCRIPTION
Focus ring: light-mode --ring / --input-focus brand-500 -> brand-600 so the keyboard focus indicator clears WCAG 2.2 1.4.11 (>=3:1) on white for the lighter hues (amber/emerald/teal/cyan were 2.8-3.0:1, now 4.2-5.7:1).

Destructive: register --color-destructive / --color-destructive-foreground in @theme so the bg-/text-/border-/ring-destructive utilities actually generate (they produced no CSS before, so error text, the required asterisk, error borders and the delete button rendered with no colour). Darkened light-mode --destructive to oklch(53% .2 25) so red error text on white hits 5.9:1, and gave the destructive button a fixed dark-red fill (.btn-destructive) so the white label clears AA in both modes without making dark-mode error text (which stays lighter) unreadable.

https://claude.ai/code/session_01EDoBx4NmEZK77quzfMSpvS

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
