### PR TITLE
Add a blog post on the Stack Marquee

### DIFF
--- a/src/assets/blog/stack-marquee.svg
+++ b/src/assets/blog/stack-marquee.svg
@@ -1,0 +1,61 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .bg  { fill: var(--brand-500); }
+    .ico { stroke: var(--brand-100); stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; fill: none; }
+    .txt { fill: var(--brand-50); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; font-weight: 800; }
+    .ln  { stroke: var(--brand-300); stroke-width: 1; stroke-opacity: 0.35; }
+    .pil { fill: var(--brand-400); fill-opacity: 0.25; stroke: var(--brand-200); stroke-opacity: 0.4; stroke-width: 1; }
+    .ptx { fill: var(--brand-100); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; }
+    .cor { stroke: var(--brand-300); stroke-width: 1.5; fill: none; stroke-opacity: 0.45; }
+    .num { fill: var(--brand-50); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; font-weight: 800; fill-opacity: 0.18; }
+  </style>
+  <defs>
+    <!-- One stack card: rounded outline + icon badge + two label bars -->
+    <g id="mq-card">
+      <rect width="200" height="84" rx="16" class="cor"/>
+      <circle cx="40" cy="42" r="17" class="pil"/>
+      <rect x="70" y="33" width="96" height="9" rx="4.5" class="pil"/>
+      <rect x="70" y="51" width="62" height="9" rx="4.5" class="pil"/>
+    </g>
+    <!-- Edge fade masks (the marquee's signature soft edges) -->
+    <linearGradient id="mq-fade-l" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="var(--brand-600)" stop-opacity="1"/>
+      <stop offset="1" stop-color="var(--brand-600)" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="mq-fade-r" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="var(--brand-600)" stop-opacity="0"/>
+      <stop offset="1" stop-color="var(--brand-600)" stop-opacity="1"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" class="bg"/>
+
+  <!-- Top row — scrolls one way -->
+  <use href="#mq-card" x="-44" y="158"/>
+  <use href="#mq-card" x="196" y="158"/>
+  <use href="#mq-card" x="436" y="158"/>
+  <use href="#mq-card" x="676" y="158"/>
+  <use href="#mq-card" x="916" y="158"/>
+  <use href="#mq-card" x="1156" y="158"/>
+
+  <!-- Bottom row — offset, scrolls the other way -->
+  <use href="#mq-card" x="-164" y="282"/>
+  <use href="#mq-card" x="76" y="282"/>
+  <use href="#mq-card" x="316" y="282"/>
+  <use href="#mq-card" x="556" y="282"/>
+  <use href="#mq-card" x="796" y="282"/>
+  <use href="#mq-card" x="1036" y="282"/>
+
+  <!-- Soft edges over both rows -->
+  <rect x="0" y="142" width="248" height="266" fill="url(#mq-fade-l)"/>
+  <rect x="952" y="142" width="248" height="266" fill="url(#mq-fade-r)"/>
+
+  <!-- Title -->
+  <text x="600" y="486" font-size="92" text-anchor="middle" letter-spacing="-2" class="txt">marquee</text>
+
+  <!-- Corner brackets -->
+  <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
+  <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
+  <path d="M 36 570 L 36 594 L 60 594" class="cor"/>
+  <path d="M 1140 594 L 1164 594 L 1164 570" class="cor"/>
+</svg>

--- a/src/content/blog/en/stack-marquee.mdx
+++ b/src/content/blog/en/stack-marquee.mdx
@@ -1,0 +1,107 @@
+---
+title: "The Stack Marquee — A Pure-CSS Infinite Tech Strip"
+description: "Astro Rocket's homepage has a new Stack Marquee: two rows of tech-stack cards scrolling opposite ways with zero JavaScript. Here's how the loop works and why it's hidden on phones."
+publishedAt: 2026-06-07
+author: "Hans Martens"
+tags: ["astro-rocket", "animation", "css", "components", "ux", "performance"]
+featured: false
+locale: en
+image: "../../../assets/blog/stack-marquee.svg"
+svgSlug: "stack-marquee"
+imageAlt: "Two rows of stack cards with softly faded edges on a brand-coloured background, beneath the word marquee"
+---
+
+Astro Rocket's homepage has a new section, tucked in just above the call to action: the **Stack Marquee**. It's two rows of tech-stack cards that scroll in opposite directions — an endless, soft-edged strip of the tools the theme is built on. It runs on pure CSS, recolours itself with your active theme, and is driven entirely by the `src/content/stack` collection. It's also deliberately absent on phones. Here's how all of that works.
+
+## A seamless loop, with zero JavaScript
+
+The trick behind every infinite marquee is duplication. Each row holds its list of cards **twice over**, and a single CSS keyframe slides the whole track left by exactly half its width. Because the second copy is identical to the first, the instant the animation loops back to the start there's nothing to give it away — the join is invisible.
+
+```css
+@keyframes stack-marquee-scroll {
+  from { transform: translate3d(0, 0, 0); }
+  to   { transform: translate3d(calc(-50% - (var(--marquee-gap) / 2)), 0, 0); }
+}
+```
+
+There's no JavaScript, no `requestAnimationFrame`, no scroll listener — just a GPU-friendly `transform` animation that the browser can run on its own thread.
+
+The two rows don't move as one. The first row scrolls one way; the second reverses the list, flips its direction, and runs a touch faster, so the lanes never march in lockstep. The edges are masked with a CSS gradient so cards fade in and out instead of popping at the boundary, and hovering a row pauses it so you can read — or click — a card.
+
+## Filling the loop on wide screens
+
+The `-50%` trick only hides the join when **one copy of the row is at least as wide as the container**. The theme ships with four tools, and on a wide desktop four cards aren't quite wide enough to span the screen — so the loop would flash a small gap at the seam (tablets and phones, being narrower, were fine).
+
+The fix is to repeat the list up to a minimum card count *before* it gets duplicated, so a single copy always overflows even the widest container. The maths above is untouched, because the track is still exactly two identical copies:
+
+```ts
+const MIN_CARDS = 8;
+const fill = (list) => {
+  if (!list.length) return list;
+  const out = [...list];
+  while (out.length < MIN_CARDS) out.push(...list);
+  return out;
+};
+```
+
+## Driven by your content
+
+Every card comes from `src/content/stack` — one MDX file per tool, each with a name, an icon, and a link. Add or remove a tool by editing that folder and both the marquee and the static tech grid on the About page update on their own; there's nothing to wire up in the component.
+
+Each card is the same `Card` and `Icon` you'll find everywhere else in the [component library](/blog/component-library), so it inherits the theme's spacing, borders, and — through a single brand token — its colour. Switch themes and the entire strip recolours instantly.
+
+## Why it sits out on phones
+
+On a phone, the marquee is hidden entirely. A horizontally-scrolling, auto-animating strip wants room: on a narrow screen only a card or two fit at a time, the effect is lost, and a constantly-moving block competes for attention while someone is trying to read. Rather than ship a cramped version, the homepage simply leaves it out below tablet size — the page reads cleaner and renders a little less.
+
+Catching *every* phone takes two rules. Portrait phones are the easy half — they're narrow, so a width query handles them:
+
+```css
+@media (max-width: 767px) {
+  .stack-marquee-section { display: none; }
+}
+```
+
+Landscape phones are the tricky half. They're **wider** than the tablet breakpoint, so a width query alone would let them slip through and show the marquee. What gives them away is that they're short and touch-driven, so a second rule catches them by their height and pointer type — without ever touching a real tablet or a laptop:
+
+```css
+@media (orientation: landscape) and (max-height: 500px) and (pointer: coarse) {
+  .stack-marquee-section { display: none; }
+}
+```
+
+## Keeping the zebra intact
+
+The homepage alternates two background tones section by section — a zebra stripe running down the page. Dropping a section in or out could easily break that rhythm, so the marquee is careful about it.
+
+When it's **hidden**, the whole `<section>` is removed from the flow with `display: none` (not just visually hidden), so the Blog section and the CTA become direct neighbours and keep alternating. When it's **shown**, it slots in as a `background` stripe, and the CTA and footer below it swap tones so the run stays perfectly two-coloured from top to bottom — no third colour required. If you want the tokens behind those two tones, the [colour token system](/blog/design-system-color-tokens) post covers them.
+
+## It respects reduced motion
+
+Like every piece of motion in the theme, the marquee defers to `prefers-reduced-motion`. If a visitor has asked their system to go easy on animation, the scroll is switched off and each row becomes a normal, manually-scrollable strip — all the content is still there, it just stops moving on its own:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .stack-marquee-track { animation: none; transform: none; }
+  .stack-marquee-row { overflow-x: auto; }
+}
+```
+
+For more on how the theme handles motion responsibly, see [Animations in Astro Rocket](/blog/animations-in-astro-rocket).
+
+## Using it
+
+The component lives at `src/components/landing/StackMarquee.astro`. Drop it into any section and it pulls from your stack collection automatically:
+
+```astro
+<StackMarquee />
+```
+
+It accepts props for the number of rows, scroll speed, card width, edge fade, and whether the cards link out — but the defaults are tuned for the homepage, where it sits in its own band directly above the CTA.
+
+## Related reading
+
+- [Animations in Astro Rocket](/blog/animations-in-astro-rocket) — the theme's approach to motion, performance, and reduced-motion.
+- [The Component Library](/blog/component-library) — the `Card` and `Icon` the marquee is built from.
+- [Scroll Progress Ring](/blog/scroll-progress-ring) — another small, GPU-friendly piece of motion.
+- [Design System Colour Tokens](/blog/design-system-color-tokens) — the background tones behind the zebra.


### PR DESCRIPTION
## Summary

A follow-up to the Stack Marquee feature (merged in #378 and #379): a blog post that documents the new homepage marquee for readers — how it works and why it's hidden on phones.

## Changes

- **`src/content/blog/en/stack-marquee.mdx`** — *"The Stack Marquee — A Pure-CSS Infinite Tech Strip."* Covers:
  - the duplicate-and-translate-`-50%` infinite loop, two rows scrolling opposite ways, edge-fade mask, pause-on-hover — all with zero JavaScript;
  - the wide-screen **fill** that keeps the loop seamless with a small stack collection;
  - that it's driven by `src/content/stack` and reuses `Card`/`Icon`;
  - **why it's hidden on phones** (portrait by width; landscape phones by short height + coarse pointer);
  - how the **zebra** stays intact when it drops out, reduced-motion support, and usage.
- **`src/assets/blog/stack-marquee.svg`** — a 1200×630 hero image in the house style (brand-themed semantic classes, themes in light/dark).
- Inline links to related posts (*Animations*, *Component Library*, *Design System Colour Tokens*); matching tags also surface the related-posts grid automatically.

## Test plan

- `astro build` passes (post + OG image generated)
- `eslint .` (CI gate) passes
- Rendered in a browser in light and dark mode

The one commit here sits on `ef48a51`, which is already in `main` via #379, so the diff is just the post and its SVG.

https://claude.ai/code/session_01WKVCGnLLyBeWZMntCtRqqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKVCGnLLyBeWZMntCtRqqC)_