### PR TITLE
Add pill, heading, and description to homepage Marquee section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -357,8 +357,22 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 
  <!-- Tech stack marquee — its own section in the 2-tone zebra. It follows the secondary Blog section, so it flips to `background` like the next stripe. Hidden on phones (portrait + landscape) via .stack-marquee-section; when it drops out, Blog (secondary) → CTA (background) still alternate, so the zebra holds on mobile too. -->
   <section class="stack-marquee-section relative z-10 py-[var(--space-section-md)] bg-background border-t border-border">
-    <div class="mx-auto max-w-6xl px-6" data-reveal>
-      <StackMarquee />
+    <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
+      <div class="flex flex-col items-center gap-4 text-center" data-reveal>
+        <div class="flex flex-col items-center gap-6">
+          <Badge variant="brand" pill>Tech stack</Badge>
+          <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
+            Building with the best
+          </h2>
+        </div>
+        <p class="text-lg text-foreground-muted max-w-2xl mx-auto">
+          I use the best of the modern web to build websites.
+        </p>
+      </div>
+
+      <div data-reveal data-reveal-delay="1">
+        <StackMarquee />
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
Add a "Tech stack" pill, "Building with the best" H2, and supporting description above the StackMarquee, matching the header pattern used by the other homepage sections (Services, Portfolio, Testimonials).

https://claude.ai/code/session_01TR9bnhuLRQWK5wygzFcthM

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
