### PR TITLE
Docs: document canonical links + slug validation (Phases 0 & 1), bump to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.6.0] — 2026-06-07
+
+### Added
+
+- **Durable internal links via `<PostLink>` (canonical ids)** — blog posts can declare an optional, stable `uid` in frontmatter (lowercase kebab-case, format-validated in `src/content.config.ts`) and reference one another by that id with the new `<PostLink>` component (`src/components/blog/PostLink.astro`), available globally in blog MDX — e.g. `<PostLink uid="configuration-guide">…</PostLink>` (a `post:` prefix is also accepted). The id resolves to the correct locale-aware URL at build time and **a broken reference fails the build** instead of shipping a silent 404, so renaming a post (and its slug) never breaks inbound links. Index/resolution helpers and an `assertValidPostUids()` guard — which also rejects duplicate canonical ids within a locale — live in `src/lib/post-links.ts`, with unit tests in `src/__tests__/post-links.test.ts`. When no link text is given, the target post's title is used. All resolution is build-time only — no client JS and no change to the shipped payload. (#377, point #5)
+- **Build-time duplicate-slug validation** — `astro build` now fails with an actionable error if any two pieces of content resolve to the same URL within a locale (checked across blog posts and pages), catching a silent content bug where one entry quietly shadows another. The pure, unit-tested helpers (`findSlugCollisions`, `formatSlugCollisions`) and the `assertNoSlugCollisions()` build guard live in `src/lib/content-validation.ts` (tests in `src/__tests__/content-validation.test.ts`), wired into the blog route's `getStaticPaths`. (#377, point #4)
+
+---
+
 ## [1.5.0] — 2026-06-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The following changes were made to the free Velocity theme to create Astro Rocke
 | **API Routes** | Contact form and newsletter endpoints with validation |
 | **Table of Contents** | Optional table of contents on blog posts, auto-generated from MDX headings, with three layouts: inline card, sticky desktop sidebar, or `auto` (sidebar on `xl+`, inline card below). Includes `IntersectionObserver` scroll-spy. Off by default; per-post `toc: false` in frontmatter hides on a single post |
 | **Blog Comments (Giscus)** | Optional comments at the bottom of blog posts, powered by [Giscus](https://giscus.app) and GitHub Discussions. **Lazy-loaded** so readers who don't scroll to comments pay zero network cost; reserved `min-height` prevents CLS. Off by default; per-post `comments: false` in frontmatter hides on a single post |
+| **Durable Internal Links** | Link between posts by a stable canonical id with `<PostLink uid="…">` instead of a slug, so renaming a post never breaks inbound links. Ids resolve to the correct locale-aware URL at build time, and a broken reference **fails the build** rather than shipping a 404. Add an optional `uid` to a post's frontmatter to make it linkable |
+| **Build-Time Content Validation** | The build fails with a clear error if two pieces of content resolve to the same URL within a locale (duplicate slugs across posts and pages), or if two posts claim the same canonical id — catching silent content mistakes before they ship |
 | **Independent Footer Menu** | Header and footer navigation configured separately in `nav.config.ts` (`navItems`, `footerNavItems`, `legalLinks`) — add a Privacy or Imprint link to the footer without cluttering the main nav |
 | **React Islands** | Optional client-side interactivity where needed |
 
@@ -576,11 +578,14 @@ description: "Brief description for SEO"
 publishedAt: 2026-01-30
 author: "Author Name"
 tags: ["astro", "tutorial"]
+uid: "your-post-id"        # optional — stable id used by <PostLink> for internal links
 locale: en
 ---
 
 Your content here...
 ```
+
+To link from one post to another, use `<PostLink uid="target-post-id">link text</PostLink>` in your MDX instead of a hard-coded `/blog/...` URL. The id resolves to the right URL at build time, and a broken reference fails the build — so renaming a post never leaves a dead internal link. Give a post an optional `uid` (above) to make it a link target. The [configuration guide](/blog/astro-rocket-configuration-guide) post has the full walkthrough.
 
 ### Querying Content
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-rocket",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Astro Rocket — A production-ready Astro 6 theme built on Tailwind CSS v4",
   "type": "module",
   "author": "Hans Martens",

--- a/src/content/blog/en/astro-rocket-configuration-guide.mdx
+++ b/src/content/blog/en/astro-rocket-configuration-guide.mdx
@@ -530,6 +530,40 @@ socialLinks: [
 
 Remove any URL you don't use. The footer won't render an empty social section. Icons are resolved automatically from the URL — GitHub, X, Instagram, LinkedIn, and Bluesky are all recognised out of the box.
 
+## Linking between posts
+
+When one post links to another, hard-coding the URL — `[text](/blog/some-slug)` — is fragile: rename the target file and every link to it breaks silently. Astro Rocket gives each post an optional **canonical id** so you can link by a stable identifier instead of the slug.
+
+Add a `uid` to the target post's frontmatter (lowercase, kebab-case):
+
+```yaml
+---
+title: "Evaluating URL Structures"
+uid: "url-structures"
+---
+```
+
+Then link to it from any post's MDX with the `<PostLink>` component — it's available globally, so no import is needed:
+
+```mdx
+Read more in the <PostLink uid="url-structures">URL structures guide</PostLink>.
+```
+
+That renders an ordinary `<a>` to the post's URL. Omit the link text and the target post's own title is used:
+
+```mdx
+See also: <PostLink uid="url-structures" />
+```
+
+Worth knowing:
+
+- **Broken links fail the build.** If a `uid` matches no published post, `astro build` stops with an error naming the missing id — a dead internal link can never ship.
+- **Rename-safe.** The `uid` is independent of the filename and slug, so you can rename a post freely and every `<PostLink>` to it keeps working.
+- **Locale-aware.** The link resolves to the URL for the current locale, falling back to the default locale when a translation doesn't exist yet.
+- A `post:` prefix is also accepted (`uid="post:url-structures"`) if you prefer that style.
+
+The `uid` field is entirely optional — posts without one behave exactly as before; they simply can't be targeted by `<PostLink>`.
+
 ## Quick reference
 
 | What | Where | Key |


### PR DESCRIPTION
Documentation follow-up to #382 (Phase 0) and #383 (Phase 1) — the code is merged, this makes the features discoverable and explains how to use them. Closes the documentation gap for #377.

### Changes
- **CHANGELOG.md** — new `[1.6.0]` entry under **Added** for the `<PostLink>` canonical-id internal links and the build-time duplicate-slug validation, in the repo's detailed style.
- **README.md** — two feature-table rows (**Durable Internal Links**, **Build-Time Content Validation**); the optional `uid` field added to the frontmatter example; a short pointer on linking posts with `<PostLink>`.
- **Configuration guide post** (`astro-rocket-configuration-guide.mdx`) — a new **"Linking between posts"** section walking authors through `uid` + `<PostLink>`, consistent with how other features are dogfooded as posts.
- **package.json** — `1.5.0` → `1.6.0` (new features = minor bump; matches the CHANGELOG).

### Notes
- **Docs only** (plus the version bump) — no functional code changes.
- The `<PostLink>` examples in the post are shown as **fenced code**, not live components, so nothing resolves at build (verified: 0 stray anchors leaked; the real `<PostLink>` in the i18n post still resolves correctly).

### Verification
- `eslint` clean · `astro check` 0 errors · 47 tests pass · full `astro build` green
- Confirmed the new "Linking between posts" section renders, with examples as inert code blocks

https://claude.ai/code/session_01HHmJNfuJhy3Wog2U48e2ff

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHmJNfuJhy3Wog2U48e2ff)_