### PR TITLE
Sync mobile-landscape/tablet/desktop responsive layout across core pages

### DIFF
--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -15,6 +15,7 @@ interface Props {
   author?: string;
   image?: ImageMetadata;
   svgSlug?: string;
+  class?: string;
 }
 
 const {
@@ -26,6 +27,7 @@ const {
   author,
   image,
   svgSlug,
+  class: className,
 } = Astro.props;
 
 // Estimate reading time (rough estimate based on average words)
@@ -34,7 +36,7 @@ const estimatedWords = description.split(' ').length * 10; // Rough estimate
 const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
 ---
 
-<article class="group rounded-lg border border-brand-500/30 bg-background p-6 shadow-md ring-1 ring-brand-500/20 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-brand-500 hover:shadow-lg" data-reveal>
+<article class:list={["group rounded-lg border border-brand-500/30 bg-background p-6 shadow-md ring-1 ring-brand-500/20 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-brand-500 hover:shadow-lg", className]} data-reveal>
 
   <a href={href} class="block">
     <div

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -70,11 +70,15 @@ const showToc = !!tocConfig?.enabled && tocOverride !== false;
 const showComments = !!commentsConfig?.enabled && commentsOverride !== false;
 
 // TOC layout: 'inline' (top-of-article card), 'sidebar' (xl+ sticky aside,
-// hidden below xl), or 'auto' (sidebar on xl+, inline card below xl).
+// hidden below xl), or 'auto' (sidebar on xl+; inline opt-in elsewhere).
 // `sidebarActive` controls whether we render the wider grid wrapper.
-const tocLayout = tocConfig?.layout ?? 'inline';
+const tocLayout = tocConfig?.layout ?? 'auto';
 const sidebarActive = showToc && (tocLayout === 'sidebar' || tocLayout === 'auto');
-const inlineActive = showToc && (tocLayout === 'inline' || tocLayout === 'auto');
+// Inline TOC is now opt-in: 'auto' shows only the desktop sidebar so the
+// mobile/landscape/tablet experience isn't dominated by a TOC card the
+// majority of visitors don't use. Posts that want the inline TOC visible
+// everywhere can set `toc.layout: 'inline'` in frontmatter.
+const inlineActive = showToc && tocLayout === 'inline';
 const sidebarOnLeft = (tocConfig?.sidebarPosition ?? 'right') === 'left';
 
 // Prefer the post's own image; otherwise serve the per-post dynamic OG image
@@ -166,10 +170,7 @@ const schemas = faqSchema ? [blogPostingSchema, faqSchema] : [blogPostingSchema]
       <Breadcrumbs items={breadcrumbs} class="mb-8" />
 
       {inlineActive && (
-        <div class:list={[
-          'mb-10 rounded-xl border border-border bg-background-secondary p-5',
-          tocLayout === 'auto' && 'xl:hidden',
-        ]}>
+        <div class="mb-10 rounded-xl border border-border bg-background-secondary p-5">
           <TableOfContents
             headings={headings}
             maxDepth={tocConfig?.maxDepth ?? 3}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -39,26 +39,26 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
   <!-- About me -->
   <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
-      <div class="grid gap-12 lg:grid-cols-2">
+      <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12">
         <!-- Left: text -->
-        <div class="flex flex-col justify-center gap-4" data-reveal="right" data-reveal-ease="smooth">
-          <div class="flex flex-col gap-6">
-            <Badge variant="brand" pill class="self-start">Building since 2010</Badge>
-            <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
+        <div class="flex flex-col justify-center gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal="right" data-reveal-ease="smooth">
+          <div class="flex flex-col gap-6 sm:items-center glitch:items-start">
+            <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">Building since 2010</Badge>
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground text-balance">
               Sixteen years of hands‑on craft
             </h2>
           </div>
-          <p class="text-lg text-foreground-muted leading-relaxed">
+          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             I'm a web designer and developer with 16 years of hands‑on experience, based in Amsterdam and working worldwide. Design and the code beneath it aren't separate jobs to me — they're one craft, kept with the same person from first sketch to final deploy.
           </p>
-          <p class="text-lg text-foreground-muted leading-relaxed">
+          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             The result is fast, maintainable sites built with intention — and a direct line to the person actually doing the work, from the first conversation to launch.
           </p>
         </div>
         <!-- Right: personal facts card -->
         <div class="flex flex-col h-full" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="flex-1 flex flex-col justify-center">
-            <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-2 gap-x-6 gap-y-8">
+            <div class="grid grid-cols-2 sm:grid-cols-3 glitch:grid-cols-2 gap-x-6 gap-y-8">
               <div class="flex flex-col items-center text-center gap-3">
                 <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
                   <Icon name="map-pin" size="md" />
@@ -145,9 +145,9 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
           These aren't aspirations — they're the constraints every project is held to, from the first conversation to the final handover.
         </p>
       </div>
-      <div class="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
+      <div class="grid gap-6 sm:gap-8 sm:grid-cols-3">
         <Card hover data-reveal>
-          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
+          <div class="flex items-start gap-4 sm:flex-col sm:items-center sm:gap-3 sm:text-center lg:flex-row lg:items-start lg:gap-4 lg:text-left">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="zap" size="md" />
             </div>
@@ -160,7 +160,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
           </div>
         </Card>
         <Card hover data-reveal data-reveal-delay="1">
-          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
+          <div class="flex items-start gap-4 sm:flex-col sm:items-center sm:gap-3 sm:text-center lg:flex-row lg:items-start lg:gap-4 lg:text-left">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="award" size="md" />
             </div>
@@ -173,7 +173,7 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
           </div>
         </Card>
         <Card hover data-reveal data-reveal-delay="2">
-          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
+          <div class="flex items-start gap-4 sm:flex-col sm:items-center sm:gap-3 sm:text-center lg:flex-row lg:items-start lg:gap-4 lg:text-left">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="rocket" size="md" />
             </div>
@@ -331,24 +331,24 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
   <!-- More about me -->
   <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
-      <div class="grid gap-10 lg:grid-cols-2">
+      <div class="grid gap-8 sm:gap-10 glitch:grid-cols-2 glitch:items-center">
         <!-- Text -->
-        <div class="flex flex-col justify-center gap-4" data-reveal="right" data-reveal-ease="smooth">
-          <Badge variant="brand" pill class="self-start">Backstory</Badge>
+        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:items-start glitch:justify-center glitch:text-left" data-reveal="right" data-reveal-ease="smooth">
+          <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">Backstory</Badge>
           <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
             The longer story
           </h2>
-          <p class="text-lg text-foreground-muted leading-relaxed">
+          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             You've seen the work, the process, and the tools. If you'd like to know the person behind them, I've put the whole story in one place.
           </p>
-          <Button variant="outline" size="lg" href="https://hansmartens.dev/blog/hans-martens-web-designer-veghel" target="_blank" rel="noopener noreferrer" class="self-start mt-2">
+          <Button variant="outline" size="lg" href="https://hansmartens.dev/blog/hans-martens-web-designer-veghel" target="_blank" rel="noopener noreferrer" class="self-start sm:self-center glitch:self-start mt-2 sm:hidden glitch:inline-flex">
             Read the full story
             <Icon name="arrow-right" size="sm" />
           </Button>
         </div>
 
         <!-- Image -->
-        <div class="mx-auto w-full max-w-sm sm:max-w-md lg:max-w-none" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="mx-auto w-full max-w-sm sm:max-w-md glitch:mx-0 glitch:max-w-none" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
           <a
             href="https://hansmartens.dev/blog/hans-martens-web-designer-veghel"
             target="_blank"
@@ -360,6 +360,12 @@ import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
               <BlogImageSVG slug="hi-im-hans-martens" title="Hi, I'm Hans Martens — the longer story" />
             </div>
           </a>
+        </div>
+        <div class="hidden sm:flex justify-center glitch:hidden" data-reveal data-reveal-delay="2">
+          <Button size="lg" variant="outline" href="https://hansmartens.dev/blog/hans-martens-web-designer-veghel" target="_blank" rel="noopener noreferrer">
+            Read the full story
+            <Icon name="arrow-right" size="sm" />
+          </Button>
         </div>
       </div>
     </div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -58,7 +58,7 @@ const topTags = collectTopTags(posts, TAG_CLOUD_LIMIT);
             Featured
           </h2>
 
-          <div class="grid gap-6 md:grid-cols-2">
+          <div class="grid gap-6 sm:grid-cols-2">
             {featuredPosts.map((post) => (
               <BlogCard
                 title={post.data.title}
@@ -94,7 +94,7 @@ const topTags = collectTopTags(posts, TAG_CLOUD_LIMIT);
 
       {
         regularPosts.length > 0 ? (
-          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {regularPosts.map((post) => (
               <BlogCard
                 title={post.data.title}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,7 +22,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
     if (a.data.featured !== b.data.featured) return a.data.featured ? -1 : 1;
     return b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf();
   })
-  .slice(0, 3);
+  .slice(0, 4);
 ---
 
 <LandingLayout
@@ -73,10 +73,10 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </p>
       </div>
 
-      <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+      <div class="grid gap-6 sm:grid-cols-3">
         <!-- Web Design -->
         <Card hover href="/services" class="group flex flex-col" data-reveal>
-          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
+          <div class="flex items-start gap-4 sm:flex-col sm:items-center sm:gap-3 sm:text-center lg:flex-row lg:items-start lg:gap-4 lg:text-left">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="layout" size="sm" />
             </div>
@@ -95,7 +95,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 
         <!-- Web Development -->
         <Card hover href="/services" class="group flex flex-col" data-reveal data-reveal-delay="1">
-          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
+          <div class="flex items-start gap-4 sm:flex-col sm:items-center sm:gap-3 sm:text-center lg:flex-row lg:items-start lg:gap-4 lg:text-left">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="code" size="sm" />
             </div>
@@ -114,7 +114,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 
         <!-- SEO & Performance -->
         <Card hover href="/services" class="group flex flex-col" data-reveal data-reveal-delay="2">
-          <div class="flex items-start gap-4 landscape:max-lg:flex-col landscape:max-lg:items-center landscape:max-lg:text-center">
+          <div class="flex items-start gap-4 sm:flex-col sm:items-center sm:gap-3 sm:text-center lg:flex-row lg:items-start lg:gap-4 lg:text-left">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
               <Icon name="zap" size="sm" />
             </div>
@@ -269,29 +269,29 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   <!-- About Teaser -->
   <section class="relative z-10 py-[var(--space-section-md)] bg-background-secondary border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
-      <div class="grid gap-12 lg:grid-cols-2">
-        <div class="flex flex-col justify-center" data-reveal="right" data-reveal-ease="smooth">
-          <div class="flex flex-col gap-6 mb-6">
-            <Badge variant="brand" pill class="self-start">About me</Badge>
+      <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12">
+        <div class="flex flex-col justify-center sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal="right" data-reveal-ease="smooth">
+          <div class="flex flex-col gap-6 mb-6 sm:items-center glitch:items-start">
+            <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">About me</Badge>
             <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
               Designer, developer,<br />
               <span class="text-brand-500">and blogger.</span>
             </h2>
           </div>
-          <p class="text-lg text-foreground-muted leading-relaxed mb-4">
+          <p class="text-lg text-foreground-muted leading-relaxed text-pretty mb-4 sm:mb-0 sm:max-w-xl glitch:mb-4 glitch:max-w-none">
            Sixteen years of hands-on experience{siteConfig.address?.city ? `, based in ${siteConfig.address.city}${siteConfig.address.country ? `, ${siteConfig.address.country}` : ''}` : ''} and available for clients worldwide. I build with Astro because it aligns with how I think about the web: lean, purposeful, and built to last.
           </p>
-          <p class="text-lg text-foreground-muted leading-relaxed mb-8">
+          <p class="text-lg text-foreground-muted leading-relaxed text-pretty mb-8 sm:max-w-xl glitch:max-w-none sm:hidden glitch:block">
            On the blog, I share the ideas and decisions that shape my work.
           </p>
-           <Button variant="outline" href="/about" class="self-start">
+           <Button variant="outline" href="/about" class="self-start sm:self-center glitch:self-start sm:hidden glitch:inline-flex">
             More about me
             <Icon name="arrow-right" size="sm" />
           </Button>
         </div>
         <Card variant="elevated" padding="lg" class="h-full flex flex-col" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
-          <p class="text-sm text-foreground mb-5 text-center">A few things about me.</p>
-          <div class="grid grid-cols-2 gap-3 flex-1 auto-rows-fr">
+          <p class="text-sm text-foreground mb-5 text-center sm:hidden glitch:block">A few things about me.</p>
+          <div class="grid grid-cols-2 sm:grid-cols-4 glitch:grid-cols-2 gap-3 flex-1 auto-rows-fr">
             <div class="bg-background-tertiary rounded-xl p-5 flex flex-col items-center justify-center text-center gap-2 border-t-2 border-brand-500/40 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-md hover:border-brand-500 cursor-default h-full">
               <Icon name="history" class="w-10 h-10 text-brand-500" />
               <p class="text-sm font-semibold text-foreground">16 Years Experience</p>
@@ -313,6 +313,12 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
             </div>
           </div>
         </Card>
+        <div class="hidden sm:flex justify-center glitch:hidden" data-reveal data-reveal-delay="2">
+          <Button variant="outline" href="/about">
+            More about me
+            <Icon name="arrow-right" size="sm" />
+          </Button>
+        </div>
       </div>
     </div>
   </section>
@@ -327,8 +333,8 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
         </h2>
       </div>
 
-      <div class="grid gap-6 lg:grid-cols-3">
-        {posts.map((post) => (
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {posts.map((post, index) => (
           <BlogCard
             title={post.data.title}
             description={post.data.description}
@@ -338,6 +344,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
             author={post.data.author}
             image={post.data.image}
             svgSlug={post.data.svgSlug}
+            class={index === 3 ? 'hidden sm:block lg:hidden' : undefined}
           />
         ))}
       </div>
@@ -426,5 +433,18 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 
   initCountup();
 </script>
+
+<style is:global>
+  /* Widen the homepage hero description from md upward so the paragraph
+     reads on two lines instead of three on landscape phones, tablets,
+     and all laptop/desktop sizes. Scoped via the unique
+     .hero-dark-gradient class so other heroes keep the default
+     max-w-xl reading measure. */
+  @media (min-width: 768px) {
+    .hero-dark-gradient .hero-title-slot + div {
+      max-width: 48rem;
+    }
+  }
+</style>
 
 </LandingLayout>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -50,31 +50,33 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
   <!-- Design -->
   <section id="design" class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
-      <div class="grid gap-12 lg:grid-cols-2">
+      <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12 glitch:items-start">
         <!-- Text -->
-        <div class="flex flex-col justify-center gap-4" data-reveal="right" data-reveal-ease="smooth">
-          <Badge variant="brand" pill class="self-start">
-            <Icon name="layout" size="sm" />
-            Web Design
-          </Badge>
-          <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
-            Design with intention
-          </h2>
-          <p class="text-lg text-foreground-muted leading-relaxed">
+        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal="right" data-reveal-ease="smooth">
+          <div class="flex flex-col gap-6 sm:items-center glitch:items-start">
+            <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">
+              <Icon name="layout" size="sm" />
+              Web Design
+            </Badge>
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
+              Design with intention
+            </h2>
+          </div>
+          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             Great design starts with the people who'll use it. I design layouts shaped around your content and your audience, not around trends that age badly. Typography, spacing, and colour are chosen for clarity — not novelty.
           </p>
-          <p class="text-lg text-foreground-muted leading-relaxed">
+          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             Every screen is considered: desktop, tablet, and the phone someone holds at the bus stop. The brand stays consistent across the whole experience, and the small details are treated as part of the design, not the polish.
           </p>
-          <Button variant="outline" href="/contact" class="self-start mt-2">
+          <Button variant="outline" href="/contact" class="self-start sm:self-center glitch:self-start mt-2 sm:hidden glitch:inline-flex">
             Discuss a design project
             <Icon name="arrow-right" size="sm" />
           </Button>
         </div>
         <!-- Card -->
-        <div data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
-            <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border">
+            <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border sm:justify-center glitch:justify-start">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
                 <Icon name="layout" size="md" />
               </div>
@@ -120,6 +122,12 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
             </ul>
           </Card>
         </div>
+        <div class="hidden sm:flex justify-center glitch:hidden" data-reveal data-reveal-delay="2">
+          <Button variant="outline" href="/contact">
+            Discuss a design project
+            <Icon name="arrow-right" size="sm" />
+          </Button>
+        </div>
       </div>
     </div>
   </section>
@@ -127,31 +135,33 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
   <!-- Development -->
   <section id="development" class="py-[var(--space-section-md)] bg-background border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
-      <div class="grid gap-12 lg:grid-cols-2">
+      <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12 glitch:items-start">
         <!-- Text -->
-        <div class="flex flex-col justify-center gap-4 lg:order-2" data-reveal="left" data-reveal-ease="smooth">
-          <Badge variant="brand" pill class="self-start">
-            <Icon name="code" size="sm" />
-            Web Development
-          </Badge>
-          <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
-            Code that earns its place
-          </h2>
-          <p class="text-lg text-foreground-muted leading-relaxed">
+        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:order-2 glitch:items-start glitch:text-left" data-reveal="left" data-reveal-ease="smooth">
+          <div class="flex flex-col gap-6 sm:items-center glitch:items-start">
+            <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">
+              <Icon name="code" size="sm" />
+              Web Development
+            </Badge>
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
+              Code that earns its place
+            </h2>
+          </div>
+          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             I build with Astro because it ships what's needed and nothing else. The result is sites that score well in audits, feel fast in the hand, and don't grow brittle over time.
           </p>
-          <p class="text-lg text-foreground-muted leading-relaxed">
+          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             Architecture matters as much as output: typed content, predictable component boundaries, and a build pipeline a future developer (or future you) can pick up without a guided tour.
           </p>
-          <Button variant="outline" href="/projects" class="self-start mt-2">
+          <Button variant="outline" href="/projects" class="self-start sm:self-center glitch:self-start mt-2 sm:hidden glitch:inline-flex">
             See recent projects
             <Icon name="arrow-right" size="sm" />
           </Button>
         </div>
         <!-- Card -->
-        <div class="lg:order-1" data-reveal="right" data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="sm:max-w-xl sm:mx-auto glitch:order-1 glitch:max-w-none glitch:mx-0" data-reveal="right" data-reveal-delay="1" data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
-            <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border">
+            <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border sm:justify-center glitch:justify-start">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
                 <Icon name="code" size="md" />
               </div>
@@ -197,6 +207,12 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
             </ul>
           </Card>
         </div>
+        <div class="hidden sm:flex justify-center glitch:hidden" data-reveal data-reveal-delay="2">
+          <Button variant="outline" href="/projects">
+            See recent projects
+            <Icon name="arrow-right" size="sm" />
+          </Button>
+        </div>
       </div>
     </div>
   </section>
@@ -204,31 +220,33 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
   <!-- Performance -->
   <section id="performance" class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
-      <div class="grid gap-12 lg:grid-cols-2">
+      <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12 glitch:items-start">
         <!-- Text -->
-        <div class="flex flex-col justify-center gap-4" data-reveal="right" data-reveal-ease="smooth">
-          <Badge variant="brand" pill class="self-start">
-            <Icon name="zap" size="sm" />
-            Performance
-          </Badge>
-          <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
-            Fast pages, found pages
-          </h2>
-          <p class="text-lg text-foreground-muted leading-relaxed">
+        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal="right" data-reveal-ease="smooth">
+          <div class="flex flex-col gap-6 sm:items-center glitch:items-start">
+            <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">
+              <Icon name="zap" size="sm" />
+              Performance
+            </Badge>
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
+              Fast pages, found pages
+            </h2>
+          </div>
+          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             Speed and search visibility aren't features to add at the end — they're constraints to honour from the first commit. Every second a page loads costs attention, ranking, and trust.
           </p>
-          <p class="text-lg text-foreground-muted leading-relaxed">
+          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             I work to measurable targets, not vibes. Core Web Vitals, technical SEO, and accessibility are tracked, tuned, and verified before launch — and the dashboards stay yours after handover.
           </p>
-          <Button variant="outline" href="/contact" class="self-start mt-2">
+          <Button variant="outline" href="/contact" class="self-start sm:self-center glitch:self-start mt-2 sm:hidden glitch:inline-flex">
             Start a project
             <Icon name="arrow-right" size="sm" />
           </Button>
         </div>
         <!-- Card -->
-        <div data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
-            <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border">
+            <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border sm:justify-center glitch:justify-start">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
                 <Icon name="zap" size="md" />
               </div>
@@ -274,6 +292,12 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
             </ul>
           </Card>
         </div>
+        <div class="hidden sm:flex justify-center glitch:hidden" data-reveal data-reveal-delay="2">
+          <Button variant="outline" href="/contact">
+            Start a project
+            <Icon name="arrow-right" size="sm" />
+          </Button>
+        </div>
       </div>
     </div>
   </section>
@@ -295,11 +319,11 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 
       <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
         <Card hover data-reveal>
-          <div class="flex items-start gap-4">
+          <div class="flex flex-col items-center text-center gap-3">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 font-bold text-base shrink-0">
               1
             </div>
-            <div class="flex-1 min-w-0">
+            <div>
               <h3 class="text-base font-semibold text-foreground">Discovery</h3>
               <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
                 A conversation about your goals, your audience, and what success looks like. No obligation.
@@ -308,11 +332,11 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
           </div>
         </Card>
         <Card hover data-reveal data-reveal-delay="1">
-          <div class="flex items-start gap-4">
+          <div class="flex flex-col items-center text-center gap-3">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 font-bold text-base shrink-0">
               2
             </div>
-            <div class="flex-1 min-w-0">
+            <div>
               <h3 class="text-base font-semibold text-foreground">Proposal</h3>
               <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
                 A clear scope, timeline, and cost. One page, plain language, fixed price.
@@ -321,11 +345,11 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
           </div>
         </Card>
         <Card hover data-reveal data-reveal-delay="2">
-          <div class="flex items-start gap-4">
+          <div class="flex flex-col items-center text-center gap-3">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 font-bold text-base shrink-0">
               3
             </div>
-            <div class="flex-1 min-w-0">
+            <div>
               <h3 class="text-base font-semibold text-foreground">Design & Build</h3>
               <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
                 Short cycles with regular check-ins. You see the site evolve as it's built.
@@ -334,11 +358,11 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
           </div>
         </Card>
         <Card hover data-reveal data-reveal-delay="3">
-          <div class="flex items-start gap-4">
+          <div class="flex flex-col items-center text-center gap-3">
             <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 font-bold text-base shrink-0">
               4
             </div>
-            <div class="flex-1 min-w-0">
+            <div>
               <h3 class="text-base font-semibold text-foreground">Launch & Support</h3>
               <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
                 Deploy, hand over, stay available. Iteration after launch is straightforward.


### PR DESCRIPTION
## What

Ports the tablet (`sm:`) and true-desktop (`glitch:`) responsive system from hansmartens.dev into the homepage, services, about, blog index and single blog page. This is a **surgical styling port** — all of Astro Rocket's own copy, branding, Testimonials section, Comments feature, dynamic OG images and project links are left untouched.

## Why

Today the pages jump straight to the two-column desktop layout at `lg:` (1024px) for **every** device, so touch tablets and landscape phones inherit a cramped desktop layout, with only a narrow `landscape:max-lg:` patch on a few cards.

This change introduces a clean 3-tier system:

| Tier | Trigger | Layout |
|------|---------|--------|
| Mobile portrait | base | stacked, left-aligned |
| Tablet / landscape phone | `sm:` (≥640px) | content centered, width-capped, card icons stacked above text, standalone centered CTAs |
| True desktop | `glitch:` (≥1024px **and a fine pointer**) | two-column splits, left-aligned, column reordering |

Keying the two-column splits off `glitch:` instead of `lg:` means touch tablets no longer get the desktop layout — only mouse-driven screens do.

## Changes

- **`index.astro`** — service cards stack icon-above-text across the tablet range; About-teaser 3-tier centering (2/4/2 facts grid); blog grid `sm:grid-cols-2 lg:grid-cols-3` with a 4th card shown only in the tablet band; `md+` hero-description width tweak.
- **`services.astro`** — three feature sections → `sm:` centered / `glitch:` two-column split with reordering + standalone tablet CTAs; centered process cards for the 4-up grid.
- **`about.astro`** — About-me grid + facts card (`sm:grid-cols-3 glitch:grid-cols-2`), Values cards stacking, Backstory 3-tier section.
- **`blog/index.astro`** — featured + all-posts grids go 2-up at `sm:` instead of `md:`.
- **`BlogLayout.astro`** — inline TOC is now opt-in (`auto` = desktop sidebar only) so mobile/landscape/tablet isn't dominated by a TOC card. Posts can still set `toc.layout: 'inline'` to force it everywhere.
- **`BlogCard.astro`** — added a `class` passthrough so the 4th homepage card can hide outside the `sm`–`lg` band.

## Verification

- ✅ `astro build` — passes
- ✅ `astro check` — 0 errors, 0 warnings (9 pre-existing hints, none from this change)
- ✅ `eslint .` — clean on changed files

Prettier isn't part of this repo's `validate` script and the touched files already failed it identically on `main`, so formatting was left as-is to keep the diff surgical.

## Test plan

Worth an eyeball at landscape-phone, tablet-portrait and desktop widths on `/`, `/services`, `/about`, `/blog`, and a single blog post (TOC behavior).

https://claude.ai/code/session_01KNf7yL7HncTFWpRfLiCZ62

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNf7yL7HncTFWpRfLiCZ62)_