### PR TITLE
Add Pagefind header search and document project galleries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Header search powered by Pagefind** — a search button in the header (next to the colour-mode pill, on by default, `showSearch={false}` to hide) opens a ⌘K / Ctrl+K command-palette modal (`src/components/layout/SearchModal.astro`). The static index is generated automatically at the end of every `astro build` by a new `pagefind()` hook in `astro.config.mjs`, which indexes the actual output directory on every deploy target (Vercel, Netlify, Cloudflare). The Pagefind bundle is lazy-loaded on first open, so initial page loads ship zero extra JavaScript; under `astro dev` (where no index exists) the modal explains how to build one instead of failing. Header and Footer now carry `data-pagefind-ignore` so navigation chrome stays out of results. The `pagefind` and `@pagefind/default-ui` packages were already dependencies — this wires the long-advertised feature up for real. (#395)
+- **Project gallery documentation + living example** — the multi-image project features were undocumented: the README now covers both the `gallery: [{ src, alt }]` frontmatter array (hero carousel, added in 1.4.0) and the in-body `<ProjectGallery>` MDX component with its click-to-zoom lightbox. `src/content/projects/ecommerce-store.mdx` demonstrates both in one file, with three placeholder storefront wireframes in `src/assets/projects/`. (#396)
+
+### Changed
+
+- **Removed `@pagefind/default-ui` dependency** — the search modal is a theme-native UI on the Pagefind JS API, so the prebuilt widget package is no longer needed.
+
+---
+
 ## [1.6.0] — 2026-06-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The following changes were made to the free Velocity theme to create Astro Rocke
 | **Durable Internal Links** | Link between posts by a stable canonical id with `<PostLink uid="…">` instead of a slug, so renaming a post never breaks inbound links. Ids resolve to the correct locale-aware URL at build time, and a broken reference **fails the build** rather than shipping a 404. Add an optional `uid` to a post's frontmatter to make it linkable |
 | **Build-Time Content Validation** | The build fails with a clear error if two pieces of content resolve to the same URL within a locale (duplicate slugs across posts and pages), or if two posts claim the same canonical id — catching silent content mistakes before they ship |
 | **Independent Footer Menu** | Header and footer navigation configured separately in `nav.config.ts` (`navItems`, `footerNavItems`, `legalLinks`) — add a Privacy or Imprint link to the footer without cluttering the main nav |
+| **Static Search (Pagefind)** | Site-wide search in the header — a ⌘K / Ctrl+K modal powered by a [Pagefind](https://pagefind.app) index generated at build time. Zero JS until the modal opens; works on every deploy target. Hide it with `showSearch={false}` on the Header |
+| **Project Galleries** | Multiple images per project: a `gallery` array in frontmatter swaps the hero image for a swipeable carousel, and the `<ProjectGallery>` MDX component renders an in-body carousel with a click-to-zoom lightbox. See [Project Galleries](#project-galleries) |
 | **React Islands** | Optional client-side interactivity where needed |
 
 ### Internationalization (i18n)
@@ -602,6 +604,43 @@ Your content here...
 
 To link from one post to another, use `<PostLink uid="target-post-id">link text</PostLink>` in your MDX instead of a hard-coded `/blog/...` URL. The id resolves to the right URL at build time, and a broken reference fails the build — so renaming a post never leaves a dead internal link. Give a post an optional `uid` (above) to make it a link target. The [configuration guide](/blog/astro-rocket-configuration-guide) post has the full walkthrough.
 
+### Project Galleries
+
+Projects live in `src/content/projects/` as one MDX file per project, and there are two ways to show more than one image.
+
+**1. Hero carousel (frontmatter).** Add a `gallery` array and the project hero swaps the single `image` for a swipeable carousel (touch swipe, prev/next arrows, dot indicators, keyboard navigation). The first slide is the lead image:
+
+```yaml
+---
+title: "My Product"
+description: "..."
+gallery:
+  - src: "../../assets/projects/shot-1.jpg"
+    alt: "Dashboard view"
+  - src: "../../assets/projects/shot-2.jpg"
+    alt: "Settings page"
+---
+```
+
+Keep the single `image` field set as well — project cards on the index and homepage still use it.
+
+**2. In-body carousel with lightbox (MDX).** For an e-commerce-style gallery inside the project body, import the `ProjectGallery` component. Clicking a slide opens a full-screen lightbox, and each image takes an optional caption:
+
+```mdx
+import ProjectGallery from '@/components/projects/ProjectGallery.astro';
+import shot1 from '@/assets/projects/shot-1.jpg';
+import shot2 from '@/assets/projects/shot-2.jpg';
+
+<ProjectGallery
+  images={[
+    { src: shot1, alt: 'Dashboard', caption: 'The main dashboard' },
+    { src: shot2, alt: 'Settings' },
+  ]}
+/>
+```
+
+Both carousels are dependency-free (native scroll-snap plus a small vanilla script) and lazy-load every slide after the first, so they don't cost you the Lighthouse score. `src/content/projects/ecommerce-store.mdx` demonstrates both in one file.
+
 ### Querying Content
 
 ```astro
@@ -646,6 +685,34 @@ import SEO from '@/components/seo/SEO.astro';
 ### OG Image
 
 A static default OG image (`public/og-default.svg`) serves as the social preview for all pages. The path is set via `ogImage` in `src/config/site.config.ts`. To use a custom image for a specific page, pass it as the `image` prop to the layout component.
+
+---
+
+## Search
+
+Site-wide static search is powered by [Pagefind](https://pagefind.app) and surfaced as a search button in the header that opens a command-palette style modal (also bound to <kbd>⌘K</kbd> / <kbd>Ctrl+K</kbd>).
+
+**How it works**
+
+- The index is generated automatically at the end of every `astro build` by the `pagefind()` hook in `astro.config.mjs`. It indexes the real output directory on every deploy target (Vercel, Netlify, Cloudflare) — no extra build command needed.
+- The header and footer carry `data-pagefind-ignore`, so navigation chrome never pollutes results.
+- The modal lazy-loads the Pagefind bundle on first open, so search adds **zero JavaScript** to the initial page load and doesn't touch the Lighthouse score.
+
+**Trying it locally**
+
+The index only exists after a production build, so search has no results under `astro dev` (the modal tells you this instead of failing):
+
+```bash
+pnpm build && pnpm preview
+```
+
+**Turning it off**
+
+The search button shows by default. Hide it per header instance:
+
+```astro
+<Header showSearch={false} />
+```
 
 ---
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,5 @@
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig, envField } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
@@ -9,6 +11,34 @@ import netlify from '@astrojs/netlify';
 import i18nConfig from './src/config/i18n.config.ts';
 
 const isNetlify = process.env.DEPLOY_TARGET === 'netlify';
+
+/**
+ * Pagefind static search index, generated after every `astro build`.
+ *
+ * Runs in the `astro:build:done` hook so it indexes the *actual* output
+ * directory — the Vercel adapter writes to `.vercel/output/static`, Netlify
+ * and plain static builds to `dist/` — without the build command needing to
+ * know which. The index is served from `/pagefind/` and loaded lazily by
+ * `src/components/layout/SearchModal.astro`; `astro dev` has no index, and
+ * the search modal explains that instead of erroring.
+ */
+function pagefind() {
+  return {
+    name: 'pagefind',
+    hooks: {
+      'astro:build:done': async ({ dir, logger }) => {
+        const sitePath = fileURLToPath(dir);
+        const outputPath = join(sitePath, 'pagefind');
+        const { createIndex, close } = await import('pagefind');
+        const { index } = await createIndex();
+        const { page_count } = await index.addDirectory({ path: sitePath });
+        await index.writeFiles({ outputPath });
+        await close();
+        logger.info(`indexed ${page_count} pages into ${outputPath}`);
+      },
+    },
+  };
+}
 
 /**
  * Native Astro i18n is only wired up when the user opts in *and* has
@@ -63,6 +93,7 @@ export default defineConfig({
     mdx(),
     sitemap(),
     icon(),
+    pagefind(),
   ],
 
   vite: {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   "devDependencies": {
     "@astrojs/check": "0.9.9",
     "@eslint/js": "^9.17.0",
-    "@pagefind/default-ui": "^1.3.0",
     "@playwright/test": "^1.49.0",
     "@tailwindcss/vite": "^4.0.0",
     "@types/node": "^22.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,9 +87,6 @@ importers:
       '@eslint/js':
         specifier: ^9.17.0
         version: 9.39.2
-      '@pagefind/default-ui':
-        specifier: ^1.3.0
-        version: 1.4.0
       '@playwright/test':
         specifier: ^1.49.0
         version: 1.58.0
@@ -1158,9 +1155,6 @@ packages:
     resolution: {integrity: sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==}
     cpu: [x64]
     os: [darwin]
-
-  '@pagefind/default-ui@1.4.0':
-    resolution: {integrity: sha512-wie82VWn3cnGEdIjh4YwNESyS1G6vRHwL6cNjy9CFgNnWW/PGRjsLq300xjVH5sfPFK3iK36UxvIBymtQIEiSQ==}
 
   '@pagefind/freebsd-x64@1.4.0':
     resolution: {integrity: sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==}
@@ -6833,8 +6827,6 @@ snapshots:
 
   '@pagefind/darwin-x64@1.4.0':
     optional: true
-
-  '@pagefind/default-ui@1.4.0': {}
 
   '@pagefind/freebsd-x64@1.4.0':
     optional: true

--- a/src/assets/projects/ecommerce-store-catalog.svg
+++ b/src/assets/projects/ecommerce-store-catalog.svg
@@ -1,0 +1,57 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Placeholder storefront screenshot: product catalogue grid -->
+  <rect width="1280" height="720" fill="#f1f5f9"/>
+  <!-- Browser chrome -->
+  <rect width="1280" height="48" fill="#e2e8f0"/>
+  <circle cx="28" cy="24" r="6" fill="#cbd5e1"/>
+  <circle cx="50" cy="24" r="6" fill="#cbd5e1"/>
+  <circle cx="72" cy="24" r="6" fill="#cbd5e1"/>
+  <rect x="320" y="12" width="640" height="24" rx="12" fill="#f8fafc"/>
+  <!-- Site header -->
+  <rect x="0" y="48" width="1280" height="64" fill="#ffffff"/>
+  <rect x="64" y="72" width="120" height="16" rx="8" fill="#334155"/>
+  <rect x="760" y="74" width="64" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="848" y="74" width="64" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="936" y="74" width="64" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="1100" y="64" width="116" height="32" rx="16" fill="#3b82f6"/>
+  <!-- Page heading -->
+  <rect x="64" y="152" width="280" height="24" rx="12" fill="#334155"/>
+  <rect x="64" y="190" width="180" height="12" rx="6" fill="#94a3b8"/>
+  <!-- Product grid: 2 rows x 4 cards -->
+  <g>
+    <rect x="64" y="238" width="268" height="200" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <rect x="64" y="238" width="268" height="130" rx="12" fill="#dbeafe"/>
+    <rect x="80" y="384" width="140" height="12" rx="6" fill="#475569"/>
+    <rect x="80" y="406" width="72" height="12" rx="6" fill="#3b82f6"/>
+    <rect x="360" y="238" width="268" height="200" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <rect x="360" y="238" width="268" height="130" rx="12" fill="#e0e7ff"/>
+    <rect x="376" y="384" width="140" height="12" rx="6" fill="#475569"/>
+    <rect x="376" y="406" width="72" height="12" rx="6" fill="#3b82f6"/>
+    <rect x="656" y="238" width="268" height="200" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <rect x="656" y="238" width="268" height="130" rx="12" fill="#cffafe"/>
+    <rect x="672" y="384" width="140" height="12" rx="6" fill="#475569"/>
+    <rect x="672" y="406" width="72" height="12" rx="6" fill="#3b82f6"/>
+    <rect x="952" y="238" width="268" height="200" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <rect x="952" y="238" width="268" height="130" rx="12" fill="#dbeafe"/>
+    <rect x="968" y="384" width="140" height="12" rx="6" fill="#475569"/>
+    <rect x="968" y="406" width="72" height="12" rx="6" fill="#3b82f6"/>
+  </g>
+  <g>
+    <rect x="64" y="470" width="268" height="200" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <rect x="64" y="470" width="268" height="130" rx="12" fill="#e0e7ff"/>
+    <rect x="80" y="616" width="140" height="12" rx="6" fill="#475569"/>
+    <rect x="80" y="638" width="72" height="12" rx="6" fill="#3b82f6"/>
+    <rect x="360" y="470" width="268" height="200" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <rect x="360" y="470" width="268" height="130" rx="12" fill="#dbeafe"/>
+    <rect x="376" y="616" width="140" height="12" rx="6" fill="#475569"/>
+    <rect x="376" y="638" width="72" height="12" rx="6" fill="#3b82f6"/>
+    <rect x="656" y="470" width="268" height="200" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <rect x="656" y="470" width="268" height="130" rx="12" fill="#dbeafe"/>
+    <rect x="672" y="616" width="140" height="12" rx="6" fill="#475569"/>
+    <rect x="672" y="638" width="72" height="12" rx="6" fill="#3b82f6"/>
+    <rect x="952" y="470" width="268" height="200" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <rect x="952" y="470" width="268" height="130" rx="12" fill="#cffafe"/>
+    <rect x="968" y="616" width="140" height="12" rx="6" fill="#475569"/>
+    <rect x="968" y="638" width="72" height="12" rx="6" fill="#3b82f6"/>
+  </g>
+</svg>

--- a/src/assets/projects/ecommerce-store-checkout.svg
+++ b/src/assets/projects/ecommerce-store-checkout.svg
@@ -1,0 +1,44 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Placeholder storefront screenshot: checkout flow -->
+  <rect width="1280" height="720" fill="#f1f5f9"/>
+  <!-- Browser chrome -->
+  <rect width="1280" height="48" fill="#e2e8f0"/>
+  <circle cx="28" cy="24" r="6" fill="#cbd5e1"/>
+  <circle cx="50" cy="24" r="6" fill="#cbd5e1"/>
+  <circle cx="72" cy="24" r="6" fill="#cbd5e1"/>
+  <rect x="320" y="12" width="640" height="24" rx="12" fill="#f8fafc"/>
+  <!-- Site header -->
+  <rect x="0" y="48" width="1280" height="64" fill="#ffffff"/>
+  <rect x="64" y="72" width="120" height="16" rx="8" fill="#334155"/>
+  <!-- Checkout steps -->
+  <circle cx="500" cy="156" r="14" fill="#3b82f6"/>
+  <rect x="522" y="152" width="80" height="8" rx="4" fill="#3b82f6"/>
+  <circle cx="640" cy="156" r="14" fill="#3b82f6"/>
+  <rect x="662" y="152" width="80" height="8" rx="4" fill="#cbd5e1"/>
+  <circle cx="780" cy="156" r="14" fill="#cbd5e1"/>
+  <!-- Shipping form -->
+  <rect x="64" y="210" width="680" height="470" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+  <rect x="104" y="250" width="220" height="20" rx="10" fill="#334155"/>
+  <rect x="104" y="300" width="120" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="104" y="322" width="600" height="44" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="2"/>
+  <rect x="104" y="390" width="120" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="104" y="412" width="600" height="44" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="2"/>
+  <rect x="104" y="480" width="120" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="104" y="502" width="288" height="44" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="2"/>
+  <rect x="416" y="502" width="288" height="44" rx="10" fill="#f8fafc" stroke="#e2e8f0" stroke-width="2"/>
+  <rect x="104" y="586" width="240" height="52" rx="26" fill="#3b82f6"/>
+  <!-- Order summary -->
+  <rect x="784" y="210" width="432" height="380" rx="16" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+  <rect x="824" y="250" width="180" height="20" rx="10" fill="#334155"/>
+  <rect x="824" y="300" width="64" height="64" rx="10" fill="#dbeafe"/>
+  <rect x="904" y="310" width="180" height="12" rx="6" fill="#475569"/>
+  <rect x="904" y="334" width="100" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="824" y="388" width="64" height="64" rx="10" fill="#e0e7ff"/>
+  <rect x="904" y="398" width="180" height="12" rx="6" fill="#475569"/>
+  <rect x="904" y="422" width="100" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="824" y="480" width="352" height="2" fill="#e2e8f0"/>
+  <rect x="824" y="506" width="100" height="14" rx="7" fill="#94a3b8"/>
+  <rect x="1076" y="506" width="100" height="14" rx="7" fill="#475569"/>
+  <rect x="824" y="540" width="100" height="18" rx="9" fill="#334155"/>
+  <rect x="1056" y="540" width="120" height="18" rx="9" fill="#3b82f6"/>
+</svg>

--- a/src/assets/projects/ecommerce-store-product.svg
+++ b/src/assets/projects/ecommerce-store-product.svg
@@ -1,0 +1,40 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Placeholder storefront screenshot: product detail page -->
+  <rect width="1280" height="720" fill="#f1f5f9"/>
+  <!-- Browser chrome -->
+  <rect width="1280" height="48" fill="#e2e8f0"/>
+  <circle cx="28" cy="24" r="6" fill="#cbd5e1"/>
+  <circle cx="50" cy="24" r="6" fill="#cbd5e1"/>
+  <circle cx="72" cy="24" r="6" fill="#cbd5e1"/>
+  <rect x="320" y="12" width="640" height="24" rx="12" fill="#f8fafc"/>
+  <!-- Site header -->
+  <rect x="0" y="48" width="1280" height="64" fill="#ffffff"/>
+  <rect x="64" y="72" width="120" height="16" rx="8" fill="#334155"/>
+  <rect x="760" y="74" width="64" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="848" y="74" width="64" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="936" y="74" width="64" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="1100" y="64" width="116" height="32" rx="16" fill="#3b82f6"/>
+  <!-- Product image with thumbnail rail -->
+  <rect x="64" y="160" width="560" height="420" rx="16" fill="#dbeafe"/>
+  <rect x="64" y="604" width="124" height="80" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="3"/>
+  <rect x="210" y="604" width="124" height="80" rx="10" fill="#e0e7ff"/>
+  <rect x="356" y="604" width="124" height="80" rx="10" fill="#cffafe"/>
+  <rect x="502" y="604" width="124" height="80" rx="10" fill="#dbeafe"/>
+  <!-- Product info -->
+  <rect x="688" y="170" width="120" height="14" rx="7" fill="#3b82f6"/>
+  <rect x="688" y="204" width="420" height="28" rx="14" fill="#334155"/>
+  <rect x="688" y="244" width="300" height="28" rx="14" fill="#334155"/>
+  <rect x="688" y="296" width="140" height="22" rx="11" fill="#475569"/>
+  <rect x="688" y="346" width="480" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="688" y="370" width="480" height="12" rx="6" fill="#94a3b8"/>
+  <rect x="688" y="394" width="320" height="12" rx="6" fill="#94a3b8"/>
+  <!-- Size selector -->
+  <rect x="688" y="442" width="80" height="14" rx="7" fill="#475569"/>
+  <rect x="688" y="472" width="56" height="40" rx="8" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+  <rect x="756" y="472" width="56" height="40" rx="8" fill="#3b82f6"/>
+  <rect x="824" y="472" width="56" height="40" rx="8" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+  <rect x="892" y="472" width="56" height="40" rx="8" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+  <!-- Add to cart -->
+  <rect x="688" y="548" width="320" height="52" rx="26" fill="#3b82f6"/>
+  <rect x="1024" y="548" width="52" height="52" rx="26" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+</svg>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -147,7 +147,7 @@ function getSocialIcon(platform: string): string {
 }
 ---
 
-<footer class={footerClasses} {...attrs}>
+<footer class={footerClasses} data-pagefind-ignore {...attrs}>
   <div class={cn('mx-auto px-6', maxWidthClass)}>
     {layout === 'simple' && (
       <>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -28,6 +28,7 @@ import { headerVariants, headerInnerVariants } from './header.variants';
 import Button from '@/components/ui/form/Button/Button.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import Logo from '@/components/ui/marketing/Logo/Logo.astro';
+import SearchModal from '@/components/layout/SearchModal.astro';
 import ThemeModeDropdown from '@/components/layout/ThemeModeDropdown.astro';
 import ThemeSelector from '@/components/layout/ThemeSelector.astro';
 import ThemeSelectorDropdown from '@/components/layout/ThemeSelectorDropdown.astro';
@@ -60,6 +61,7 @@ interface Props extends HTMLAttributes<'header'> {
   showCta?: boolean;
   cta?: { label?: string; href?: string; icon?: string; trailingIcon?: string };
   actions?: HeaderAction[];
+  showSearch?: boolean;
   showThemeToggle?: boolean;
   showThemeSelector?: boolean;
   showMobileMenu?: boolean;
@@ -91,6 +93,7 @@ const {
   showCta = false,
   cta = { label: 'Start a project', href: '/contact' },
   actions = [],
+  showSearch = true,
   showThemeToggle = true,
   showThemeSelector = true,
   showMobileMenu = true,
@@ -196,6 +199,7 @@ const buttonId = `${menuId}-button`;
 
 <header
   class={headerClasses}
+  data-pagefind-ignore
   data-menu-id={menuId}
   data-button-id={buttonId}
   data-header-shape={shape}
@@ -263,6 +267,12 @@ const buttonId = `${menuId}-button`;
           <slot name="actions" />
         ) : (
           <>
+            {showSearch && (
+              <div class="flex">
+                <SearchModal class={isFloating ? 'hdr-invert-text' : undefined} />
+              </div>
+            )}
+
             {showThemeToggle && (
               <div class="flex">
                 <ThemeModeDropdown class={isFloating ? 'hdr-invert-text' : undefined} />

--- a/src/components/layout/SearchModal.astro
+++ b/src/components/layout/SearchModal.astro
@@ -1,0 +1,290 @@
+---
+/**
+ * SearchModal — header search trigger + command-palette style modal,
+ * powered by Pagefind's static index.
+ *
+ * - The index is generated at build time by the `pagefind` hook in
+ *   `astro.config.mjs`, so search ships zero JS until the modal is opened —
+ *   the Pagefind bundle (~6 kB) is imported lazily on first open.
+ * - In `astro dev` the index does not exist; the modal explains how to
+ *   build it instead of failing silently.
+ * - The dialog node is portalled to <body> on init so the fixed overlay
+ *   escapes the header's transform (auto-hide) and backdrop-filter.
+ * - Keyboard: Cmd/Ctrl+K opens, Escape closes, ↑/↓ move through results.
+ */
+import { cn } from '@/lib/cn';
+
+interface Props {
+  class?: string;
+}
+
+const { class: className } = Astro.props;
+
+const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
+---
+
+<div class="search-wrapper" data-search-modal-id={modalId}>
+  <!-- Trigger pill — matches the ThemeModeDropdown trigger -->
+  <button
+    type="button"
+    class={cn(
+      'search-trigger inline-flex items-center gap-1.5 rounded-full border border-border-strong px-2.5 py-1.5',
+      'text-foreground-muted hover:text-foreground hover:bg-secondary',
+      'transition-colors duration-(--transition-fast)',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className
+    )}
+    aria-haspopup="dialog"
+    aria-controls={modalId}
+    aria-label="Search"
+  >
+    <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+      <circle cx="11" cy="11" r="7" />
+      <path stroke-linecap="round" d="m20 20-3.5-3.5" />
+    </svg>
+    <kbd class="hidden lg:inline text-[10px] font-medium tracking-wide" aria-hidden="true">⌘K</kbd>
+  </button>
+
+  <!-- Modal (moved to <body> by the init script) -->
+  <div
+    id={modalId}
+    class="search-modal fixed inset-0 z-[100] hidden"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Search"
+    data-pagefind-ignore
+  >
+    <div class="search-backdrop absolute inset-0 bg-black/60 backdrop-blur-sm" data-search-close></div>
+
+    <div class="relative mx-auto mt-[12vh] w-[calc(100%-2rem)] max-w-xl overflow-hidden rounded-xl border border-border bg-background shadow-2xl">
+      <!-- Input row -->
+      <div class="flex items-center gap-3 border-b border-border px-4">
+        <svg class="h-5 w-5 shrink-0 text-foreground-muted" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <circle cx="11" cy="11" r="7" />
+          <path stroke-linecap="round" d="m20 20-3.5-3.5" />
+        </svg>
+        <input
+          type="search"
+          class="search-input w-full bg-transparent py-4 text-base text-foreground placeholder:text-foreground-subtle focus:outline-none"
+          placeholder="Search posts, projects, and pages…"
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          aria-label="Search query"
+        />
+        <button
+          type="button"
+          class="shrink-0 rounded-md border border-border-strong px-1.5 py-0.5 text-[10px] font-medium text-foreground-muted hover:bg-secondary hover:text-foreground transition-colors"
+          data-search-close
+        >
+          ESC
+        </button>
+      </div>
+
+      <!-- Results -->
+      <div class="search-results max-h-[55vh] overflow-y-auto overscroll-contain p-2" role="listbox" aria-label="Search results">
+        <p class="search-hint px-3 py-8 text-center text-sm text-foreground-muted">
+          Start typing to search the site.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  /* Highlighted terms in Pagefind excerpts (injected at runtime) */
+  :global(.search-results mark) {
+    background: transparent;
+    color: var(--color-brand-500);
+    font-weight: 600;
+  }
+  /* Hide the native WebKit clear button — the ESC affordance covers it */
+  .search-input::-webkit-search-cancel-button {
+    display: none;
+  }
+</style>
+
+<script>
+  interface PagefindResultData {
+    url: string;
+    excerpt: string;
+    meta: { title?: string };
+  }
+  interface PagefindResult {
+    data: () => Promise<PagefindResultData>;
+  }
+  interface Pagefind {
+    search: (query: string) => Promise<{ results: PagefindResult[] }>;
+  }
+
+  const MAX_RESULTS = 8;
+
+  let pagefind: Pagefind | null = null;
+  let pagefindFailed = false;
+
+  async function loadPagefind(): Promise<Pagefind | null> {
+    if (pagefind || pagefindFailed) return pagefind;
+    try {
+      // Generated at build time (`astro:build:done` hook in astro.config.mjs).
+      // The variable indirection + @vite-ignore keep Vite from trying to
+      // resolve the module at bundle time.
+      const url = '/pagefind/pagefind.js';
+      pagefind = (await import(/* @vite-ignore */ url)) as Pagefind;
+    } catch {
+      pagefindFailed = true;
+    }
+    return pagefind;
+  }
+
+  function escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function initSearchModals() {
+    const wrappers = document.querySelectorAll<HTMLElement>(
+      '.search-wrapper:not([data-search-init])'
+    );
+
+    wrappers.forEach((wrapper) => {
+      wrapper.dataset.searchInit = 'true';
+
+      const trigger = wrapper.querySelector<HTMLButtonElement>('.search-trigger');
+      const modal = wrapper.querySelector<HTMLElement>('.search-modal');
+      if (!trigger || !modal) return;
+
+      // Portal the dialog to <body>: the header animates with a transform
+      // (auto-hide), which would turn it into the containing block for this
+      // fixed overlay and drag the modal off-screen with it.
+      document.body.appendChild(modal);
+
+      const input = modal.querySelector<HTMLInputElement>('.search-input');
+      const results = modal.querySelector<HTMLElement>('.search-results');
+      if (!input || !results) return;
+
+      const open = () => {
+        modal.classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
+        input.focus();
+        input.select();
+      };
+
+      const close = () => {
+        modal.classList.add('hidden');
+        document.body.style.overflow = '';
+        trigger.focus();
+      };
+
+      const renderMessage = (html: string) => {
+        results.innerHTML = `<p class="px-3 py-8 text-center text-sm text-foreground-muted">${html}</p>`;
+      };
+
+      const renderResults = async (query: string) => {
+        const pf = await loadPagefind();
+        if (!pf) {
+          renderMessage(
+            'The search index is generated at build time and isn’t available in <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">astro dev</code>.<br />Run <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">pnpm build &amp;&amp; pnpm preview</code> to try it locally.'
+          );
+          return;
+        }
+
+        const search = await pf.search(query);
+        // A newer keystroke may have superseded this query while we awaited
+        if (input.value.trim() !== query) return;
+
+        if (search.results.length === 0) {
+          renderMessage(`No results for “${escapeHtml(query)}”`);
+          return;
+        }
+
+        const items = await Promise.all(
+          search.results.slice(0, MAX_RESULTS).map((r) => r.data())
+        );
+
+        results.innerHTML = items
+          .map(
+            (item) => `
+              <a
+                href="${item.url}"
+                class="search-result block rounded-lg px-3 py-2.5 hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                role="option"
+              >
+                <span class="block text-sm font-semibold text-foreground">${escapeHtml(item.meta.title ?? item.url)}</span>
+                <span class="mt-0.5 block text-xs leading-relaxed text-foreground-muted [&_mark]:bg-transparent">${item.excerpt}</span>
+              </a>`
+          )
+          .join('');
+      };
+
+      let debounce: number | undefined;
+      input.addEventListener('input', () => {
+        if (debounce) window.clearTimeout(debounce);
+        const query = input.value.trim();
+        if (!query) {
+          renderMessage('Start typing to search the site.');
+          return;
+        }
+        debounce = window.setTimeout(() => renderResults(query), 150);
+      });
+
+      trigger.addEventListener('click', open);
+      modal.querySelectorAll('[data-search-close]').forEach((el) => {
+        el.addEventListener('click', close);
+      });
+
+      // ↑/↓ between input and results, Escape to close
+      modal.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          close();
+          return;
+        }
+        if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+        const links = Array.from(modal.querySelectorAll<HTMLAnchorElement>('.search-result'));
+        if (links.length === 0) return;
+        e.preventDefault();
+        const active = document.activeElement;
+        const index = links.indexOf(active as HTMLAnchorElement);
+        if (e.key === 'ArrowDown') {
+          (index === -1 ? links[0] : links[Math.min(index + 1, links.length - 1)]).focus();
+        } else if (index <= 0) {
+          input.focus();
+        } else {
+          links[index - 1].focus();
+        }
+      });
+
+    });
+
+    // Cmd/Ctrl+K toggles the first search modal on the page. Bound once per
+    // session (window survives view-transition swaps; the listener queries
+    // the live DOM instead of closing over a node that a swap may replace).
+    const w = window as unknown as { __searchHotkeyInit?: boolean };
+    if (!w.__searchHotkeyInit) {
+      w.__searchHotkeyInit = true;
+      document.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 'k') return;
+        const modal = document.querySelector<HTMLElement>('.search-modal');
+        if (!modal) return;
+        e.preventDefault();
+        if (modal.classList.contains('hidden')) {
+          modal.classList.remove('hidden');
+          document.body.style.overflow = 'hidden';
+          const input = modal.querySelector<HTMLInputElement>('.search-input');
+          input?.focus();
+          input?.select();
+        } else {
+          modal.classList.add('hidden');
+          document.body.style.overflow = '';
+        }
+      });
+    }
+  }
+
+  initSearchModals();
+  document.addEventListener('astro:page-load', initSearchModals);
+  document.addEventListener('astro:after-swap', initSearchModals);
+</script>

--- a/src/content/projects/ecommerce-store.mdx
+++ b/src/content/projects/ecommerce-store.mdx
@@ -8,8 +8,23 @@ year: 2025
 client: "Your Client Name"
 role: "Designer & Developer"
 services: ["Web Design", "Web Development", "E-Commerce"]
-placeholder: true
+# Multiple images? Add a `gallery` array and the hero swaps the single
+# `image` for a swipeable carousel. The first slide is the lead image.
+# (Galleries render on the project detail page, so this demo project is
+# routable — placeholder projects only appear as cards.)
+gallery:
+  - src: "../../assets/projects/ecommerce-store-catalog.svg"
+    alt: "Product catalogue grid with eight product cards"
+  - src: "../../assets/projects/ecommerce-store-product.svg"
+    alt: "Product detail page with size selector and add-to-cart button"
+  - src: "../../assets/projects/ecommerce-store-checkout.svg"
+    alt: "Checkout flow with shipping form and order summary"
 ---
+
+import ProjectGallery from '@/components/projects/ProjectGallery.astro';
+import catalog from '@/assets/projects/ecommerce-store-catalog.svg';
+import product from '@/assets/projects/ecommerce-store-product.svg';
+import checkout from '@/assets/projects/ecommerce-store-checkout.svg';
 
 ## The Brief
 
@@ -25,6 +40,18 @@ Describe the store's structure and what made it technically interesting.
 - Cart and checkout flow
 - Mobile-first design
 - Performance optimisation strategy
+
+## Screens
+
+Need an image carousel with a lightbox inside the body of a project? Import `ProjectGallery` and pass it your screenshots — click any slide to zoom. Replace these placeholder wireframes with real screenshots of your work.
+
+<ProjectGallery
+  images={[
+    { src: catalog, alt: 'Product catalogue grid', caption: 'The catalogue — eight products per page, filterable by collection.' },
+    { src: product, alt: 'Product detail page', caption: 'Product detail with size selector and sticky add-to-cart.' },
+    { src: checkout, alt: 'Checkout flow', caption: 'Two-step checkout with a persistent order summary.' },
+  ]}
+/>
 
 ## Mobile-First Approach
 


### PR DESCRIPTION
Header search (#395):
- New SearchModal.astro — ⌘K/Ctrl+K command-palette modal on the
  Pagefind JS API, lazy-loaded on first open (zero JS on page load)
- New showSearch Header prop (on by default), search pill next to the
  colour-mode dropdown
- pagefind() hook in astro.config.mjs indexes the real build output dir
  on every adapter (Vercel/Netlify/Cloudflare) after astro build
- data-pagefind-ignore on Header/Footer keeps nav chrome out of results
- Drop unused @pagefind/default-ui dependency

Project galleries (#396):
- README: document the gallery frontmatter hero carousel and the
  in-body ProjectGallery MDX component (both shipped undocumented)
- ecommerce-store.mdx is now a routable living example of both, with
  three placeholder storefront wireframe SVGs

https://claude.ai/code/session_01VxbgmrzzJzsEh9qEhHZPeD