### PR TITLE
Make colour-mode and theme pills round icon-only buttons

### DIFF
--- a/src/components/layout/ThemeModeDropdown.astro
+++ b/src/components/layout/ThemeModeDropdown.astro
@@ -22,12 +22,14 @@ const { class: className } = Astro.props;
 ---
 
 <div class={cn('relative ttg-wrapper', className)}>
-  <!-- Trigger pill -->
+  <!-- Trigger — round icon-only button; the open state gets a pressed
+       background (aria-expanded) since there's no chevron to rotate -->
   <button
     type="button"
     class={cn(
-      'ttg-trigger inline-flex items-center gap-1.5 rounded-full border border-border-strong px-2.5 py-1.5',
+      'ttg-trigger inline-flex items-center justify-center rounded-full border border-border-strong p-1.5',
       'text-foreground-muted hover:text-foreground hover:bg-secondary',
+      'aria-expanded:bg-secondary aria-expanded:text-foreground',
       'transition-colors duration-(--transition-fast)',
       'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
     )}
@@ -47,20 +49,6 @@ const { class: className } = Astro.props;
     <!-- Moon -->
     <svg class="ttg-icon ttg-icon-dark h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
       <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z" />
-    </svg>
-    <!-- Chevron — rotates 180° when panel is open -->
-    <svg
-      class="ttg-chevron h-3 w-3 flex-shrink-0 transition-transform duration-200"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      aria-hidden="true"
-    >
-      <path d="m6 9 6 6 6-6" />
     </svg>
   </button>
 

--- a/src/components/layout/ThemeSelectorDropdown.astro
+++ b/src/components/layout/ThemeSelectorDropdown.astro
@@ -38,32 +38,19 @@ const themes = [
     aria-expanded="false"
     aria-label="Select colour theme"
     class={cn(
-      'inline-flex items-center gap-1.5 rounded-full border border-border-strong px-2.5 py-1.5',
+      'inline-flex items-center justify-center rounded-full border border-border-strong p-1.5',
       'text-foreground-muted hover:text-foreground hover:bg-secondary',
+      'aria-expanded:bg-secondary aria-expanded:text-foreground',
       'transition-colors duration-(--transition-fast)',
       'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
     )}
   >
-    <!-- Active theme dot -->
+    <!-- Active theme dot — the live colour swatch IS the icon -->
     <span
-      class="h-3.5 w-3.5 rounded-full block flex-shrink-0"
+      class="h-4 w-4 rounded-full block flex-shrink-0"
       style="background-color: var(--color-brand-500)"
       aria-hidden="true"
     />
-    <!-- Chevron — inline, rotates on open -->
-    <svg
-      class="theme-chevron h-3 w-3 flex-shrink-0 transition-transform duration-200"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      aria-hidden="true"
-    >
-      <path d="m6 9 6 6 6-6"/>
-    </svg>
   </button>
 
   <!-- Dropdown panel -->


### PR DESCRIPTION
All three header controls are now matching 30px circles: search (magnifier), colour mode (system/sun/moon icon), theme selector (the live colour dot as its own swatch-icon, bumped to h-4 for parity). Chevrons removed; the open state shows a pressed background via the aria-expanded variant instead.

https://claude.ai/code/session_01VxbgmrzzJzsEh9qEhHZPeD

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
