### PR TITLE
Sync contact page styling 

### DIFF
--- a/src/components/patterns/ContactForm.astro
+++ b/src/components/patterns/ContactForm.astro
@@ -64,7 +64,7 @@ const {
   <div id="form-message" class="hidden text-sm"></div>
 
   <div class="flex justify-center">
-    <Button type="submit" id="submit-button" class="gap-2">
+    <Button type="submit" id="submit-button" class="gap-2 cta-btn-brand">
       Send message
       <Icon name="arrow-right" size="sm" />
     </Button>
@@ -80,6 +80,7 @@ const {
     if (!form || !button || !message) return;
 
     const successMessage = form.dataset.successMessage || 'Message sent successfully!';
+    const originalButtonHTML = button.innerHTML;
 
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -113,7 +114,7 @@ const {
         message.className = 'text-sm text-destructive';
       } finally {
         button.disabled = false;
-        button.textContent = 'Send message';
+        button.innerHTML = originalButtonHTML;
         message.classList.remove('hidden');
       }
     });

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -55,21 +55,21 @@ const channels = [
   </Hero>
 
   <!-- Contact Section -->
-  <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
-    <div class="mx-auto max-w-5xl px-6">
-      <div class="grid grid-cols-1 lg:grid-cols-5 gap-10 lg:gap-16 items-stretch">
+  <section class="relative isolate overflow-hidden py-[var(--space-section-md)] bg-background-secondary border-t border-border">
+    <div class="relative z-10 mx-auto max-w-5xl px-6">
+      <div class="grid grid-cols-1 glitch:grid-cols-5 gap-10 glitch:gap-16 items-stretch">
 
         <!-- Left column: contact form -->
-        <div class="lg:col-span-3 h-full" data-reveal="right" data-reveal-ease="smooth">
+        <div class="glitch:col-span-3 h-full sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal="right" data-reveal-ease="smooth">
           <Card padding="lg" class="h-full flex flex-col justify-center">
-            <h2 class="font-display text-xl font-bold text-foreground mb-6">Project details</h2>
+            <h2 class="font-display text-xl font-bold text-foreground mb-6 sm:text-center glitch:text-left">Project details</h2>
             <ContactForm />
           </Card>
         </div>
 
         <!-- Right column: contact channels -->
-        <div class="lg:col-span-2 space-y-4" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
-          <div>
+        <div class="glitch:col-span-2 space-y-4 sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+          <div class="sm:text-center glitch:text-left">
             <h2 class="font-display text-lg font-bold text-foreground mb-1">Other channels</h2>
             <p class="text-sm text-foreground-muted">Prefer a direct channel? Pick whichever works best.</p>
           </div>


### PR DESCRIPTION
Syncs the contact page styling from the [HansMartens](https://github.com/hansmartensdev/HansMartens) repo. **Styling only** — page copy and the site-wide `.cta-btn-brand` color were intentionally left unchanged.

## Changes

**`src/pages/contact.astro`** — layout/responsive classes
- `<section>` gains `relative isolate overflow-hidden`; container gains `relative z-10`
- Two-column layout moves from the `lg:` breakpoint to the `glitch:` breakpoint (≥1024px **and** fine pointer), so columns only sit side-by-side on real desktops
- Both columns stack centered on small/tablet screens (`sm:max-w-xl sm:mx-auto`, then `glitch:max-w-none glitch:mx-0`)
- Both headings get `sm:text-center glitch:text-left`

**`src/components/patterns/ContactForm.astro`** — now byte-identical to HansMartens
- Submit button gets the `cta-btn-brand` fill class
- Captures `originalButtonHTML` and restores it via `innerHTML` after submit, so the arrow icon returns (instead of resetting to plain "Send message" text)

## Intentionally not changed
- **Copy/text**: page title, meta description, hero description, and "Drop us a line" remain as-is (HansMartens' wording is site-specific).
- **Site-wide button color**: `.cta-btn-brand` stays at this repo's `brand-700`/`brand-800`, matching the rest of the site's CTAs. No site-wide change.

`FormField.astro` was already identical between the two repos.

## Notes
- The `glitch:` custom variant and `.cta-btn-brand` class are both already defined in this repo's `global.css`, so all classes resolve.
- The existing `contact.test.ts` makes no assertions about the changed markup.

https://claude.ai/code/session_01192bwxWhnPvc3pSC11SQDN

---
_Generated by [Claude Code](https://claude.ai/code/session_01192bwxWhnPvc3pSC11SQDN)_