### PR TITLE
Make the marquee cards in the blog hero SVG clearly visible

### DIFF
--- a/src/assets/blog/stack-marquee.svg
+++ b/src/assets/blog/stack-marquee.svg
@@ -8,14 +8,18 @@
     .ptx { fill: var(--brand-100); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; }
     .cor { stroke: var(--brand-300); stroke-width: 1.5; fill: none; stroke-opacity: 0.45; }
     .num { fill: var(--brand-50); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; font-weight: 800; fill-opacity: 0.18; }
+    /* Stack cards — light frosted panels so the marquee reads clearly on the brand background (light + dark) */
+    .mq-card { fill: var(--brand-100); fill-opacity: 0.42; stroke: var(--brand-50); stroke-opacity: 0.9; stroke-width: 1.5; }
+    .mq-ico  { fill: var(--brand-600); fill-opacity: 0.9; }
+    .mq-bar  { fill: var(--brand-500); fill-opacity: 0.8; }
   </style>
   <defs>
     <!-- One stack card: rounded outline + icon badge + two label bars -->
     <g id="mq-card">
-      <rect width="200" height="84" rx="16" class="cor"/>
-      <circle cx="40" cy="42" r="17" class="pil"/>
-      <rect x="70" y="33" width="96" height="9" rx="4.5" class="pil"/>
-      <rect x="70" y="51" width="62" height="9" rx="4.5" class="pil"/>
+      <rect width="200" height="84" rx="16" class="mq-card"/>
+      <circle cx="40" cy="42" r="17" class="mq-ico"/>
+      <rect x="70" y="33" width="96" height="9" rx="4.5" class="mq-bar"/>
+      <rect x="70" y="51" width="62" height="9" rx="4.5" class="mq-bar"/>
     </g>
     <!-- Edge fade masks (the marquee's signature soft edges) -->
     <linearGradient id="mq-fade-l" x1="0" y1="0" x2="1" y2="0">


### PR DESCRIPTION
The cards were drawn as faint outlines (.cor) with .pil details, which read as near-invisible — and worse in dark mode, where .pil's fill resolves to the background colour. Give the cards a light frosted fill with a crisp border and darker icon/label elements, using their own fixed-tone classes (the same pattern scroll-progress-bar.svg uses for its bar) so they stay clear and consistent in both light and dark mode.

https://claude.ai/code/session_01WKVCGnLLyBeWZMntCtRqqC

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
