### PR TITLE
Match search pill styling to the other header pills in all modes

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -958,13 +958,15 @@ const buttonId = `${menuId}-button`;
   }
 
   html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) .ttg-wrapper > .ttg-trigger,
-  html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) .theme-dropdown-wrapper > button {
+  html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) .theme-dropdown-wrapper > button,
+  html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) .search-wrapper > .search-trigger {
     border-color: oklch(58% 0.008 250 / 0.6);
     color: oklch(68% 0.01 250);
     box-shadow: none;
   }
   html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) .ttg-wrapper > .ttg-trigger:hover,
-  html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) .theme-dropdown-wrapper > button:hover {
+  html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) .theme-dropdown-wrapper > button:hover,
+  html:not(.dark) [data-header-shape="floating"]:not([data-scrolled]) .search-wrapper > .search-trigger:hover {
     border-color: oklch(58% 0.008 250 / 0.85);
     background-color: rgb(255 255 255 / 0.06);
     color: oklch(91% 0.008 250);
@@ -981,7 +983,8 @@ const buttonId = `${menuId}-button`;
   }
 
   .dark [data-header-shape="floating"] .theme-dropdown-wrapper button,
-  .dark [data-header-shape="floating"] .ttg-wrapper .ttg-trigger {
+  .dark [data-header-shape="floating"] .ttg-wrapper .ttg-trigger,
+  .dark [data-header-shape="floating"] .search-wrapper .search-trigger {
     border-color: var(--color-foreground-subtle);
   }
 
@@ -1037,7 +1040,8 @@ const buttonId = `${menuId}-button`;
     color: var(--color-brand-700);
   }
   .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .theme-dropdown-wrapper button,
-  .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .ttg-wrapper .ttg-trigger {
+  .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .ttg-wrapper .ttg-trigger,
+  .dark [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .search-wrapper .search-trigger {
     border-color: rgba(0, 0, 0, 0.15);
   }
 
@@ -1058,7 +1062,8 @@ const buttonId = `${menuId}-button`;
     color: var(--color-brand-500);
   }
   html:not(.dark) [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .theme-dropdown-wrapper button,
-  html:not(.dark) [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .ttg-wrapper .ttg-trigger {
+  html:not(.dark) [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .ttg-wrapper .ttg-trigger,
+  html:not(.dark) [data-header-shape="floating"][data-header-returned][data-header-invert-on-return="true"] .search-wrapper .search-trigger {
     border-color: rgba(255, 255, 255, 0.2);
   }
 

--- a/src/components/layout/SearchModal.astro
+++ b/src/components/layout/SearchModal.astro
@@ -23,16 +23,17 @@ const { class: className } = Astro.props;
 const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
 ---
 
-<div class="search-wrapper" data-search-modal-id={modalId}>
-  <!-- Trigger pill — matches the ThemeModeDropdown trigger -->
+<div class={cn('search-wrapper', className)} data-search-modal-id={modalId}>
+  <!-- Trigger pill — same structure and classes as the ThemeModeDropdown
+       trigger, so the header's floating/returned state CSS treats both pills
+       identically (those rules target the wrapper > trigger pair). -->
   <button
     type="button"
     class={cn(
       'search-trigger inline-flex items-center rounded-full border border-border-strong px-2.5 py-1.5',
       'text-foreground-muted hover:text-foreground hover:bg-secondary',
       'transition-colors duration-(--transition-fast)',
-      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-      className
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
     )}
     aria-haspopup="dialog"
     aria-controls={modalId}


### PR DESCRIPTION
The floating-header state CSS (dark-glass capsule at rest, dark-mode border softening, returned-state colour flips) targets the colour-mode and theme pills by their wrapper/trigger selectors — the search pill now joins every one of those selector groups, and carries the hdr-invert-text class on its wrapper like the other two, so all three pills render identically in every header state and colour mode.

https://claude.ai/code/session_01VxbgmrzzJzsEh9qEhHZPeD

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
