### PR TITLE
Fix broken image refs in hans-martens project (Vercel build failure)

### DIFF
--- a/src/content/projects/hans-martens.mdx
+++ b/src/content/projects/hans-martens.mdx
@@ -9,11 +9,9 @@ year: 2026
 role: "Designer & Developer"
 services: ["Web Design", "Web Development", "Performance"]
 meta: ["Personal site", "Built on Astro Rocket", "Astro 6", "Lighthouse 4×100"]
-image: "../../assets/projects/hansmartensdev-website.jpg"
+image: "../../assets/projects/hansmartens-project.jpeg"
 imageAlt: "Hans Martens Dev website"
 gallery:
-  - src: "../../assets/projects/hansmartensdev-website.jpg"
-    alt: "Hans Martens Dev — website."
   - src: "../../assets/projects/hansmartensdev-a.jpg"
     alt: "Hans Martens Dev — website."
   - src: "../../assets/projects/hansmartensdev-b.jpg"


### PR DESCRIPTION
The Hans Martens Dev project still referenced
src/assets/projects/hansmartensdev-website.jpg as its cover image and first gallery slide, but that file was deleted in 75aa7a4. Astro's content schema resolves both fields through image() at build time, so the missing asset failed the production build on Vercel.

Repoint the cover to the existing hansmartens-project.jpeg and drop the broken first gallery slide, leaving four valid screenshots (hansmartensdev-a/b/c/d). Verified with a clean astro build.

https://claude.ai/code/session_01TfzQzivL3pqumcj3pF3FAt

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
