### PR TITLE
Replace partnership section with Building since 2010 on about page

### DIFF
--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -129,7 +129,7 @@ const siteConfig: SiteConfig = {
   email: 'hello@hansmartens.dev',
   address: {
     street: '',
-    city: 'Eindhoven',
+    city: 'Amsterdam',
     state: '',
     zip: '',
     country: 'the Netherlands',

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -15,7 +15,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
 ---
 <PageLayout
-  title="About Astro Rocket — Web Designer & Developer | Eindhoven"
+  title="About Astro Rocket — Web Designer & Developer | Amsterdam"
   description="Designer & developer — Crafting modern web experiences shaped by clean design, solid structure, and attention to detail."
 >
   <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
@@ -36,66 +36,93 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
     </p>
   </Hero>
 
-  <!-- What's possible now -->
+  <!-- About me -->
   <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-12 lg:grid-cols-2">
         <!-- Left: text -->
-        <div class="flex flex-col gap-4" data-reveal="right" data-reveal-ease="smooth">
+        <div class="flex flex-col justify-center gap-4" data-reveal="right" data-reveal-ease="smooth">
           <div class="flex flex-col gap-6">
-            <Badge variant="brand" pill class="self-start">The partnership</Badge>
+            <Badge variant="brand" pill class="self-start">Building since 2010</Badge>
             <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
-              Meet the team:<br /> Astro Rocket & Claude
+              Sixteen years of hands‑on craft
             </h2>
           </div>
           <p class="text-lg text-foreground-muted leading-relaxed">
-           I'm a web designer and developer with 16 years of hands‑on experience. Today I work alongside <a href="https://claude.ai/code" target="_blank" rel="noopener noreferrer" class="underline underline-offset-2 decoration-brand-500 hover:text-brand-400 transition-colors">Claude</a> — not as a shortcut, but as a genuine collaborator that helps me think through design decisions, review code, and build more thoroughly than I could alone.
+            I'm a web designer and developer with 16 years of hands‑on experience, based in Amsterdam and working worldwide. Design and the code beneath it aren't separate jobs to me — they're one craft, kept with the same person from first sketch to final deploy.
           </p>
           <p class="text-lg text-foreground-muted leading-relaxed">
-            This isn't about automating the work — it's about raising the standard of it. Every design decision still comes from craft and experience. Every line of code is still written with intention. Claude helps me think more rigorously, not less. The work stays mine. The thinking gets sharper.
+            The result is fast, maintainable sites built with intention — and a direct line to the person actually doing the work, from the first conversation to launch.
           </p>
         </div>
-        <!-- Right: two stacked partner cards -->
-        <div class="flex flex-col gap-4 h-full" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
-          <Card variant="elevated" hover class="flex-1 flex flex-col justify-center">
+        <!-- Right: personal facts card -->
+        <div class="flex flex-col h-full" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+          <Card variant="elevated" class="flex-1 flex flex-col justify-center gap-6">
+            <div class="flex items-start gap-4">
+              <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
+                <Icon name="map-pin" size="md" />
+              </div>
+              <div class="flex-1 min-w-0">
+                <h3 class="text-base font-semibold text-foreground">Based in Amsterdam</h3>
+                <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
+                  Working with clients worldwide, in Dutch or English.
+                </p>
+              </div>
+            </div>
             <div class="flex items-start gap-4">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
                 <Icon name="code-2" size="md" />
               </div>
               <div class="flex-1 min-w-0">
-                <p class="text-xs font-bold tracking-wide casesensitive text-foreground-muted mb-1">Web Designer & Developer</p>
-                <h3 class="text-base font-semibold text-foreground">Astro Rocket</h3>
+                <h3 class="text-base font-semibold text-foreground">Built on Astro</h3>
                 <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
-                  16 years of craft — design, code, performance, and honest communication. Based in Eindhoven, working worldwide.
+                  Every site runs on Astro: fast by default, easy to maintain.
                 </p>
-                <div class="flex flex-wrap gap-1.5 mt-3">
-                  <Badge size="sm" variant="brand">Astro</Badge>
-                  <Badge size="sm" variant="brand">Tailwind</Badge>
-                  <Badge size="sm" variant="brand">TypeScript</Badge>
-                </div>
               </div>
             </div>
-          </Card>
-          <Card variant="elevated" hover href="https://claude.ai/code" target="_blank" rel="noopener noreferrer" class="group flex-1 flex flex-col justify-center">
-            <div class="flex items-start justify-between gap-4">
-              <div class="flex items-start gap-4 flex-1 min-w-0">
-                <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
-                  <Icon name="sparkles" size="md" />
-                </div>
-                <div class="flex-1 min-w-0">
-                  <p class="text-xs font-bold tracking-wide casesensitive text-foreground-muted mb-1">AI Thinking Partner</p>
-                <h3 class="text-base font-semibold text-foreground">Claude</h3>
+            <div class="flex items-start gap-4">
+              <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
+                <Icon name="search" size="md" />
+              </div>
+              <div class="flex-1 min-w-0">
+                <h3 class="text-base font-semibold text-foreground">Built to be found</h3>
                 <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
-                  Reasoning through decisions, reviewing code and copy, exploring alternatives — a second perspective at every stage of a project.
+                  Clean, semantic markup with SEO baked in from the first line.
                 </p>
-                <div class="flex flex-wrap gap-1.5 mt-3">
-                  <Badge size="sm" variant="brand">Design review</Badge>
-                  <Badge size="sm" variant="brand">Code QA</Badge>
-                  <Badge size="sm" variant="brand">Deep thinking</Badge>
-                </div>
               </div>
+            </div>
+            <div class="flex items-start gap-4">
+              <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
+                <Icon name="laptop" size="md" />
               </div>
-              <Icon name="arrow-up-right" size="sm" class="text-foreground-muted group-hover:text-brand-500 transition-colors shrink-0" />
+              <div class="flex-1 min-w-0">
+                <h3 class="text-base font-semibold text-foreground">Looks right everywhere</h3>
+                <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
+                  Responsive by design, from phone to widescreen.
+                </p>
+              </div>
+            </div>
+            <div class="flex items-start gap-4">
+              <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
+                <Icon name="sparkles" size="md" />
+              </div>
+              <div class="flex-1 min-w-0">
+                <h3 class="text-base font-semibold text-foreground">A thinking partner</h3>
+                <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
+                  I work alongside Claude to review code — a second perspective that challenges my decisions before they ship.
+                </p>
+              </div>
+            </div>
+            <div class="flex items-start gap-4">
+              <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
+                <Icon name="message-circle" size="md" />
+              </div>
+              <div class="flex-1 min-w-0">
+                <h3 class="text-base font-semibold text-foreground">Direct contact</h3>
+                <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
+                  You talk to the person doing the work.
+                </p>
+              </div>
             </div>
           </Card>
         </div>
@@ -290,7 +317,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
                 <Icon name="chevron-down" size="sm" class="faq-icon shrink-0 text-foreground-muted transition-transform duration-200" />
               </summary>
               <div class="pb-4 text-sm text-foreground-muted leading-relaxed">
-                Absolutely. I'm based in Eindhoven but work with clients worldwide. Most projects run entirely remote, which works well for clear briefs and good communication. Time zone differences are rarely a problem.
+                Absolutely. I'm based in Amsterdam but work with clients worldwide. Most projects run entirely remote, which works well for clear briefs and good communication. Time zone differences are rarely a problem.
               </div>
             </details>
           </div>


### PR DESCRIPTION
Swap the partnership section for the Building since 2010 section.

https://claude.ai/code/session_01SNocyTTg2d7VDEQEnEDDxu

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
