### PR TITLE
Match HM animation engine: eager first-section reveals + parity

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -350,8 +350,13 @@ const locale = getLocaleFromPath(Astro.url.pathname);
 
           if (!els.length) return;
 
+          // Non-eager pages trigger a bit deeper in the viewport (-15% bottom)
+          // so a block is comfortably on-screen before it rises — its slide-up
+          // plays in front of the reader instead of being masked by the scroll
+          // as it peeks in at the bottom edge. Eager pages keep the earlier -5%
+          // so their first above-fold cards still reveal promptly.
           const eager = document.body.hasAttribute('data-eager-reveal');
-          const belowFoldMargin = eager ? '0px 0px -5% 0px' : '0px 0px -10% 0px';
+          const belowFoldMargin = eager ? '0px 0px -5% 0px' : '0px 0px -15% 0px';
 
           // Two scroll-triggered observers for below-fold elements. Tall
           // elements (taller than ~85% of the viewport) use threshold 0 so
@@ -407,7 +412,60 @@ const locale = getLocaleFromPath(Astro.url.pathname);
             });
           }, { threshold: 0, rootMargin: '0px 0px -25% 0px' });
 
-          els.forEach(function (el) { firstPass.observe(el); });
+          // Cards flagged data-reveal-eager (the first card on a listing page)
+          // reveal on load with the normal animation instead of waiting for
+          // scroll. On mobile the centered hero can push the first card below
+          // firstPass's fold line, which would otherwise leave it hidden until
+          // the reader scrolls — unlike pages with no heading above the grid
+          // (e.g. projects), where the first card sits above the fold and
+          // animates on load. The 250ms delay mirrors firstPass's base reveal
+          // timing so the entrance matches, and lets the opacity:0 frame paint
+          // first so the transition plays.
+          //
+          // On a multi-column grid the eager card's same-row neighbours would
+          // otherwise ride the scroll observers on a different clock, so a
+          // side-by-side pair enters visibly out of sync. Group each eager card
+          // with its same-row [data-reveal] siblings and reveal them in one
+          // tick. "Same row" is detected by a shared offsetTop, so on a stacked
+          // single-column layout (mobile) nothing qualifies and the existing
+          // top-to-bottom stagger is left untouched. The offsetTop reads happen
+          // in a single pass with no interleaved writes, so they share one
+          // layout flush rather than thrashing.
+          const eagerGroups = new Map();
+          const syncedSiblings = new Set();
+          els.forEach(function (el) {
+            if (!el.hasAttribute('data-reveal-eager')) return;
+            const group = [el];
+            const parent = el.parentElement;
+            if (parent) {
+              const top = el.offsetTop;
+              Array.prototype.forEach.call(parent.children, function (sib) {
+                if (
+                  sib !== el &&
+                  sib.hasAttribute('data-reveal') &&
+                  !sib.hasAttribute('data-reveal-eager') &&
+                  Math.abs(sib.offsetTop - top) <= 1
+                ) {
+                  group.push(sib);
+                  syncedSiblings.add(sib);
+                }
+              });
+            }
+            eagerGroups.set(el, group);
+          });
+
+          els.forEach(function (el) {
+            if (el.hasAttribute('data-reveal-eager')) {
+              const group = eagerGroups.get(el);
+              setTimeout(function () {
+                group.forEach(function (node) { node.classList.add('is-visible'); });
+              }, 250);
+              return;
+            }
+            // Already revealed in lockstep with its eager row-mate above.
+            if (syncedSiblings.has(el)) return;
+            firstPass.observe(el);
+          });
         }
 
         if (document.readyState === 'loading') {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -40,7 +40,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12">
         <!-- Left: text -->
-        <div class="flex flex-col justify-center gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal data-reveal-ease="smooth">
+        <div class="flex flex-col justify-center gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal data-reveal-eager data-reveal-ease="smooth">
           <div class="flex flex-col gap-6 sm:items-center glitch:items-start">
             <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">Free & Open Source</Badge>
             <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground text-balance">
@@ -55,7 +55,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
           </p>
         </div>
         <!-- Right: theme facts card -->
-        <div class="flex flex-col h-full" data-reveal data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="flex flex-col h-full" data-reveal data-reveal-eager data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="flex-1 flex flex-col justify-center">
             <div class="grid grid-cols-2 sm:grid-cols-3 glitch:grid-cols-2 gap-x-6 gap-y-8">
               <div class="flex flex-col items-center text-center gap-3">

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -52,7 +52,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
     <div class="mx-auto max-w-6xl px-6">
       <div class="grid gap-10 glitch:grid-cols-2 glitch:gap-12 glitch:items-start">
         <!-- Text -->
-        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal data-reveal-ease="smooth">
+        <div class="flex flex-col gap-4 sm:items-center sm:text-center glitch:items-start glitch:text-left" data-reveal data-reveal-eager data-reveal-ease="smooth">
           <div class="flex flex-col gap-6 sm:items-center glitch:items-start">
             <Badge variant="brand" pill class="self-start sm:self-center glitch:self-start">
               <Icon name="layout" size="sm" />
@@ -74,7 +74,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
           </Button>
         </div>
         <!-- Card -->
-        <div class="sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal data-reveal-delay="1" data-reveal-ease="smooth">
+        <div class="sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal data-reveal-eager data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
             <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border sm:justify-center glitch:justify-start">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1044,11 +1044,15 @@
    transition shorthand is always valid.
    ------------------------------------------------------------------------- */
 
-/* Clean ease-out curve: elements slide up and decelerate to a smooth stop
-   on entrance, with no overshoot or bounce. */
+/* Clean ease-out curve: elements slide up and decelerate to a smooth stop on
+   entrance, no overshoot. This fade-in is for the non-LCP hero elements (badge,
+   description, actions); the LCP hero title uses the transform-only keyframe
+   below so it never fades, keeping its first paint at full opacity. The 0.01
+   start (not 0) keeps these faded elements as paint candidates so none is
+   misread as a late LCP if it ever becomes the largest element. */
 @keyframes hero-slide-up {
   from {
-    opacity: 0;
+    opacity: 0.01;
     transform: translateY(80px);
   }
   to {
@@ -1203,6 +1207,21 @@
 [data-reveal-content] > *.is-visible {
   opacity: 1;
   transform: none;
+}
+
+/* In-page anchor jumps (e.g. the services hero section buttons) tag their
+   destination with .reveal-instant so the content is already in its final
+   position when the smooth-scroll lands, instead of sliding in mid-jump.
+   Natural scrolling is untouched and still animates. */
+.reveal-instant[data-reveal],
+.reveal-instant [data-reveal],
+.reveal-instant[data-reveal-children] > *,
+.reveal-instant [data-reveal-children] > *,
+.reveal-instant[data-reveal-content] > *,
+.reveal-instant [data-reveal-content] > * {
+  opacity: 1;
+  transform: none;
+  transition: none;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Bring Astro-Rocket's page reveal animations to parity with the hansmartensdev/HansMartens site:

- BaseLayout observer: port the data-reveal-eager mechanism so a flagged first below-hero section reveals on load (250ms), grouped in sync with its same-row [data-reveal] siblings; deepen the non-eager trigger from -10% to -15% of the viewport so blocks are comfortably on-screen before they rise.
- global.css: hero-slide-up now starts at opacity 0.01 (keeps faded hero elements as LCP paint candidates); add the global .reveal-instant utility for in-page anchor jumps.
- about & services: mark the first below-hero section's two columns data-reveal-eager (no stagger delay) so they reveal together on load.

Kept Astro-Rocket's hero-lcp-title treatment (covers the project/blog heroes for LCP, which HansMartens does not) since it yields the same visible slide. The TechStack "spotlight" cycle is intentionally not ported — HansMartens never enables it on a page.

https://claude.ai/code/session_01R2K6EkU5FzCgzAeYk2HNrA

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
