### PR TITLE
Warn in dev when Header receives default-slot content

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -134,6 +134,21 @@ const hasNavSlot = Astro.slots.has('nav');
 const hasActionsSlot = Astro.slots.has('actions');
 const hasMobileMenuSlot = Astro.slots.has('mobile-menu');
 
+// Dev-time guard: Header renders only its named slots (logo, nav, actions,
+// mobile-menu) — it has no default <slot/>. So any default-slot content is
+// silently dropped. The usual culprit is a misplaced </Header> that swallows
+// the layout's page <slot /> and <Footer>, leaving the page blank below the
+// navbar with no error. Warn loudly in dev so this fails fast instead of
+// silently. No-op in production.
+if (import.meta.env.DEV && Astro.slots.has('default')) {
+  console.warn(
+    '[Header] Received content in the default slot, which Header does not render — ' +
+    'it only outputs the named slots (logo, nav, actions, mobile-menu), so this content is dropped. ' +
+    'A common cause is a misplaced </Header> wrapping the page <slot /> or <Footer>: ' +
+    'make sure those sit OUTSIDE <Header> and that only slotted children (e.g. <img slot="logo" />) sit inside it.'
+  );
+}
+
 const headerClasses = cn(
   headerVariants({ position, variant, shape }),
   isInvert && !isFloating && 'invert-section',


### PR DESCRIPTION
Header renders only its named slots (logo, nav, actions, mobile-menu) and has no default <slot/>, so any default-slot content is silently dropped. The common trap is a misplaced </Header> that swallows the layout's page <slot /> and <Footer>, blanking everything below the navbar with no error (issue #389).

Add a dev-only console.warn that names the cause and the fix, turning a silent blank page into an actionable message. No-op in production.

https://claude.ai/code/session_01PVjQ6LoMTnD8tYzeDA6adt

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
