### PR TITLE
Add build-time duplicate-slug validation (Phase 0)

### DIFF
--- a/src/__tests__/content-validation.test.ts
+++ b/src/__tests__/content-validation.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collectSlugRecords,
+  findSlugCollisions,
+  formatSlugCollisions,
+  type SlugRecord,
+} from '@/lib/content-validation';
+
+const post = (id: string, locale = 'en') => ({ id, data: { locale } });
+
+describe('collectSlugRecords', () => {
+  it('maps blog posts to /blog/<slug>, stripping the locale prefix', () => {
+    const records = collectSlugRecords([post('en/getting-started')], []);
+    expect(records).toEqual([
+      { source: 'blog: en/getting-started', locale: 'en', path: '/blog/getting-started' },
+    ]);
+  });
+
+  it('maps pages to /<slug> at the site root', () => {
+    const records = collectSlugRecords([], [post('en/about')]);
+    expect(records).toEqual([
+      { source: 'pages: en/about', locale: 'en', path: '/about' },
+    ]);
+  });
+
+  it('keeps nested slugs intact after the locale prefix', () => {
+    const records = collectSlugRecords([post('en/guides/deploy')], []);
+    expect(records[0].path).toBe('/blog/guides/deploy');
+  });
+
+  it('leaves ids without a matching locale prefix unchanged', () => {
+    const records = collectSlugRecords([post('getting-started', 'en')], []);
+    expect(records[0].path).toBe('/blog/getting-started');
+  });
+});
+
+describe('findSlugCollisions', () => {
+  it('returns nothing when every path is unique within its locale', () => {
+    const records: SlugRecord[] = [
+      { source: 'blog: en/a', locale: 'en', path: '/blog/a' },
+      { source: 'blog: en/b', locale: 'en', path: '/blog/b' },
+    ];
+    expect(findSlugCollisions(records)).toEqual([]);
+  });
+
+  it('does not flag the same path across different locales', () => {
+    const records: SlugRecord[] = [
+      { source: 'blog: en/a', locale: 'en', path: '/blog/a' },
+      { source: 'blog: es/a', locale: 'es', path: '/blog/a' },
+    ];
+    expect(findSlugCollisions(records)).toEqual([]);
+  });
+
+  it('flags two entries that resolve to the same path in one locale', () => {
+    const records: SlugRecord[] = [
+      { source: 'blog: en/a', locale: 'en', path: '/blog/a' },
+      { source: 'blog: en/sub/a', locale: 'en', path: '/blog/a' },
+    ];
+    const collisions = findSlugCollisions(records);
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0]).toMatchObject({ locale: 'en', path: '/blog/a' });
+    expect(collisions[0].sources).toEqual(['blog: en/a', 'blog: en/sub/a']);
+  });
+
+  it('catches a blog post and a page colliding on the same root path', () => {
+    const records = collectSlugRecords([post('en/about')], [post('en/about')]);
+    // /blog/about and /about do not collide — different URL namespaces.
+    expect(findSlugCollisions(records)).toEqual([]);
+  });
+
+  it('does collide when two pages share a slug', () => {
+    const records = collectSlugRecords([], [post('en/about'), post('about')]);
+    const collisions = findSlugCollisions(records);
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0].path).toBe('/about');
+  });
+});
+
+describe('formatSlugCollisions', () => {
+  it('produces a readable, actionable message listing every source', () => {
+    const message = formatSlugCollisions([
+      { locale: 'en', path: '/blog/a', sources: ['blog: en/a', 'blog: en/sub/a'] },
+    ]);
+    expect(message).toContain('Duplicate slugs detected');
+    expect(message).toContain('[en] /blog/a');
+    expect(message).toContain('blog: en/a');
+    expect(message).toContain('blog: en/sub/a');
+  });
+});

--- a/src/lib/content-validation.ts
+++ b/src/lib/content-validation.ts
@@ -1,0 +1,146 @@
+/**
+ * Build-time content validation.
+ *
+ * Phase 0: fail the build when two pieces of content resolve to the same URL
+ * within a locale. As the content set grows — and especially once slugs are
+ * derived from filenames across many posts — duplicate slugs become an easy
+ * mistake that otherwise fails silently (one post quietly shadows another).
+ * Catching it at build time turns a silent content bug into a loud, actionable
+ * error.
+ *
+ * The pure helpers (`collectSlugRecords`, `findSlugCollisions`,
+ * `formatSlugCollisions`) take plain data so they can be unit-tested without
+ * the Astro content runtime. `assertNoSlugCollisions` is the build-time entry
+ * point that loads the collections and throws.
+ */
+
+/** A single URL a piece of content will be published at, within a locale. */
+export interface SlugRecord {
+  /** Human-readable origin for diagnostics, e.g. `blog: en/getting-started`. */
+  source: string;
+  /** Locale the entry belongs to; collisions are only checked within a locale. */
+  locale: string;
+  /** URL path within the locale, e.g. `/blog/getting-started` or `/about`. */
+  path: string;
+}
+
+/** Two or more entries that resolve to the same path within a locale. */
+export interface SlugCollision {
+  locale: string;
+  path: string;
+  /** The `source` of every entry that landed on this path. */
+  sources: string[];
+}
+
+/** Minimal shape shared by content-collection entries used here. */
+interface ContentEntryLike {
+  id: string;
+  data: { locale: string };
+}
+
+/**
+ * Strip a leading `<locale>/` segment from a collection entry id to get its
+ * slug. Mirrors `getPostSlug` in `./blog`, reimplemented here so this module
+ * stays free of the `astro:content` runtime import and remains unit-testable.
+ */
+function localeStrippedSlug(id: string, locale: string): string {
+  const prefix = `${locale}/`;
+  return id.startsWith(prefix) ? id.slice(prefix.length) : id;
+}
+
+/**
+ * Build the list of published URLs from the blog and pages collections.
+ * Blog posts live under `/blog/<slug>`; pages live at the site root `/<slug>`.
+ */
+export function collectSlugRecords(
+  posts: ContentEntryLike[],
+  pages: ContentEntryLike[]
+): SlugRecord[] {
+  const records: SlugRecord[] = [];
+
+  for (const post of posts) {
+    const { locale } = post.data;
+    records.push({
+      source: `blog: ${post.id}`,
+      locale,
+      path: `/blog/${localeStrippedSlug(post.id, locale)}`,
+    });
+  }
+
+  for (const page of pages) {
+    const { locale } = page.data;
+    records.push({
+      source: `pages: ${page.id}`,
+      locale,
+      path: `/${localeStrippedSlug(page.id, locale)}`,
+    });
+  }
+
+  return records;
+}
+
+/**
+ * Group records by (locale, path) and return every path that more than one
+ * entry resolves to. Output is sorted (locale, then path) and each collision's
+ * sources are sorted, so error messages are deterministic.
+ */
+export function findSlugCollisions(records: SlugRecord[]): SlugCollision[] {
+  const groups = new Map<string, SlugRecord[]>();
+  for (const record of records) {
+    const key = JSON.stringify([record.locale, record.path]);
+    const existing = groups.get(key);
+    if (existing) existing.push(record);
+    else groups.set(key, [record]);
+  }
+
+  const collisions: SlugCollision[] = [];
+  for (const group of groups.values()) {
+    if (group.length > 1) {
+      collisions.push({
+        locale: group[0].locale,
+        path: group[0].path,
+        sources: group.map((r) => r.source).sort(),
+      });
+    }
+  }
+
+  return collisions.sort(
+    (a, b) => a.locale.localeCompare(b.locale) || a.path.localeCompare(b.path)
+  );
+}
+
+/** Render collisions as a single, actionable error message. */
+export function formatSlugCollisions(collisions: SlugCollision[]): string {
+  const blocks = collisions.map((c) => {
+    const sources = c.sources.map((s) => `      - ${s}`).join('\n');
+    return `  [${c.locale}] ${c.path}\n${sources}`;
+  });
+  return (
+    `Duplicate slugs detected — every entry must resolve to a unique URL ` +
+    `within its locale:\n\n${blocks.join('\n\n')}\n\n` +
+    `Rename the offending file(s) so each resolves to a distinct slug.`
+  );
+}
+
+/**
+ * Build-time guard: throw if any two published entries collide on the same URL
+ * within a locale. Drafts are excluded — they are not emitted in production, so
+ * they cannot cause a real collision. Call this from a route's
+ * `getStaticPaths`; a throw here aborts `astro build`.
+ */
+export async function assertNoSlugCollisions(): Promise<void> {
+  const { getCollection } = await import('astro:content');
+  const [posts, pages] = await Promise.all([
+    getCollection('blog'),
+    getCollection('pages'),
+  ]);
+
+  const publishablePosts = posts.filter((post) => post.data.draft !== true);
+  const collisions = findSlugCollisions(
+    collectSlugRecords(publishablePosts, pages)
+  );
+
+  if (collisions.length > 0) {
+    throw new Error(formatSlugCollisions(collisions));
+  }
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,8 +1,12 @@
 ---
 import BlogLayout from '@/layouts/BlogLayout.astro';
 import { getCollection, render } from 'astro:content';
+import { assertNoSlugCollisions } from '@/lib/content-validation';
 
 export async function getStaticPaths() {
+  // Fail the build early if any two entries resolve to the same URL in a locale.
+  await assertNoSlugCollisions();
+
   const posts = await getCollection('blog', ({ data }) => {
     return data.locale === 'en' && (import.meta.env.PROD ? data.draft !== true : true);
   });


### PR DESCRIPTION
Fail the build when two pieces of content resolve to the same URL within a locale. As the content set grows, duplicate slugs are an easy mistake that otherwise fails silently — one entry quietly shadows another.

- New src/lib/content-validation.ts with pure, unit-testable helpers (collectSlugRecords, findSlugCollisions, formatSlugCollisions) plus assertNoSlugCollisions, the build-time guard.
- Call assertNoSlugCollisions() from the blog route's getStaticPaths so a collision aborts the build with an actionable message naming both files.
- Unit tests covering slug derivation, per-locale grouping, cross-namespace behaviour, and message formatting.

Addresses point #4 of #377 (non-breaking).

https://claude.ai/code/session_01HHmJNfuJhy3Wog2U48e2ff

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
