### PR TITLE
Add tech-stack Marquee section to the homepage above the CTA

### DIFF
--- a/src/components/landing/StackMarquee.astro
+++ b/src/components/landing/StackMarquee.astro
@@ -1,0 +1,280 @@
+---
+/**
+ * StackMarquee
+ * A double-row, pure-CSS infinite marquee of tech-stack cards. Row one scrolls
+ * one way, row two scrolls the other (at a slightly different speed) for an
+ * organic, non-synced feel. Content is driven by src/content/stack/*.mdx by
+ * default, so adding or removing a tool is an MDX edit — no changes here.
+ *
+ * Reuses the existing Card and Icon components and the site's semantic colour
+ * tokens, so it themes automatically in light and dark mode. Zero JavaScript:
+ * the loop is a CSS keyframe animation on a duplicated track (GPU transform).
+ * It pauses on hover, hides the duplicate/decorative copies from assistive
+ * tech, and freezes under prefers-reduced-motion.
+ *
+ * Usage:
+ *   <StackMarquee />                         // pulls from content/stack, 2 rows
+ *   <StackMarquee rows={1} duration={30} />  // single strip
+ *   <StackMarquee items={[{ name: 'Vercel', icon: 'brand-vercel', url: '…' }]} />
+ */
+import { getCollection } from 'astro:content';
+import { cn } from '@/lib/cn';
+import Icon from '@/components/ui/primitives/Icon/Icon.astro';
+import Card from '@/components/ui/data-display/Card/Card.astro';
+
+export interface StackItem {
+  /** Display name, e.g. "Astro". */
+  name: string;
+  /** Icon name resolved by Icon.astro, e.g. "brand-astro". */
+  icon: string;
+  /** Optional link target; when set (and `linked`), the card links here. */
+  url?: string;
+  /** Optional small sub-label, e.g. "v6". */
+  version?: string;
+  /** Optional per-tool OKLCH params for the logo colour, e.g. "62.5% 0.22 38". */
+  colorOklch?: string;
+}
+
+interface Props {
+  /** Items to show. Defaults to the src/content/stack collection (sorted by order). */
+  items?: StackItem[];
+  /** Number of rows. 2 = double, opposite-direction marquee (default). 1 = single strip. */
+  rows?: number;
+  /** Direction of the first row; each subsequent row alternates. Default "left". */
+  direction?: 'left' | 'right';
+  /** Seconds for one loop of the first row. Each further row is a touch faster. Default 40. */
+  duration?: number;
+  /** Pause a row while it is hovered so visitors can read or click. Default true. */
+  pauseOnHover?: boolean;
+  /** Gap between cards within a row. Default "1.5rem". */
+  gap?: string;
+  /** Gap between rows. Default "1rem". */
+  rowGap?: string;
+  /** Fixed card width. Default "230px". */
+  cardWidth?: string;
+  /** Gradient fade on the left/right edges. Default true. */
+  fade?: boolean;
+  /** Logo colour: "brand" tints every logo with the theme brand colour (default); "tool" uses each tool's own `colorOklch`. */
+  logoColor?: 'brand' | 'tool';
+  /** Wrap each card in its `url`. Default true. */
+  linked?: boolean;
+  /** Show the version sub-label when present. Default false — avoids version numbers that can go stale. */
+  showVersion?: boolean;
+  /** Extra classes on the wrapper. */
+  class?: string;
+}
+
+const {
+  items,
+  rows = 2,
+  direction = 'left',
+  duration = 40,
+  pauseOnHover = true,
+  gap = '1.5rem',
+  rowGap = '1rem',
+  cardWidth = '230px',
+  fade = true,
+  logoColor = 'brand',
+  linked = true,
+  showVersion = false,
+  class: className,
+} = Astro.props;
+
+// Default source: the MDX-driven stack collection, sorted by `order`.
+let data: StackItem[] = items ?? [];
+if (!items) {
+  const entries = await getCollection('stack');
+  data = entries
+    .sort((a, b) => a.data.order - b.data.order)
+    .map((e) => ({
+      name: e.data.name,
+      icon: e.data.icon,
+      url: e.data.url,
+      version: e.data.version,
+      colorOklch: e.data.colorOklch,
+    }));
+}
+
+const opposite = (d: 'left' | 'right'): 'left' | 'right' => (d === 'left' ? 'right' : 'left');
+const rowCount = Math.max(1, rows);
+const MIN_DURATION = 12;
+
+// Per-row config: alternate direction, nudge the speed so lanes don't march in
+// lockstep, and reverse the order so the same logos don't line up vertically.
+const rowConfigs = Array.from({ length: rowCount }, (_, r) => ({
+  items: r % 2 === 0 ? data : [...data].reverse(),
+  direction: r % 2 === 0 ? direction : opposite(direction),
+  duration: Math.max(MIN_DURATION, duration - r * 4),
+  decorative: r > 0, // only the first row is exposed to assistive tech
+}));
+---
+
+<div
+  class={cn('stack-marquee', className)}
+  data-fade={fade ? 'true' : 'false'}
+  data-pause={pauseOnHover ? 'true' : 'false'}
+  data-logo-color={logoColor}
+  style={`--card-width: ${cardWidth}; --row-gap: ${rowGap};`}
+  aria-label="Tech stack"
+>
+  {
+    rowConfigs.map((row) => (
+      <div
+        class="stack-marquee-row"
+        data-direction={row.direction}
+        style={`--marquee-duration: ${row.duration}s; --marquee-gap: ${gap};`}
+      >
+        <div class="stack-marquee-track">
+          {[...row.items, ...row.items].map((item, idx) => {
+            const hidden = idx >= row.items.length || row.decorative;
+            return (
+              <div
+                class="stack-marquee-item"
+                style={logoColor === 'tool' && item.colorOklch ? `--tech-color: oklch(${item.colorOklch});` : undefined}
+              >
+                <Card
+                  variant="default"
+                  padding="md"
+                  href={linked ? item.url : undefined}
+                  target={linked && item.url ? '_blank' : undefined}
+                  rel={linked && item.url ? 'noopener noreferrer' : undefined}
+                  class="h-full w-full"
+                  aria-hidden={hidden ? 'true' : undefined}
+                  tabindex={hidden ? -1 : undefined}
+                >
+                  <div class="flex flex-col items-center justify-center gap-2 md:flex-row md:gap-3">
+                    <span class="stack-icon">
+                      <Icon name={item.icon} size="lg" />
+                    </span>
+                    <span class="flex min-w-0 flex-col">
+                      <span class="font-display text-foreground truncate text-base leading-tight font-bold">
+                        {item.name}
+                      </span>
+                      {showVersion && item.version && (
+                        <span class="text-foreground-muted text-xs font-medium">
+                          {item.version}
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                </Card>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    ))
+  }
+</div>
+
+<style>
+  .stack-marquee {
+    display: flex;
+    flex-direction: column;
+    gap: var(--row-gap, 1rem);
+    width: 100%;
+  }
+
+  .stack-marquee-row {
+    position: relative;
+    /* Clip horizontally but let card shadows breathe vertically. */
+    overflow-x: clip;
+    overflow-y: visible;
+    width: 100%;
+  }
+
+  /* Gradient fade on the leading/trailing edges. */
+  .stack-marquee[data-fade='true'] .stack-marquee-row {
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent 0%,
+      #000 8%,
+      #000 92%,
+      transparent 100%
+    );
+    mask-image: linear-gradient(to right, transparent 0%, #000 8%, #000 92%, transparent 100%);
+  }
+
+  .stack-marquee-track {
+    display: flex;
+    gap: var(--marquee-gap, 1.5rem);
+    width: max-content;
+    animation: stack-marquee-scroll var(--marquee-duration, 40s) linear infinite;
+    will-change: transform;
+  }
+
+  .stack-marquee-row[data-direction='right'] .stack-marquee-track {
+    animation-direction: reverse;
+  }
+
+  /* Pause the hovered row so visitors can read or click a card. Hover-capable
+     devices only: on touch, :hover sticks after a tap and would freeze the
+     marquee until you tapped elsewhere. */
+  @media (hover: hover) {
+    .stack-marquee[data-pause='true'] .stack-marquee-row:hover .stack-marquee-track {
+      animation-play-state: paused;
+    }
+  }
+
+  .stack-marquee-item {
+    flex: none;
+    width: var(--card-width, 230px);
+  }
+
+  /* On phones, collapse to a single row. Two opposite-scrolling rows share the
+     same logos, so in a narrow viewport the same card lines up top-and-bottom
+     for too long. One row removes the collision and reads cleaner on mobile. */
+  @media (max-width: 767px) {
+    .stack-marquee-row:not(:first-child) {
+      display: none;
+    }
+  }
+
+  /* On touch devices (any orientation), make the cards non-interactive so
+     scrolling the page never triggers an accidental tap through to a logo's
+     website. Pointer-driven (desktop) devices keep the links. */
+  @media (pointer: coarse) {
+    .stack-marquee-item {
+      pointer-events: none;
+    }
+  }
+
+  .stack-icon {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 9999px;
+    /* Default: tint every logo with the active theme's brand colour for a cohesive look. */
+    color: var(--color-brand-500);
+    background: color-mix(in oklch, var(--color-brand-500) 12%, transparent);
+  }
+
+  /* Opt in to each tool's own colour via logoColor="tool" (falls back to foreground). */
+  .stack-marquee[data-logo-color='tool'] .stack-icon {
+    color: var(--tech-color, var(--color-foreground));
+    background: color-mix(in oklch, var(--tech-color, var(--color-foreground)) 12%, transparent);
+  }
+
+  @keyframes stack-marquee-scroll {
+    from {
+      transform: translate3d(0, 0, 0);
+    }
+    to {
+      /* -50% minus half a gap lands the duplicate exactly on the original for a seamless loop. */
+      transform: translate3d(calc(-50% - (var(--marquee-gap, 1.5rem) / 2)), 0, 0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .stack-marquee-track {
+      animation: none;
+      transform: none;
+    }
+    .stack-marquee-row {
+      overflow-x: auto;
+    }
+  }
+</style>

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -64,5 +64,6 @@ const {
 
   <slot />
 
-  <Footer slot="footer" layout="simple" background="secondary" />
+  <!-- Footer defaults to `background` so it alternates with the secondary CTA above while the marquee is shown; on phones .home-footer reverts it to secondary (see the homepage zebra swap in index.astro) -->
+  <Footer slot="footer" layout="simple" background="default" class="home-footer" />
 </BaseLayout>

--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -42,6 +42,8 @@ import SearchInput from '@/components/patterns/SearchInput.astro';
 import PasswordInput from '@/components/patterns/PasswordInput.astro';
 import StatCard from '@/components/patterns/StatCard.astro';
 import EmptyState from '@/components/patterns/EmptyState.astro';
+// Landing Components
+import StackMarquee from '@/components/landing/StackMarquee.astro';
 ---
 
 <PageLayout
@@ -158,6 +160,19 @@ import EmptyState from '@/components/patterns/EmptyState.astro';
                 <Button size="sm" variant="ghost">Our Story</Button>
               </Fragment>
             </Hero>
+          </div>
+        </div>
+
+        <!-- Stack Marquee (double row) -->
+        <div class="component-showcase">
+          <div class="showcase-header">
+            <span class="showcase-label">Stack Marquee</span>
+            <span class="showcase-hint">Two rows of stack cards scrolling opposite ways — driven by src/content/stack, themed for light &amp; dark</span>
+          </div>
+          <div class="showcase-content !p-0 overflow-hidden rounded-b-xl">
+            <div class="w-full py-[var(--space-stack-lg)]">
+              <StackMarquee />
+            </div>
           </div>
         </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import Card from '@/components/ui/data-display/Card/Card.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import BlogCard from '@/components/blog/BlogCard.astro';
 import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
+import StackMarquee from '@/components/landing/StackMarquee.astro';
 import { getCollection } from 'astro:content';
 import siteConfig from '@/config/site.config';
 
@@ -354,6 +355,13 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
     </div>
   </section>
 
+ <!-- Tech stack marquee — its own band: the tertiary background sets it apart as a standalone section, so the primary/secondary zebra of the sections above (Blog) and below (CTA) stays intact. Hidden on phones (portrait + landscape) via .stack-marquee-section; on phones the band drops out and the Blog→CTA zebra still alternates. -->
+  <section class="stack-marquee-section relative z-10 py-[var(--space-section-md)] bg-background-tertiary border-t border-border">
+    <div class="mx-auto max-w-6xl px-6" data-reveal>
+      <StackMarquee />
+    </div>
+  </section>
+
  <!-- CTA -->
   <section class="relative z-10 py-[var(--space-section-md)] bg-background border-t border-border">
     <!-- Mobile: flat section, no card -->
@@ -439,6 +447,23 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   @media (min-width: 768px) {
     .hero-dark-gradient .hero-title-slot + div {
       max-width: 48rem;
+    }
+  }
+
+  /* Hide the tech-stack marquee band on mobile phones — both portrait and
+     landscape — while keeping it on tablets and desktops. Portrait phones are
+     caught by width; landscape phones are wider than the md breakpoint, so
+     they're caught by their short height plus a coarse (touch) pointer, which
+     excludes tablets (taller) and small laptop windows (fine pointer). The
+     whole section drops out, so on phones the Blog → CTA zebra still alternates. */
+  @media (max-width: 767px) {
+    .stack-marquee-section {
+      display: none;
+    }
+  }
+  @media (orientation: landscape) and (max-height: 500px) and (pointer: coarse) {
+    .stack-marquee-section {
+      display: none;
     }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -362,8 +362,8 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
     </div>
   </section>
 
- <!-- CTA -->
-  <section class="relative z-10 py-[var(--space-section-md)] bg-background border-t border-border">
+ <!-- CTA — secondary by default so it alternates with the Marquee (background) above and the Footer (background) below while the marquee is shown; on phones (marquee hidden) .cta-section reverts it to background so Blog → CTA → Footer still alternates -->
+  <section class="cta-section relative z-10 py-[var(--space-section-md)] bg-background-secondary border-t border-border">
     <!-- Mobile: flat section, no card -->
     <div class="glitch:hidden mx-auto max-w-2xl px-6 text-center" data-reveal>
       <Badge variant="brand" pill class="mb-6">Let's talk</Badge>
@@ -450,21 +450,25 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
     }
   }
 
-  /* Hide the tech-stack marquee band on mobile phones — both portrait and
-     landscape — while keeping it on tablets and desktops. Portrait phones are
-     caught by width; landscape phones are wider than the md breakpoint, so
-     they're caught by their short height plus a coarse (touch) pointer, which
-     excludes tablets (taller) and small laptop windows (fine pointer). The
-     whole section drops out, so on phones the Blog → CTA zebra still alternates. */
+  /* Mobile-phone zebra swap. On phones — portrait (caught by width) and
+     landscape (wider than the md breakpoint, so caught by short height + a
+     coarse/touch pointer, which excludes tablets and laptops) — the marquee
+     band is hidden and the CTA + footer revert to their no-marquee colours.
+     The default (tablet/desktop, marquee shown) order is:
+       Blog(secondary) → Marquee(background) → CTA(secondary) → Footer(background)
+     and on phones it collapses to:
+       Blog(secondary) → CTA(background) → Footer(secondary)
+     so every adjacent section alternates in both states. The element+class
+     selectors outrank the Tailwind bg utilities, so no !important is needed. */
   @media (max-width: 767px) {
-    .stack-marquee-section {
-      display: none;
-    }
+    .stack-marquee-section { display: none; }
+    section.cta-section { background-color: var(--color-background); }
+    footer.home-footer { background-color: var(--color-background-secondary); }
   }
   @media (orientation: landscape) and (max-height: 500px) and (pointer: coarse) {
-    .stack-marquee-section {
-      display: none;
-    }
+    .stack-marquee-section { display: none; }
+    section.cta-section { background-color: var(--color-background); }
+    footer.home-footer { background-color: var(--color-background-secondary); }
   }
 </style>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -355,8 +355,8 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
     </div>
   </section>
 
- <!-- Tech stack marquee — its own band: the tertiary background sets it apart as a standalone section, so the primary/secondary zebra of the sections above (Blog) and below (CTA) stays intact. Hidden on phones (portrait + landscape) via .stack-marquee-section; on phones the band drops out and the Blog→CTA zebra still alternates. -->
-  <section class="stack-marquee-section relative z-10 py-[var(--space-section-md)] bg-background-tertiary border-t border-border">
+ <!-- Tech stack marquee — its own section in the 2-tone zebra. It follows the secondary Blog section, so it flips to `background` like the next stripe. Hidden on phones (portrait + landscape) via .stack-marquee-section; when it drops out, Blog (secondary) → CTA (background) still alternate, so the zebra holds on mobile too. -->
+  <section class="stack-marquee-section relative z-10 py-[var(--space-section-md)] bg-background border-t border-border">
     <div class="mx-auto max-w-6xl px-6" data-reveal>
       <StackMarquee />
     </div>


### PR DESCRIPTION
## Summary

Syncs the `StackMarquee` tech-stack marquee from the HansMartens site into this repo, places it on the homepage in its own section directly above the CTA, and showcases it on the components page.

## Changes

- **New component** `src/components/landing/StackMarquee.astro` — a pure-CSS, double-row infinite marquee of stack cards, driven by the existing `src/content/stack` collection. All dependencies (Card, Icon brand glyphs, `cn`, the stack collection) already exist here, so it works unchanged.
- **Homepage** (`src/pages/index.astro`) — marquee added as its own section above the CTA.
- **Components page** (`src/pages/components.astro`) — "Stack Marquee" showcase added to the Hero section.
- **Layout** (`src/layouts/LandingLayout.astro`) — footer flips to keep the zebra intact (see below).

## Two-tone zebra, preserved in every state

The marquee inserts a stripe between the `secondary` Blog section and the `background` CTA. To keep strict two-colour alternation (no third surface colour), the swap cascades through the CTA and footer:

| | Blog | Marquee | CTA | Footer |
|---|---|---|---|---|
| Tablet / desktop (marquee shown) | `secondary` | `background` | `secondary` | `background` |
| Phones (marquee hidden) | `secondary` | — | `background` | `secondary` |

Every adjacent section alternates in both states, using only the two zebra tones.

## Hidden on phones (both orientations)

The marquee is hidden on phones — portrait (`max-width: 767px`) and landscape (`max-height: 500px` + coarse pointer, since landscape phones are wider than the `md` breakpoint) — while staying on tablets and desktops. The same two media queries also perform the CTA/footer swap, so the zebra holds when the band drops out.

## Test plan

- `astro build` passes
- `eslint .` (CI gate) passes
- Verified in the built CSS that both phone media queries hide the marquee and flip the CTA + footer (each override rule appears once per query)

https://claude.ai/code/session_01WKVCGnLLyBeWZMntCtRqqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKVCGnLLyBeWZMntCtRqqC)_