### PR TITLE
Make the animation engine byte-identical to HansMartens

### DIFF
--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -54,7 +54,7 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
     )}
 
     <!-- Title -->
-    <h1 class="hero-lcp-title font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl lg:text-6xl mb-[var(--space-heading-gap)]">
+    <h1 class="font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl lg:text-6xl mb-[var(--space-heading-gap)]">
       {title}
     </h1>
 

--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -132,7 +132,7 @@ const gridClasses = cn(
       {/* Title Slot */}
       {hasTitleSlot && (
         <div class={cn(
-          'hero-title-slot hero-lcp-title mb-[var(--space-heading-gap)]',
+          'hero-title-slot mb-[var(--space-heading-gap)]',
           '[&>h1]:font-display [&>h1]:text-5xl [&>h1]:leading-[1.1] [&>h1]:font-bold [&>h1]:tracking-tight [&>h1]:text-balance [&>h1]:text-foreground md:[&>h1]:text-6xl lg:[&>h1]:text-7xl',
           '[&>h2]:font-display [&>h2]:text-4xl [&>h2]:leading-[1.1] [&>h2]:font-bold [&>h2]:tracking-tight [&>h2]:text-balance [&>h2]:text-foreground md:[&>h2]:text-5xl lg:[&>h2]:text-6xl'
         )}>

--- a/src/components/projects/ProjectHero.astro
+++ b/src/components/projects/ProjectHero.astro
@@ -53,7 +53,7 @@ const hasMedia = slides.length > 0;
     >
       <!-- Text column -->
       <div class="animate-hero-stagger min-w-0">
-        <h1 class="hero-lcp-title font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl lg:text-6xl mb-[var(--space-heading-gap)] text-balance">
+        <h1 class="font-display text-4xl font-bold tracking-tight text-foreground md:text-5xl lg:text-6xl mb-[var(--space-heading-gap)] text-balance">
           {title}
         </h1>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -359,9 +359,9 @@ const locale = getLocaleFromPath(Astro.url.pathname);
           const belowFoldMargin = eager ? '0px 0px -5% 0px' : '0px 0px -15% 0px';
 
           // Two scroll-triggered observers for below-fold elements. Tall
-          // elements (taller than ~85% of the viewport) use threshold 0 so
-          // they still fire; shorter elements use 0.15 so animations feel
-          // earned (the user actually sees them play).
+          // elements (taller than ~85% of the viewport — long code blocks,
+          // large embeds) use threshold 0 so they still fire; shorter
+          // elements use 0.15 so animations feel earned.
           const shortObs = new IntersectionObserver(function (entries) {
             entries.forEach(function (entry) {
               if (entry.isIntersecting) {
@@ -382,11 +382,13 @@ const locale = getLocaleFromPath(Astro.url.pathname);
 
           // First-pass observer: hands us boundingClientRect and rootBounds
           // for each element without forcing a synchronous layout read. The
-          // browser computes the geometry off the main thread, replacing
-          // the previous getBoundingClientRect() classifier loop that
-          // Lighthouse flagged as a ~76ms forced reflow.
-          // rootMargin -25% bottom defines "above-the-fold" as the top 75%
-          // of the viewport, matching the prior `rect.top < vh*0.75` rule.
+          // browser computes the geometry off the main thread, so this
+          // replaces the previous getBoundingClientRect() loop that caused
+          // Lighthouse to flag a 76ms forced reflow.
+          //
+          // rootMargin -25% on the bottom defines "above-the-fold" as the
+          // top 75% of the viewport, matching the prior `rect.top < vh*0.75`
+          // condition.
           let revealIndex = 0;
           const firstPass = new IntersectionObserver(function (entries) {
             // Preserve document order so the above-fold stagger is stable.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1044,12 +1044,14 @@
    transition shorthand is always valid.
    ------------------------------------------------------------------------- */
 
-/* Clean ease-out curve: elements slide up and decelerate to a smooth stop on
-   entrance, no overshoot. This fade-in is for the non-LCP hero elements (badge,
-   description, actions); the LCP hero title uses the transform-only keyframe
-   below so it never fades, keeping its first paint at full opacity. The 0.01
-   start (not 0) keeps these faded elements as paint candidates so none is
-   misread as a late LCP if it ever becomes the largest element. */
+/* Clean ease-out (cubic-bezier(0.16, 1, 0.3, 1)) — the same curve used by the
+   scroll-reveal system below, so hero and content entrances share one motion
+   language: a quick rise that decelerates to a smooth stop, no overshoot.
+   This fade-in is for the non-LCP hero elements (badge, description, actions).
+   The LCP element — the hero title — uses the transform-only `hero-rise`
+   below so it never fades, keeping its first paint at full opacity. The
+   0.01 start (not 0) keeps these faded elements as paint candidates so none
+   is misread as a late LCP if it ever becomes the largest element. */
 @keyframes hero-slide-up {
   from {
     opacity: 0.01;
@@ -1057,19 +1059,6 @@
   }
   to {
     opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* Transform-only variant for the hero heading. The heading is the LCP
-   element, so it must never fade in: an element below full opacity can be
-   deferred or skipped as an LCP paint candidate. It slides up like the rest
-   of the hero but stays fully opaque from the first painted frame. */
-@keyframes hero-slide-up-solid {
-  from {
-    transform: translateY(80px);
-  }
-  to {
     transform: translateY(0);
   }
 }
@@ -1091,12 +1080,21 @@
 .animate-hero-stagger > *:nth-child(5)   { animation-delay: 360ms; }
 .animate-hero-stagger > *:nth-child(n+6) { animation-delay: 450ms; }
 
-/* The hero heading opts into the transform-only keyframe so it paints opaque
-   on frame 1. This selector outranks the `> *` rule above, so it overrides
-   only animation-name — duration, easing, fill mode and the per-position
-   animation-delay are all inherited unchanged. */
-.animate-hero-stagger > .hero-lcp-title {
-  animation-name: hero-slide-up-solid;
+/* The hero title holds the LCP text. Animate its transform only — it paints
+   at full opacity from the first frame, so Chrome times LCP at first paint
+   instead of part-way through an opacity fade. Overriding only the
+   animation-name keeps the stagger's duration, delay and easing; the title
+   still rides the slide-up, just without the fade. Reduced-motion users fall
+   through to the `animation: none` rule below. */
+@media (prefers-reduced-motion: no-preference) {
+  .animate-hero-stagger > .hero-title-slot {
+    animation-name: hero-rise;
+  }
+}
+
+@keyframes hero-rise {
+  from { transform: translateY(80px); }
+  to   { transform: translateY(0); }
 }
 
 /* Floating header drop-in: lands from above as the hero rises from below.
@@ -1126,24 +1124,15 @@
   will-change: opacity, transform;
 }
 
-[data-reveal][data-reveal-ease="smooth"] {
-  transition:
-    opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 1.1s cubic-bezier(0.22, 1, 0.36, 1);
-}
-
 [data-reveal="down"]  { transform: translateY(-96px); }
 [data-reveal="left"]  { transform: translateX(96px); }
 [data-reveal="right"] { transform: translateX(-96px); }
 [data-reveal="scale"] { transform: scale(0.88); }
 
-/* Below lg the two-column split sections stack vertically, so horizontal
-   left/right reveals slide sideways against the page's vertical flow — and
-   collide with the hero's slide-up on load. Redirect them to slide up too,
-   so all motion shares one direction on mobile. */
-@media (max-width: 1023.98px) {
-  [data-reveal="left"],
-  [data-reveal="right"] { transform: translateY(96px); }
+[data-reveal][data-reveal-ease="smooth"] {
+  transition:
+    opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 1.1s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 [data-reveal].is-visible {
@@ -1155,6 +1144,19 @@
 [data-reveal][data-reveal-delay="2"] { transition-delay: 200ms; }
 [data-reveal][data-reveal-delay="3"] { transition-delay: 300ms; }
 [data-reveal][data-reveal-delay="4"] { transition-delay: 400ms; }
+
+/* Below lg the two-column sections collapse to a single stacked column, so a
+   horizontal reveal slides content sideways while the hero above it rises —
+   two motion axes at once, which reads as awkward on phones and tablets.
+   Collapse left/right reveals to the default vertical rise here so every
+   entrance shares one axis with the hero. Desktop keeps its side-by-side
+   left/right reveals, and reduced-motion still flattens all of this below. */
+@media (max-width: 1023.98px) {
+  [data-reveal="left"],
+  [data-reveal="right"] {
+    transform: translateY(96px);
+  }
+}
 
 /* Cascading reveal for grids of cards. Each direct child stages in behind
    the previous when the parent intersects. Stagger and travel distance are
@@ -1194,7 +1196,7 @@
 /* Per-block reveal for long-form article bodies (single blog posts /
    single project pages). Each direct child of the prose container —
    paragraph, heading, list, image, blockquote, custom MDX block — is
-   given its own observer so it eases in as the reader scrolls to it. */
+   given its own observer so it springs in as the reader scrolls to it. */
 [data-reveal-content] > * {
   opacity: 0;
   transform: translateY(56px);
@@ -1227,7 +1229,6 @@
 @media (prefers-reduced-motion: reduce) {
   .animate-hero-slide-up,
   .animate-hero-stagger > *,
-  .animate-hero-stagger > .hero-lcp-title,
   .animate-header-drop {
     animation: none;
   }


### PR DESCRIPTION
Eliminate the deviations from the prior parity pass so the scroll-reveal and hero-entrance engine matches hansmartensdev/HansMartens exactly, verified by diffing the source (hero+reveal CSS region and the 141-line reveal observer both diff clean):

- global.css: restore HansMartens' hero-title-slot + hero-rise keyframe (gated to prefers-reduced-motion: no-preference) in place of the hero-lcp-title / hero-slide-up-solid variant; match the [data-reveal] block ordering, the mobile-collapse comment, and the reduced-motion list.
- BaseLayout.astro: the reveal observer is now identical to HansMartens.
- Hero / ProjectHero / ArticleHero: the hero title uses hero-title-slot only. HansMartens applies the LCP hook to the main hero; project and article titles ride the normal slide-up fade, as in HansMartens.

Only intentional difference: the TechStack process-card "spotlight" CSS and script are not ported, per instruction — HansMartens never enables it on a page.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
