### PR TITLE
Add optional config-driven image logo

### DIFF
--- a/src/components/ui/marketing/Logo/Logo.astro
+++ b/src/components/ui/marketing/Logo/Logo.astro
@@ -1,9 +1,14 @@
 ---
 /**
- * Logo Component — first-letter monogram badge
+ * Logo Component
  *
- * Renders a brand-coloured square badge with the first letter of the site
- * name, used in the navbar, footer, and blog post bylines.
+ * By default renders a brand-coloured square badge with the first letter of
+ * the site name (used in the navbar, footer, and blog post bylines).
+ *
+ * When `branding.logo.image` is set in site.config, a custom <img> logo is
+ * rendered instead — everywhere <Logo> is used, with no layout edits. The
+ * per-author `letter` override (byline avatars) always keeps the monogram, so
+ * author initials are unaffected by a configured brand image.
  */
 import { cn } from '@/lib/cn';
 import siteConfig from '@/config/site.config';
@@ -27,28 +32,52 @@ const {
   letter: letterProp,
 } = Astro.props;
 
-const sizeClasses: Record<string, { box: string; text: string; radius: string }> = {
-  sm:    { box: 'w-5 h-5',   text: 'text-[14px]', radius: 'rounded-[4px]' },
-  md:    { box: 'w-6 h-6',   text: 'text-[16px]', radius: 'rounded-[5px]' },
-  lg:    { box: 'w-8 h-8',   text: 'text-[22px]', radius: 'rounded-[6px]' },
-  xl:    { box: 'w-12 h-12', text: 'text-[34px]', radius: 'rounded-[8px]' },
-  '2xl': { box: 'w-24 h-24', text: 'text-[68px]', radius: 'rounded-[14px]' },
+const sizeClasses: Record<string, { box: string; text: string; radius: string; img: string; px: number }> = {
+  sm:    { box: 'w-5 h-5',   text: 'text-[14px]', radius: 'rounded-[4px]',  img: 'h-5 w-auto',  px: 20 },
+  md:    { box: 'w-6 h-6',   text: 'text-[16px]', radius: 'rounded-[5px]',  img: 'h-6 w-auto',  px: 24 },
+  lg:    { box: 'w-8 h-8',   text: 'text-[22px]', radius: 'rounded-[6px]',  img: 'h-8 w-auto',  px: 32 },
+  xl:    { box: 'w-12 h-12', text: 'text-[34px]', radius: 'rounded-[8px]',  img: 'h-12 w-auto', px: 48 },
+  '2xl': { box: 'w-24 h-24', text: 'text-[68px]', radius: 'rounded-[14px]', img: 'h-24 w-auto', px: 96 },
 };
 
-const { box, text, radius } = sizeClasses[size] ?? sizeClasses.md;
+const { box, text, radius, img, px } = sizeClasses[size] ?? sizeClasses.md;
+
+// A custom image logo (site.config → branding.logo.image) replaces the
+// monogram everywhere, except when a specific `letter` is requested (byline
+// author avatars), which always keep their initial badge.
+const logoImage = siteConfig.branding.logo.image;
+const useImage = Boolean(logoImage) && !letterProp;
 const letter = letterProp ?? siteConfig.name.charAt(0).toUpperCase();
 ---
 
-<span
-  class={cn(
-    'inline-flex items-center justify-center shrink-0',
-    'bg-brand-500 text-white',
-    'font-display font-bold leading-none select-none',
-    box, text, radius,
-    className
-  )}
-  aria-label={siteConfig.branding.logo.alt}
-  role="img"
->
-  {letter}
-</span>
+{useImage ? (
+  <img
+    src={logoImage}
+    alt={siteConfig.branding.logo.alt}
+    height={px}
+    class={cn(
+      'inline-block shrink-0 object-contain',
+      img,
+      // Neutralise the brand-tint background the call sites pass for the
+      // monogram badge (e.g. `bg-brand-600`) — a custom logo shouldn't sit on
+      // a coloured square. The trailing class wins via tailwind-merge, while
+      // non-background utilities (e.g. `mx-auto`) are preserved.
+      className,
+      'bg-transparent'
+    )}
+  />
+) : (
+  <span
+    class={cn(
+      'inline-flex items-center justify-center shrink-0',
+      'bg-brand-500 text-white',
+      'font-display font-bold leading-none select-none',
+      box, text, radius,
+      className
+    )}
+    aria-label={siteConfig.branding.logo.alt}
+    role="img"
+  >
+    {letter}
+  </span>
+)}

--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -102,6 +102,14 @@ export interface SiteConfig {
     /** Logo alt text for accessibility */
     logo: {
       alt: string;
+      /**
+       * Optional path to a custom logo image in public/ (e.g. '/logo.svg').
+       * When set, it replaces the generated letter-monogram badge in the
+       * header, footer, and anywhere <Logo> is rendered — no layout edits
+       * needed. Leave unset to keep the monogram. Per-author byline avatars
+       * (which pass an explicit letter) are unaffected.
+       */
+      image?: string;
       /** Path to logo image for structured data (e.g. '/logo.png'). Add a PNG to public/ and set this. */
       imageUrl?: string;
     };
@@ -180,6 +188,7 @@ const siteConfig: SiteConfig = {
   branding: {
     logo: {
       alt: 'Astro Rocket',
+      // image: '/logo.svg', // Optional: set to a file in public/ to use a custom logo image instead of the letter monogram.
       imageUrl: '/favicon.svg',
     },
     favicon: {


### PR DESCRIPTION
Let users use their own logo image without editing any layout. Setting branding.logo.image in site.config makes Logo.astro render that <img> instead of the first-letter monogram badge — so it flows automatically to the header, footer, and anywhere <Logo> is used.

- Default unset → monogram unchanged (fully backwards compatible).
- Per-author byline avatars pass an explicit `letter`, so they keep their initials even when a brand image logo is configured.
- Image is height-constrained (w-auto, object-contain) so square marks and wide wordmarks both render without distortion.
- A trailing bg-transparent neutralises the brand-tint background the call sites pass for the monogram badge, so a transparent logo isn't placed on a coloured square; non-background classes (e.g. mx-auto) are preserved via tailwind-merge.

Verified: header + footer render the image at the right size, bylines still show letter badges, computed background is transparent, and lint + astro check pass clean.

https://claude.ai/code/session_01PVjQ6LoMTnD8tYzeDA6adt

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
