### PR TITLE
Increase hero entrance slide distance from 40px to 80px

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1049,7 +1049,7 @@
 @keyframes hero-slide-up {
   from {
     opacity: 0;
-    transform: translateY(40px);
+    transform: translateY(80px);
   }
   to {
     opacity: 1;
@@ -1063,7 +1063,7 @@
    of the hero but stays fully opaque from the first painted frame. */
 @keyframes hero-slide-up-solid {
   from {
-    transform: translateY(40px);
+    transform: translateY(80px);
   }
   to {
     transform: translateY(0);


### PR DESCRIPTION
Bump the starting translateY in both hero entrance keyframes so every hero (homepage Hero, ProjectHero, ArticleHero, any <Hero> page) travels further on entrance:

- hero-slide-up: badge, description, actions, and project/blog hero media still fade in while sliding up, now from 80px.
- hero-slide-up-solid: the LCP hero title still slides up transform-only (no opacity fade), now from 80px, so Chrome times LCP at first paint.

Settle point stays translateY(0); the 1s duration, easing, opacity behavior, and prefers-reduced-motion rule are unchanged. Scroll-reveal section distances ([data-reveal], --reveal-distance, [data-reveal-content]) are untouched. Pure GPU-composited transform — no CLS/LCP/TBT regression.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
