### PR TITLE
Phase 1: durable internal links via &lt;PostLink&gt; (canonical ids)

### DIFF
--- a/src/__tests__/post-links.test.ts
+++ b/src/__tests__/post-links.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { buildUidIndex, normalizeUid, type ResolvedPost } from '@/lib/post-links';
+
+const post = (
+  id: string,
+  uid: string | undefined,
+  title: string,
+  locale = 'en'
+) => ({ id, data: { locale, uid, title } });
+
+describe('normalizeUid', () => {
+  it('strips a leading post: prefix', () => {
+    expect(normalizeUid('post:getting-started')).toBe('getting-started');
+  });
+
+  it('leaves a bare uid unchanged', () => {
+    expect(normalizeUid('getting-started')).toBe('getting-started');
+  });
+});
+
+describe('buildUidIndex', () => {
+  it('indexes posts by uid then locale, deriving slug and title', () => {
+    const index = buildUidIndex([
+      post('en/astro-rocket-configuration-guide', 'configuration-guide', 'Config Guide'),
+    ]);
+    expect(index.get('configuration-guide')?.get('en')).toEqual({
+      slug: 'astro-rocket-configuration-guide',
+      title: 'Config Guide',
+    } satisfies ResolvedPost);
+  });
+
+  it('skips posts without a uid', () => {
+    const index = buildUidIndex([post('en/no-uid', undefined, 'No uid')]);
+    expect(index.size).toBe(0);
+  });
+
+  it('allows the same uid across different locales (translations)', () => {
+    const index = buildUidIndex([
+      post('en/guide', 'guide', 'Guide', 'en'),
+      post('es/guia', 'guide', 'Guía', 'es'),
+    ]);
+    expect(index.get('guide')?.get('en')?.slug).toBe('guide');
+    expect(index.get('guide')?.get('es')?.slug).toBe('guia');
+  });
+
+  it('throws when two posts in the same locale claim the same uid', () => {
+    expect(() =>
+      buildUidIndex([post('en/a', 'dup', 'A'), post('en/b', 'dup', 'B')])
+    ).toThrow(/Duplicate canonical id "dup"/);
+  });
+});

--- a/src/components/blog/PostLink.astro
+++ b/src/components/blog/PostLink.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * Resolve a stable canonical id to a real internal link at build time.
+ *
+ * Usage in MDX (the component is provided globally to blog content, so no
+ * import is needed):
+ *
+ *   the <PostLink uid="configuration-guide">configuration guide</PostLink> covers…
+ *   <PostLink uid="post:configuration-guide" />   (the post: prefix is optional; falls back to the post title)
+ *
+ * If the uid does not match any published post the build fails — broken
+ * internal links can never ship.
+ */
+import { resolvePostUrl } from '@/lib/post-links';
+import { defaultLocale } from '@/i18n';
+
+interface Props {
+  /** Canonical id of the target post (a leading `post:` is allowed and ignored). */
+  uid: string;
+  /** Locale to resolve against; defaults to the current route locale. */
+  locale?: string;
+  /** Optional class passthrough for the rendered anchor. */
+  class?: string;
+}
+
+const { uid, locale, class: className } = Astro.props;
+const targetLocale = locale ?? Astro.currentLocale ?? defaultLocale;
+const { url, title } = await resolvePostUrl(uid, targetLocale);
+---
+
+<a href={url} class={className}><slot>{title}</slot></a>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -16,6 +16,18 @@ const blog = defineCollection({
       imageAlt: z.string().optional(),
       tags: z.array(z.string()).default([]),
       svgSlug: z.string().optional(),
+      /**
+       * Optional stable canonical id, decoupled from the slug. Used by
+       * <PostLink> for durable internal links that survive slug renames.
+       * Lowercase kebab-case.
+       */
+      uid: z
+        .string()
+        .regex(
+          /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+          'uid must be lowercase kebab-case, e.g. "getting-started"'
+        )
+        .optional(),
       draft: z.boolean().default(false),
       featured: z.boolean().default(false),
       locale: z.enum(['en', 'es', 'fr']).default('en'),

--- a/src/content/blog/en/astro-rocket-configuration-guide.mdx
+++ b/src/content/blog/en/astro-rocket-configuration-guide.mdx
@@ -9,6 +9,7 @@ locale: en
 image: "../../../assets/blog/astro-rocket-configuration-guide.svg"
 svgSlug: "astro-rocket-configuration-guide"
 imageAlt: "Feature overview graphic for Astro Rocket on a dark background"
+uid: "configuration-guide"
 ---
 
 Astro Rocket ships configured with sensible defaults. This post documents every meaningful option you can change — what it does, where to find it, and what value to set.

--- a/src/content/blog/en/i18n-in-astro-rocket.mdx
+++ b/src/content/blog/en/i18n-in-astro-rocket.mdx
@@ -13,7 +13,7 @@ imageAlt: "Globe icon centred on a brand-coloured background with the label 'i18
 
 Astro Rocket 1.3.0 ships native, opt-in internationalization. You can now run your site in two (or twenty) languages without leaving the theme — no scaffolding CLI, no plugins, no separate package. This post walks through what the feature is, what it costs (spoiler: nothing if you leave it off), and exactly how to turn it on for an English-plus-Dutch site.
 
-If you want the broader picture of how Astro Rocket is structured first, the [configuration guide](/blog/astro-rocket-configuration-guide) covers `site.config.ts`, themes, and layout switches; the [SEO post](/blog/seo-in-astro-rocket) covers everything in the `<head>` that i18n now extends with `hreflang`.
+If you want the broader picture of how Astro Rocket is structured first, the <PostLink uid="configuration-guide">configuration guide</PostLink> covers `site.config.ts`, themes, and layout switches; the [SEO post](/blog/seo-in-astro-rocket) covers everything in the `<head>` that i18n now extends with `hreflang`.
 
 ## Opt-in, off by default
 

--- a/src/lib/content-validation.ts
+++ b/src/lib/content-validation.ts
@@ -40,10 +40,11 @@ interface ContentEntryLike {
 
 /**
  * Strip a leading `<locale>/` segment from a collection entry id to get its
- * slug. Mirrors `getPostSlug` in `./blog`, reimplemented here so this module
- * stays free of the `astro:content` runtime import and remains unit-testable.
+ * slug. Mirrors `getPostSlug` in `./blog`, kept here free of the
+ * `astro:content` runtime import so it stays unit-testable and can be reused
+ * by other build-time helpers (e.g. canonical-id resolution).
  */
-function localeStrippedSlug(id: string, locale: string): string {
+export function localeStrippedSlug(id: string, locale: string): string {
   const prefix = `${locale}/`;
   return id.startsWith(prefix) ? id.slice(prefix.length) : id;
 }

--- a/src/lib/post-links.ts
+++ b/src/lib/post-links.ts
@@ -1,0 +1,120 @@
+/**
+ * Canonical-id resolution for durable internal links.
+ *
+ * Phase 1: lets posts link to one another by a stable `uid` instead of a slug,
+ * so renaming a file (and therefore its slug) never silently breaks inbound
+ * links. The <PostLink> component calls `resolvePostUrl`, which throws at build
+ * time when a uid is unknown — turning a broken internal link into a failed
+ * build instead of a silent 404.
+ *
+ * The pure helpers (`buildUidIndex`, `normalizeUid`) take plain data so they
+ * can be unit-tested without the Astro content runtime. The astro-facing
+ * `resolvePostUrl` / `assertValidPostUids` load the blog collection (cached)
+ * and build locale-aware URLs.
+ */
+import { localizedPath, defaultLocale } from '@/i18n';
+import { localeStrippedSlug } from './content-validation';
+
+/** A post resolved from its canonical id, within one locale. */
+export interface ResolvedPost {
+  slug: string;
+  title: string;
+}
+
+/** Minimal shape of a blog entry needed to resolve canonical ids. */
+interface UidEntryLike {
+  id: string;
+  data: { locale: string; uid?: string; title: string };
+}
+
+/**
+ * Build an index of `uid -> (locale -> post)`. Posts without a uid are skipped.
+ * Throws if two posts in the same locale claim the same uid, since a canonical
+ * id must point to a single post per locale (the same uid across *different*
+ * locales is expected — those are translations of one logical post).
+ */
+export function buildUidIndex(
+  posts: UidEntryLike[]
+): Map<string, Map<string, ResolvedPost>> {
+  const index = new Map<string, Map<string, ResolvedPost>>();
+  for (const post of posts) {
+    const { uid, locale, title } = post.data;
+    if (!uid) continue;
+
+    let byLocale = index.get(uid);
+    if (!byLocale) {
+      byLocale = new Map();
+      index.set(uid, byLocale);
+    }
+    if (byLocale.has(locale)) {
+      throw new Error(
+        `Duplicate canonical id "${uid}" in locale "${locale}": more than one ` +
+          `post declares it. A uid must map to a single post per locale.`
+      );
+    }
+    byLocale.set(locale, { slug: localeStrippedSlug(post.id, locale), title });
+  }
+  return index;
+}
+
+/** Strip an optional `post:` prefix from a uid reference (`post:foo` → `foo`). */
+export function normalizeUid(ref: string): string {
+  return ref.startsWith('post:') ? ref.slice('post:'.length) : ref;
+}
+
+let cachedIndex: Map<string, Map<string, ResolvedPost>> | null = null;
+
+/** Load and cache the uid index from the blog collection (drafts excluded). */
+async function getUidIndex(): Promise<Map<string, Map<string, ResolvedPost>>> {
+  if (cachedIndex) return cachedIndex;
+  const { getCollection } = await import('astro:content');
+  const posts = (await getCollection('blog')).filter(
+    (post) => post.data.draft !== true
+  );
+  cachedIndex = buildUidIndex(posts);
+  return cachedIndex;
+}
+
+/**
+ * Build-time guard: validate every canonical id (throws on duplicates). Runs
+ * regardless of whether any <PostLink> is rendered, so uid integrity is always
+ * checked. Call from a route's `getStaticPaths`.
+ */
+export async function assertValidPostUids(): Promise<void> {
+  await getUidIndex();
+}
+
+/**
+ * Resolve a canonical id to a locale-aware URL and the target post's title.
+ * Throws when the id is unknown (a broken internal link) so the build fails
+ * loudly. Falls back to the default-locale variant when the requested locale
+ * has no translation of the post.
+ */
+export async function resolvePostUrl(
+  ref: string,
+  locale: string = defaultLocale
+): Promise<{ url: string; title: string }> {
+  const uid = normalizeUid(ref);
+  const index = await getUidIndex();
+
+  const byLocale = index.get(uid);
+  if (!byLocale) {
+    throw new Error(
+      `<PostLink>: unknown canonical id "${uid}". No published blog post ` +
+        `declares uid: "${uid}" — add it to the target post's frontmatter, or ` +
+        `fix the reference.`
+    );
+  }
+
+  const resolved = byLocale.get(locale) ?? byLocale.get(defaultLocale);
+  if (!resolved) {
+    throw new Error(
+      `<PostLink>: canonical id "${uid}" has no variant for locale "${locale}".`
+    );
+  }
+
+  return {
+    url: localizedPath(`/blog/${resolved.slug}`, locale),
+    title: resolved.title,
+  };
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -2,10 +2,14 @@
 import BlogLayout from '@/layouts/BlogLayout.astro';
 import { getCollection, render } from 'astro:content';
 import { assertNoSlugCollisions } from '@/lib/content-validation';
+import { assertValidPostUids } from '@/lib/post-links';
+import PostLink from '@/components/blog/PostLink.astro';
 
 export async function getStaticPaths() {
-  // Fail the build early if any two entries resolve to the same URL in a locale.
+  // Fail the build early on content-integrity problems: two entries resolving
+  // to the same URL within a locale, or a duplicated canonical id.
   await assertNoSlugCollisions();
+  await assertValidPostUids();
 
   const posts = await getCollection('blog', ({ data }) => {
     return data.locale === 'en' && (import.meta.env.PROD ? data.draft !== true : true);
@@ -37,5 +41,5 @@ const { Content, headings } = await render(post);
   toc={post.data.toc}
   comments={post.data.comments}
 >
-  <Content />
+  <Content components={{ PostLink }} />
 </BlogLayout>


### PR DESCRIPTION
## Phase 1 — durable internal links via `<PostLink>`

Follow-up to #382 (Phase 0). Implements **point #5 of #377**: link posts by a stable canonical id instead of a slug, so renaming a file (and therefore its slug) never silently breaks inbound links.

### What's in it
- **Optional `uid` frontmatter field** on blog posts — a stable canonical id, decoupled from the slug. Lowercase kebab-case, format-validated in the schema.
- **`<PostLink>` component**, provided globally to blog MDX (no per-file import needed). Resolves a `uid` (optional `post:` prefix) to a locale-aware URL and **throws at build time on an unknown id** — a broken internal link fails the build instead of shipping a 404. Falls back to the target post's title as link text.
- **`src/lib/post-links.ts`** — pure, unit-tested index/resolution helpers + a cached astro-facing resolver + `assertValidPostUids()`, a build guard that also catches duplicate canonical ids per locale. Wired into the blog route's `getStaticPaths` alongside the Phase 0 slug guard.
- **Demonstrated** on a real internal link (the i18n post → configuration guide) so the build exercises it end-to-end.

### Non-breaking
`uid` is optional; existing posts and links are unaffected. All resolution happens at build time — no client JS, no change to the shipped payload, no Lighthouse impact.

### Verification
- 47 unit tests pass (6 new for `post-links`)
- `eslint` clean, `astro check` 0 errors
- Full `astro build` green; `<PostLink uid="configuration-guide">` renders `<a href="/blog/astro-rocket-configuration-guide">configuration guide</a>`
- Negative test: a broken `uid` correctly fails the build with an actionable error

https://claude.ai/code/session_01HHmJNfuJhy3Wog2U48e2ff

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHmJNfuJhy3Wog2U48e2ff)_