### PR TITLE
Stack card icon above text on landscape phone/tablet

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -147,7 +147,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
       </div>
       <div class="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
         <Card hover data-reveal>
-          <div class="flex items-start gap-4">
+          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="zap" size="md" />
             </div>
@@ -160,7 +160,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
           </div>
         </Card>
         <Card hover data-reveal data-reveal-delay="1">
-          <div class="flex items-start gap-4">
+          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="award" size="md" />
             </div>
@@ -173,7 +173,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
           </div>
         </Card>
         <Card hover data-reveal data-reveal-delay="2">
-          <div class="flex items-start gap-4">
+          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="rocket" size="md" />
             </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,7 +76,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
       <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
         <!-- Web Design -->
         <Card hover href="/services" class="group flex flex-col" data-reveal>
-          <div class="flex items-start gap-4">
+          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="layout" size="sm" />
             </div>
@@ -95,7 +95,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 
         <!-- Web Development -->
         <Card hover href="/services" class="group flex flex-col" data-reveal data-reveal-delay="1">
-          <div class="flex items-start gap-4">
+          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="code" size="sm" />
             </div>
@@ -114,7 +114,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 
         <!-- SEO & Performance -->
         <Card hover href="/services" class="group flex flex-col" data-reveal data-reveal-delay="2">
-          <div class="flex items-start gap-4">
+          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="zap" size="sm" />
             </div>


### PR DESCRIPTION
On landscape orientation below the desktop breakpoint, the Process and Services cards now lay the icon centered above the text instead of beside it, which reads better in the narrower multi-column layout. Portrait views and desktop keep the icon beside the text.

https://claude.ai/code/session_01NqKGjKEMJUF1kJ1V4SQjVA

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
