### PR TITLE
Remove brand glow from LetterGlitch CTA bands

### DIFF
--- a/src/components/patterns/LetterGlitchBand.astro
+++ b/src/components/patterns/LetterGlitchBand.astro
@@ -12,10 +12,6 @@ const maxWidthClass = maxWidth === '7xl' ? 'max-w-7xl' : 'max-w-6xl';
 
 <div class:list={['hidden glitch:block mx-auto px-6', maxWidthClass]}>
   <div class="relative isolate">
-    <div
-      class="pointer-events-none absolute inset-0 -z-10 rounded-3xl blur-3xl dark:bg-brand-500/25"
-      aria-hidden="true"
-    ></div>
     <div class="invert-section relative overflow-hidden rounded-3xl border border-white/10">
       <div class="absolute inset-0" aria-hidden="true">
         <LetterGlitch client:visible outerVignette />


### PR DESCRIPTION
Drop the blurred brand-500 backdrop behind the LetterGlitchBand so the desktop CTA sections render without the brand glow in dark and light mode.

https://claude.ai/code/session_01GyihKWbHM1FsSn5zqDFuKU

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
