### PR TITLE
Restore second Selected work card on homepage

### DIFF
--- a/src/content/projects/studio-portfolio.mdx
+++ b/src/content/projects/studio-portfolio.mdx
@@ -2,7 +2,7 @@
 title: "Studio Portfolio"
 description: "Complete redesign of a creative studio's portfolio — fast, focused, and built to convert visitors into clients."
 tags: ["Astro", "Tailwind CSS", "Design", "Client Work"]
-featured: false
+featured: true
 order: 2
 year: 2025
 client: "Your Client Name"


### PR DESCRIPTION
The homepage 'Selected work' section renders projects flagged featured: true. After hans-martens.mdx (order 1) was deleted, only astro-rocket (order 0) remained featured, so the grid showed a single card. Feature studio-portfolio (next by order) to bring it back to two.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
