### PR TITLE
Replace split-section left/right slide-ins with staggered slide-up

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -40,7 +40,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12">
         <!-- Left: text -->
-        <div class="flex flex-col justify-center gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal="right" data-reveal-ease="smooth">
+        <div class="flex flex-col justify-center gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal data-reveal-ease="smooth">
           <div class="flex flex-col gap-6 sm:items-center glitch:items-start">
             <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">Free & Open Source</Badge>
             <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground text-balance">
@@ -55,7 +55,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
           </p>
         </div>
         <!-- Right: theme facts card -->
-        <div class="flex flex-col h-full" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="flex flex-col h-full" data-reveal data-reveal-delay="1" data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="flex-1 flex flex-col justify-center">
             <div class="grid grid-cols-2 sm:grid-cols-3 glitch:grid-cols-2 gap-x-6 gap-y-8">
               <div class="flex flex-col items-center text-center gap-3">
@@ -335,7 +335,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-8 sm:gap-10 glitch:grid-cols-2 glitch:items-center">
         <!-- Text -->
-        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:items-start glitch:justify-center glitch:text-left" data-reveal="right" data-reveal-ease="smooth">
+        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:items-start glitch:justify-center glitch:text-left" data-reveal data-reveal-ease="smooth">
           <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">Open Source</Badge>
           <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
             Built in the open
@@ -350,7 +350,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
         </div>
 
         <!-- Info card -->
-        <div class="flex flex-col h-full" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="flex flex-col h-full" data-reveal data-reveal-delay="1" data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="flex-1 flex flex-col justify-center gap-6">
             <div class="flex flex-col gap-2">
               <h3 class="text-base font-semibold text-foreground">Made by Hans Martens</h3>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -60,7 +60,7 @@ const channels = [
       <div class="grid grid-cols-1 glitch:grid-cols-5 gap-10 glitch:gap-16 items-stretch">
 
         <!-- Left column: contact form -->
-        <div class="glitch:col-span-3 h-full sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal="right" data-reveal-ease="smooth">
+        <div class="glitch:col-span-3 h-full sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal data-reveal-ease="smooth">
           <Card padding="lg" class="h-full flex flex-col justify-center">
             <h2 class="font-display text-xl font-bold text-foreground mb-6 sm:text-center glitch:text-left">Project details</h2>
             <ContactForm />
@@ -68,7 +68,7 @@ const channels = [
         </div>
 
         <!-- Right column: contact channels -->
-        <div class="glitch:col-span-2 space-y-4 sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="glitch:col-span-2 space-y-4 sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal data-reveal-delay="1" data-reveal-ease="smooth">
           <div class="sm:text-center glitch:text-left">
             <h2 class="font-display text-lg font-bold text-foreground mb-1">Other channels</h2>
             <p class="text-sm text-foreground-muted">Prefer a direct channel? Pick whichever works best.</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -267,7 +267,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   <section class="relative z-10 py-[var(--space-section-md)] bg-background border-t border-border">
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12">
-        <div class="flex flex-col justify-center sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal="right" data-reveal-ease="smooth">
+        <div class="flex flex-col justify-center sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal data-reveal-ease="smooth">
           <div class="flex flex-col gap-6 mb-6 sm:items-center glitch:items-start">
             <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">About me</Badge>
             <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
@@ -286,7 +286,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
             <Icon name="arrow-right" size="sm" />
           </Button>
         </div>
-        <Card variant="elevated" padding="lg" class="h-full flex flex-col" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+        <Card variant="elevated" padding="lg" class="h-full flex flex-col" data-reveal data-reveal-delay="1" data-reveal-ease="smooth">
           <p class="text-sm text-foreground mb-5 text-center sm:hidden glitch:block">A few things about me.</p>
           <div class="grid grid-cols-2 sm:grid-cols-4 glitch:grid-cols-2 gap-3 flex-1 auto-rows-fr">
             <div class="bg-background-tertiary rounded-xl p-5 flex flex-col items-center justify-center text-center gap-2 border-t-2 border-brand-500/40 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-md hover:border-brand-500 cursor-default h-full">

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -52,7 +52,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12 glitch:items-start">
         <!-- Text -->
-        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal="right" data-reveal-ease="smooth">
+        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal data-reveal-ease="smooth">
           <div class="flex flex-col gap-6 sm:items-center glitch:items-start">
             <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">
               <Icon name="layout" size="sm" />
@@ -74,7 +74,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
           </Button>
         </div>
         <!-- Card -->
-        <div class="sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal data-reveal-delay="1" data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
             <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border sm:justify-center glitch:justify-start">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
@@ -137,7 +137,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12 glitch:items-start">
         <!-- Text -->
-        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:order-2 glitch:items-start glitch:text-left" data-reveal="left" data-reveal-ease="smooth">
+        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:order-2 glitch:items-start glitch:text-left" data-reveal data-reveal-delay="1" data-reveal-ease="smooth">
           <div class="flex flex-col gap-6 sm:items-center glitch:items-start">
             <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">
               <Icon name="code" size="sm" />
@@ -159,7 +159,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
           </Button>
         </div>
         <!-- Card -->
-        <div class="sm:max-w-xl sm:mx-auto glitch:order-1 glitch:max-w-none glitch:mx-0" data-reveal="right" data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="sm:max-w-xl sm:mx-auto glitch:order-1 glitch:max-w-none glitch:mx-0" data-reveal data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
             <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border sm:justify-center glitch:justify-start">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
@@ -222,7 +222,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12 glitch:items-start">
         <!-- Text -->
-        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal="right" data-reveal-ease="smooth">
+        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal data-reveal-ease="smooth">
           <div class="flex flex-col gap-6 sm:items-center glitch:items-start">
             <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">
               <Icon name="zap" size="sm" />
@@ -244,7 +244,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
           </Button>
         </div>
         <!-- Card -->
-        <div class="sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal="left" data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal data-reveal-delay="1" data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
             <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border sm:justify-center glitch:justify-start">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">


### PR DESCRIPTION
The two-column split sections on the home, about, services, and contact pages previously slid in horizontally on desktop and tablet landscape (left column from the left, right column from the right) via data-reveal="left|right". Below 1024px these already redirected to a vertical slide-up.

Switch every split section to the default vertical data-reveal so both columns rise and fade in on all breakpoints, cascading left-to-right via data-reveal-delay: the visually-left column leads, the visually-right column follows 100ms behind. In the alternating "Development" section on the services page the delay moves to the (visually-right) text column so the cascade still reads left-to-right despite the reversed column order.

The horizontal data-reveal="left|right" variants remain defined in global.css for future use.

https://claude.ai/code/session_01R2K6EkU5FzCgzAeYk2HNrA

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
