### PR TITLE
Move hero, header, and section reveals to calm no-bounce ease-out

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1044,8 +1044,8 @@
    transition shorthand is always valid.
    ------------------------------------------------------------------------- */
 
-/* Spring curve approximating Framer Motion's spring(stiffness:100, damping:15).
-   Pronounced overshoot gives elements a "settle" feel on entrance. */
+/* Clean ease-out curve: elements slide up and decelerate to a smooth stop
+   on entrance, with no overshoot or bounce. */
 @keyframes hero-slide-up {
   from {
     opacity: 0;
@@ -1071,14 +1071,14 @@
 }
 
 .animate-hero-slide-up {
-  animation: hero-slide-up 1s cubic-bezier(0.22, 1.6, 0.36, 1) both;
+  animation: hero-slide-up 1s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
-/* Stagger direct children of a hero container. Each child springs in 90ms
+/* Stagger direct children of a hero container. Each child eases in 90ms
    behind the previous — used on the Hero content column to cascade
    badge → title → description → actions. */
 .animate-hero-stagger > * {
-  animation: hero-slide-up 1s cubic-bezier(0.22, 1.6, 0.36, 1) both;
+  animation: hero-slide-up 1s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 .animate-hero-stagger > *:nth-child(1)   { animation-delay: 0ms;   }
 .animate-hero-stagger > *:nth-child(2)   { animation-delay: 90ms;  }
@@ -1110,27 +1110,27 @@
 }
 
 .animate-header-drop {
-  animation: header-drop-in 0.8s cubic-bezier(0.22, 1.6, 0.36, 1) 150ms both;
+  animation: header-drop-in 0.8s cubic-bezier(0.16, 1, 0.3, 1) 150ms both;
 }
 
 [data-reveal] {
   opacity: 0;
-  transform: translateY(56px) scale(0.94);
+  transform: translateY(96px);
   transition:
     opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 1s cubic-bezier(0.22, 1.6, 0.36, 1);
+    transform 1.1s cubic-bezier(0.16, 1, 0.3, 1);
   will-change: opacity, transform;
 }
 
 [data-reveal][data-reveal-ease="smooth"] {
   transition:
     opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 1s cubic-bezier(0.22, 1, 0.36, 1);
+    transform 1.1s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-[data-reveal="down"]  { transform: translateY(-56px) scale(0.94); }
-[data-reveal="left"]  { transform: translateX(56px) scale(0.94); }
-[data-reveal="right"] { transform: translateX(-56px) scale(0.94); }
+[data-reveal="down"]  { transform: translateY(-96px); }
+[data-reveal="left"]  { transform: translateX(96px); }
+[data-reveal="right"] { transform: translateX(-96px); }
 [data-reveal="scale"] { transform: scale(0.88); }
 
 /* Below lg the two-column split sections stack vertically, so horizontal
@@ -1139,7 +1139,7 @@
    so all motion shares one direction on mobile. */
 @media (max-width: 1023.98px) {
   [data-reveal="left"],
-  [data-reveal="right"] { transform: translateY(56px) scale(0.94); }
+  [data-reveal="right"] { transform: translateY(96px); }
 }
 
 [data-reveal].is-visible {
@@ -1157,15 +1157,15 @@
    tunable per-instance via custom properties. */
 [data-reveal-children] {
   --reveal-stagger: 100ms;
-  --reveal-distance: 48px;
+  --reveal-distance: 80px;
 }
 
 [data-reveal-children] > * {
   opacity: 0;
-  transform: translateY(var(--reveal-distance)) scale(0.94);
+  transform: translateY(var(--reveal-distance));
   transition:
     opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 1s cubic-bezier(0.22, 1.6, 0.36, 1);
+    transform 1.1s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 [data-reveal-children].is-visible > * {
@@ -1190,13 +1190,13 @@
 /* Per-block reveal for long-form article bodies (single blog posts /
    single project pages). Each direct child of the prose container —
    paragraph, heading, list, image, blockquote, custom MDX block — is
-   given its own observer so it springs in as the reader scrolls to it. */
+   given its own observer so it eases in as the reader scrolls to it. */
 [data-reveal-content] > * {
   opacity: 0;
-  transform: translateY(40px);
+  transform: translateY(56px);
   transition:
     opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 0.9s cubic-bezier(0.22, 1.6, 0.36, 1);
+    transform 0.9s cubic-bezier(0.16, 1, 0.3, 1);
   will-change: opacity, transform;
 }
 


### PR DESCRIPTION
Replace the springy cubic-bezier(0.22, 1.6, 0.36, 1) with the smooth ease-out cubic-bezier(0.16, 1, 0.3, 1) across the hero entrance, the floating header drop-in, and every on-scroll section reveal.

For the reveals, also drop the scale(0.94) zoom from the start transforms, lengthen the travel (56->96px, child distance 48->80px, content 40->56px), and bump the transform durations (1s->1.1s, 0.9s kept) so the longer slide stays smooth. Opacity timing, keyframe distances, stagger and header delays, and the scale(0.88) reveal variant are unchanged.

Refresh the stale spring/overshoot comments to describe the clean ease-out that decelerates to a smooth stop with no bounce.

https://claude.ai/code/session_01AE6BUSv8fp54hdo6YYeQ47

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
