### PR TITLE
Make Violet the default theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Astro Rocket uses a three-tier design token system with OKLCH colors for percept
 
 Astro Rocket ships with 12 colour themes, all based on Tailwind's color palette. All 12 are shown as colour swatches in the header dropdown (`ThemeSelectorDropdown`) on desktop and in the mobile menu (`ThemeSelector`). Clicking a swatch applies the theme instantly — the logo badge, blog image gradients, and every brand color on the page update live. No file edits, no rebuilds. This is the key difference from Velocity, where switching theme requires editing a CSS import file and rebuilding.
 
-The 12 themes in order: Orange, Amber, Lime, Emerald, Teal, Cyan, Sky, Blue (default), Indigo, Violet, Purple, and Magenta. The `themes` array in `src/components/layout/ThemeSelector.astro` controls which swatches are shown and in what order. You can also **remove the selector from the header entirely** once you've settled on a color — just remove `showThemeSelector` from the layout file.
+The 12 themes in order: Orange, Amber, Lime, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet (default), Purple, and Magenta. The `themes` array in `src/components/layout/ThemeSelector.astro` controls which swatches are shown and in what order. You can also **remove the selector from the header entirely** once you've settled on a color — just remove `showThemeSelector` from the layout file.
 
 The theme files live in `src/styles/themes/`:
 
@@ -374,7 +374,7 @@ State contract:
 Defaults are seeded directly on the `<html>` element in `src/layouts/BaseLayout.astro` so JS-disabled visitors still see a sensible state:
 
 ```html
-<html lang="en" class="scroll-smooth dark" data-theme="blue" data-theme-mode="system">
+<html lang="en" class="scroll-smooth dark" data-theme="violet" data-theme-mode="system">
 ```
 
 Flash-of-wrong-theme is prevented by an inline `<script>` in `<head>` that runs synchronously before body paint, reads `localStorage.theme`, and reconciles `data-theme-mode` + `.dark`. The same script also re-applies on `astro:before-swap` / `astro:after-swap` to handle view transitions, and subscribes once to the OS-preference media query.

--- a/src/components/layout/ThemeSelector.astro
+++ b/src/components/layout/ThemeSelector.astro
@@ -84,7 +84,7 @@ const themes = [
 
 <script>
   const STORAGE_KEY = 'color-theme';
-  const DEFAULT_THEME = 'blue';
+  const DEFAULT_THEME = 'violet';
 
   function getActiveTheme(): string {
     try {

--- a/src/components/layout/ThemeSelectorDropdown.astro
+++ b/src/components/layout/ThemeSelectorDropdown.astro
@@ -118,7 +118,7 @@ const themes = [
 
 <script>
   const STORAGE_KEY = 'color-theme';
-  const DEFAULT_THEME = 'blue';
+  const DEFAULT_THEME = 'violet';
 
   function getActiveTheme(): string {
     try {

--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -186,7 +186,7 @@ const siteConfig: SiteConfig = {
       svg: '/favicon.svg',
     },
     colors: {
-      themeColor: '#3b82f6',
+      themeColor: '#8b5cf6',
       backgroundColor: '#ffffff',
     },
   },

--- a/src/content/blog/en/astro-rocket-configuration-guide.mdx
+++ b/src/content/blog/en/astro-rocket-configuration-guide.mdx
@@ -73,19 +73,19 @@ When `true`, a translucent brand-colour tint is applied over blog cover images. 
 Astro Rocket uses a 3-state colour-mode system — **System / Light / Dark** — instead of a binary toggle. Defaults are declared on the `<html>` element in `src/layouts/BaseLayout.astro`:
 
 ```html
-<html lang="en" class="scroll-smooth dark" data-theme="blue" data-theme-mode="system">
+<html lang="en" class="scroll-smooth dark" data-theme="violet" data-theme-mode="system">
 ```
 
 Three pieces of state cooperate:
 
 - `class="dark"` is the SSR fallback for visitors with JavaScript disabled — Tailwind's dark variant keys off it.
 - `data-theme-mode="system"` mirrors the user's saved choice and drives the icon shown in the header pill.
-- `data-theme="blue"` is the default colour palette.
+- `data-theme="violet"` is the default colour palette.
 
 For visitors with JavaScript enabled, the inline bootstrap script in `<head>` runs before body paint and reconciles all three values from storage:
 
 - `localStorage.theme` ∈ `'system' | 'light' | 'dark'` — the user's saved colour mode (default `'system'`)
-- `sessionStorage['color-theme']` — the active colour palette (default `'blue'`, resets per tab session)
+- `sessionStorage['color-theme']` — the active colour palette (default `'violet'`, resets per tab session)
 
 Under `'system'`, the bootstrap also subscribes to `window.matchMedia('(prefers-color-scheme: dark)')` once and re-applies on every OS flip. The full design — including the no-flash bootstrap, view-transition handling, and the header pill — is written up in [System, Light, Dark — How Astro Rocket's Colour-Mode System Works](/blog/colour-mode-system).
 
@@ -165,7 +165,7 @@ Astro Rocket ships with **12 colour themes**. All 12 are shown as coloured swatc
 The default theme is set with `data-theme` on the `<html>` element in `src/layouts/BaseLayout.astro`:
 
 ```html
-data-theme="indigo"
+data-theme="violet"
 ```
 
 Available values — all 12 themes:
@@ -180,8 +180,8 @@ Available values — all 12 themes:
 | `cyan` | 200° | Fresh, vibrant tech — more energetic than teal |
 | `sky` | 222° | Clean and airy — between teal and blue, great for services |
 | `blue` | 255° | Studio aesthetic (Linear/Raycast feel), authoritative |
-| `indigo` | 264° | Enterprise, productivity tools, serious B2B — the default |
-| `violet` | 277° | Creative and premium — sweet spot between indigo and purple |
+| `indigo` | 264° | Enterprise, productivity tools, serious B2B |
+| `violet` | 277° | Creative and premium — sweet spot between indigo and purple — the default |
 | `purple` | 303° | Expressive, personality-forward, vivid |
 | `magenta` | 330° | Creative agencies, bold personal brands — maximum vivid |
 
@@ -542,7 +542,7 @@ Remove any URL you don't use. The footer won't render an empty social section. I
 | Twitter card handles | `src/config/site.config.ts` | `twitter.site`, `twitter.creator` |
 | Search console verification | `.env` or `site.config.ts` | `verification.google/bing` |
 | Navigation items | `src/config/nav.config.ts` | `navItems` array |
-| Default colour theme | `src/layouts/BaseLayout.astro` | `data-theme="indigo"` |
+| Default colour theme | `src/layouts/BaseLayout.astro` | `data-theme="violet"` |
 | Default dark/light mode | `src/layouts/BaseLayout.astro` | `class="dark"` on `<html>` |
 | JSON-LD schema switches | `src/pages/index.astro` | `includePersonSchema`, `includeOrgSchema` |
 | noindex / nofollow | any layout | `noindex={true}`, `nofollow={true}` |

--- a/src/content/blog/en/astro-rocket-getting-started.mdx
+++ b/src/content/blog/en/astro-rocket-getting-started.mdx
@@ -53,7 +53,7 @@ Start here. The `name` field populates the logo badge, page titles, footer copyr
 Astro Rocket ships with 12 ready-to-use colour themes. Pick your preferred theme by setting the `data-theme` attribute in `src/layouts/BaseLayout.astro`:
 
 ```html
-<html lang="en" class="scroll-smooth dark" data-theme="indigo">
+<html lang="en" class="scroll-smooth dark" data-theme="violet">
 ```
 
 Available values: `orange`, `amber`, `lime`, `emerald`, `teal`, `cyan`, `sky`, `blue`, `indigo`, `violet`, `purple`, `magenta`. The theme CSS files live in `src/styles/themes/` — open the active one to fine-tune the `--brand-*` colour scale if needed.
@@ -63,7 +63,7 @@ The `branding.colors` section in `site.config.ts` controls two unrelated browser
 ```ts
 branding: {
   colors: {
-    themeColor: '#6366f1',       // Browser toolbar colour on mobile Chrome/Safari
+    themeColor: '#8b5cf6',       // Browser toolbar colour on mobile Chrome/Safari
     backgroundColor: '#ffffff',  // PWA splash screen background
   },
 },

--- a/src/content/projects/astro-rocket.mdx
+++ b/src/content/projects/astro-rocket.mdx
@@ -61,7 +61,7 @@ The scores are a side-effect of decisions made throughout the build: Astro's sta
 
 ## 12 Themes. Switch in Seconds.
 
-The theme switcher is one of Astro Rocket's most satisfying details. Twelve colour themes — **Orange, Amber, Lime, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, Purple, and Magenta** — toggle instantly from a pill in the header. Click a swatch and every button, link, badge, progress bar, scroll-progress arc, logo monogram, blog cover gradient, and accent on the page updates in a single frame. No waiting, no code changes, no deploy.
+The theme switcher is one of Astro Rocket's most satisfying details. Twelve colour themes — **Orange, Amber, Lime, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, Purple, and Magenta**, with **Violet shipping as the default** — toggle instantly from a pill in the header. Click a swatch and every button, link, badge, progress bar, scroll-progress arc, logo monogram, blog cover gradient, and accent on the page updates in a single frame. No waiting, no code changes, no deploy.
 
 The secret is CSS custom properties scoped to `data-theme` attributes on `<html>`. The browser does all the work — the server never needs to know. The full token system — how colours, spacing, and typography are wired together — is covered in [How Astro Rocket's Design System Works](/blog/design-system-color-tokens).
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -64,7 +64,7 @@ const locale = getLocaleFromPath(Astro.url.pathname);
 ---
 
 <!doctype html>
-<html lang={locale} class="scroll-smooth dark" data-theme="blue" data-theme-mode="system">
+<html lang={locale} class="scroll-smooth dark" data-theme="violet" data-theme-mode="system">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Summary
- Switch the default colour theme from Blue to Violet across the SSR seed (`BaseLayout.astro`), the runtime JS fallbacks (`ThemeSelector.astro`, `ThemeSelectorDropdown.astro`), and the mobile/PWA `themeColor` hex (`site.config.ts`: `#3b82f6` → `#8b5cf6`).
- Update the README, the configuration-guide and getting-started blog posts, and the Astro Rocket project page so every reference to the default theme now reads Violet.
- Left the per-theme CSS files (`blue.css`/`indigo.css`) and the illustrative "customise the indigo theme" snippet untouched, since those aren't default declarations. Verified `violet.css` ships the matching `data-theme="violet"` selectors so the new default resolves.

## Test plan
- [ ] `data-theme="violet"` is applied on first load (no flash), and a fresh tab defaults to Violet
- [ ] Mobile browser toolbar / PWA chrome shows the violet `themeColor`
- [ ] README, blog posts, and project page read correctly and consistently mark Violet as the default

https://claude.ai/code/session_014YeZfMkKVaxPV5aPN9PHeE

---
_Generated by [Claude Code](https://claude.ai/code/session_014YeZfMkKVaxPV5aPN9PHeE)_