### PR TITLE
Remove gallery carousel from Hans Martens project, keep website image…

### DIFF
--- a/src/content/projects/hans-martens.mdx
+++ b/src/content/projects/hans-martens.mdx
@@ -11,17 +11,6 @@ services: ["Web Design", "Web Development", "Performance"]
 meta: ["Personal site", "Built on Astro Rocket", "Astro 6", "Lighthouse 4×100"]
 image: "../../assets/projects/hansmartensdev-website.jpg"
 imageAlt: "Hans Martens Dev website"
-gallery:
-  - src: "../../assets/projects/hansmartensdev-website.jpg"
-    alt: "Hans Martens Dev — website."
-  - src: "../../assets/projects/hansmartensdev-a.jpg"
-    alt: "Hans Martens Dev — website."
-  - src: "../../assets/projects/hansmartensdev-b.jpg"
-    alt: "Hans Martens Dev — website."
-  - src: "../../assets/projects/hansmartensdev-c.jpg"
-    alt: "Hans Martens Dev — website."
-  - src: "../../assets/projects/hansmartensdev-d.jpg"
-    alt: "Hans Martens Dev — website."
 ---
 
 import LighthouseScoresGrid from '@/components/landing/LighthouseScoresGrid.astro';


### PR DESCRIPTION
… as hero

Drop the 5-slide gallery so the single project page no longer renders a carousel. The hero now shows the former first carousel image (hansmartensdev-website.jpg) as a single static image via the existing image fallback in ProjectHero. Verified with a clean astro build.

https://claude.ai/code/session_01TfzQzivL3pqumcj3pF3FAt

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
