### PR TITLE
Sync about "Building since 2010" section and fix landscape card grids

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -145,7 +145,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
           These aren't aspirations — they're the constraints every project is held to, from the first conversation to the final handover.
         </p>
       </div>
-      <div class="grid gap-8 lg:grid-cols-3">
+      <div class="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
         <Card hover data-reveal>
           <div class="flex items-start gap-4">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -73,7 +73,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </p>
       </div>
 
-      <div class="grid gap-6 lg:grid-cols-3">
+      <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
         <!-- Web Design -->
         <Card hover href="/services" class="group flex flex-col" data-reveal>
           <div class="flex items-start gap-4">


### PR DESCRIPTION
## Summary
- Synced the **Building since 2010** section of the About page with the HansMartens repo (right-side facts card now uses the centered grid layout and matching items), while keeping the **Amsterdam** location instead of "Veghel".
- Fixed the responsive layout of the **My Process** (About) and **Services** (Home) card grids, which stayed single-column from 640px to 1023px and looked awkward on landscape phones and tablets. Both now step `sm:grid-cols-2 md:grid-cols-3`.

## Layout behavior after change
| Viewport | Before | After |
|---|---|---|
| Portrait phone (<640) | 1 col | 1 col |
| Small landscape phone (640–767) | 1 col (awkward) | 2 cols |
| Landscape phone & tablets (768–1023) | 1 col (awkward) | 3 cols |
| Desktop / landscape iPad (1024+) | 3 cols | 3 cols |

## Test plan
- [ ] Verify the About page "Building since 2010" facts card matches HansMartens, with "Based in Amsterdam" (not Veghel)
- [ ] Check **My Process** (About) and **Services** (Home) at landscape phone (~844×390) and landscape tablet (~1024×768)
- [ ] Confirm portrait phone, portrait tablet, and desktop still look correct
- [ ] `astro check` passes (verified: 0 errors)

Note: layout was not visually verified in CI — no browser was available in the build environment.

The **Blog "Featured"** grid on the home page (`index.astro`) has the same `lg:grid-cols-3` pattern and was intentionally left untouched per scope.

https://claude.ai/code/session_01NqKGjKEMJUF1kJ1V4SQjVA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqKGjKEMJUF1kJ1V4SQjVA)_