### PR TITLE
Change Lighthouse heading text on Astro Rocket project page

### DIFF
--- a/src/content/projects/astro-rocket.mdx
+++ b/src/content/projects/astro-rocket.mdx
@@ -23,7 +23,7 @@ import LighthouseScoresGrid from '@/components/landing/LighthouseScoresGrid.astr
 
 I made it for the people I know best: designers, freelancers, and developers who want a site that already looks finished on day one. It's MIT-licensed, [up on GitHub](https://github.com/hansmartensdev/Astro-Rocket), and listed on the [official Astro themes directory](https://astro.build/themes/details/astro-rocket/). The full thing runs live at [astrorocket.dev](https://astrorocket.dev).
 
-## 100 / 100 / 100 / 100
+## Lighthouse score result
 
 <div class="my-10">
   <LighthouseScoresGrid />


### PR DESCRIPTION
Rename the '## 100 / 100 / 100 / 100' heading to '## Lighthouse score result'.

https://claude.ai/code/session_01VnRapMD4FN8VYX7yrVH5dp

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
