### PR TITLE
Keep footer zebra pattern intact across all pages

### DIFF
--- a/src/components/layout/footer.variants.ts
+++ b/src/components/layout/footer.variants.ts
@@ -4,7 +4,7 @@ export const footerVariants = cva('py-[var(--space-stack-lg)]', {
   variants: {
     background: {
       default: 'bg-background border-t border-border',
-      secondary: 'bg-surface-secondary border-t border-border',
+      secondary: 'bg-background-secondary border-t border-border',
       invert: 'invert-section bg-background border-t border-border',
     },
   },

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -297,5 +297,5 @@ const schemas = faqSchema ? [blogPostingSchema, faqSchema] : [blogPostingSchema]
   </section>
   </div>
 
-  <Footer slot="footer" layout="simple" background="secondary" maxWidth="7xl" />
+  <Footer slot="footer" layout="simple" background="default" maxWidth="7xl" />
 </BaseLayout>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -17,9 +17,16 @@ interface Props {
   nofollow?: boolean;
   showScrollProgress?: boolean;
   eagerReveal?: boolean;
+  /**
+   * Footer background. Set this to the opposite of the page's last section so
+   * the zebra pattern (bg-background ↔ bg-background-secondary) stays intact:
+   * - last section `bg-background`           → footer `secondary`
+   * - last section `bg-background-secondary` → footer `default`
+   */
+  footerBackground?: 'default' | 'secondary' | 'invert';
 }
 
-const { title, description, image, imageAlt, noindex, nofollow, showScrollProgress = false, eagerReveal = false } = Astro.props;
+const { title, description, image, imageAlt, noindex, nofollow, showScrollProgress = false, eagerReveal = false, footerBackground = 'default' } = Astro.props;
 
 ---
 
@@ -47,5 +54,5 @@ const { title, description, image, imageAlt, noindex, nofollow, showScrollProgre
     <slot />
   </main>
 
-  <Footer slot="footer" layout="simple" />
+  <Footer slot="footer" layout="simple" background={footerBackground} />
 </BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -16,6 +16,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 <PageLayout
   title="About Astro Rocket — Astro 6 Starter Theme"
   description="Astro Rocket is a production-ready Astro 6 starter theme with 12 themes, 57+ components, built-in i18n, dark mode, and everything you need to launch fast."
+  footerBackground="secondary"
 >
   <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -37,7 +37,7 @@ const regularPosts = regularPostsAll.slice(0, BLOG_POSTS_PER_PAGE);
 const topTags = collectTopTags(posts, TAG_CLOUD_LIMIT);
 ---
 
-<PageLayout title="Blog — Astro Rocket" description="Articles on web design, development, and the web by Astro Rocket." showScrollProgress eagerReveal>
+<PageLayout title="Blog — Astro Rocket" description="Articles on web design, development, and the web by Astro Rocket." showScrollProgress eagerReveal footerBackground={featuredPosts.length > 0 ? 'default' : 'secondary'}>
   <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>
       <Icon name="book" size="sm" />

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -52,6 +52,7 @@ const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
   description={`Page ${page} of ${totalPages} — articles on Astro, web performance, design, and the web.`}
   showScrollProgress
   eagerReveal
+  footerBackground="secondary"
 >
   <Hero layout="centered" size="sm">
     <Badge slot="badge" variant="brand" pill>

--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -48,6 +48,7 @@ import EmptyState from '@/components/patterns/EmptyState.astro';
   title="Component Showcase"
   description="Explore Astro Rocket's comprehensive UI component library. Production-ready, accessible, and beautifully designed."
   noindex={true}
+  footerBackground="secondary"
 >
 
   <!-- Hero Section -->

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -20,6 +20,7 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
   title="Projects — Astro Rocket"
   description="Selected work — websites, tools, and open-source projects built by Astro Rocket."
   eagerReveal
+  footerBackground="secondary"
 >
   <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>


### PR DESCRIPTION
## Problem

On several pages the footer rendered the **same** background color as the section directly above it, breaking the alternating "zebra" pattern.

Root cause: the footer's `secondary` variant referenced an **undefined** token — `bg-surface-secondary`. Tailwind v4 only generates `bg-*` utilities for defined `--color-*` tokens, and no `--color-surface-secondary` exists, so the class was a no-op and the footer silently fell through to `bg-background`.

The section zebra uses two colors: **A** = `bg-background`, **B** = `bg-background-secondary`. The footer now always renders the opposite of each page's last section.

## Changes

**Core**
- `footer.variants.ts` — `secondary` now points at the real `bg-background-secondary` token (the same one the section zebra uses).
- `PageLayout.astro` — added a documented `footerBackground` prop (default `'default'`), threaded to the `<Footer>`. This layout is shared by 9 pages with differing last-section colors, so the choice has to live with the page.
- `BlogLayout.astro` — footer → `default` (blog posts end in B).

**Per-page overrides** (pages ending in A → footer B)
- `about`, `projects/index`, `blog/page/[page]`, `components` → `footerBackground="secondary"`
- `blog/index` → `footerBackground={featuredPosts.length > 0 ? 'default' : 'secondary'}` (its last section flips with featured content)

Pages already correct after the variant fix needed no change: `index` (Landing) and `projects/[slug]` (Project) end in A → secondary footer; `services` / `contact` / `404` / `blog/tag` end in B → default footer.

## Verification

- `pnpm build` succeeds; `astro check` reports **0 errors**; ESLint clean.
- Parsed the built HTML for all **58 pages** (static, every blog post, every tag page, pagination, project pages) and confirmed each footer's background differs from its last `<section>` → **zebra intact on every page**.

| Page | Last section | Footer |
|------|------|------|
| index | A | B |
| about | A | B |
| services | B | A |
| contact | B | A |
| 404 | B | A |
| projects/index | A | B |
| blog/index | B (featured) | A |
| blog/page/[page] | A | B |
| blog/tag/[tag] | B | A |
| components | A | B |
| blog/[...slug] | B | A |
| projects/[slug] | A | B |

https://claude.ai/code/session_01BvqRrGSS8GpcCTWunDhLe8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvqRrGSS8GpcCTWunDhLe8)_