### PR TITLE
Restore HansMartens' per-card reveal stagger on blog and project cards

### DIFF
--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -15,6 +15,19 @@ interface Props {
   author?: string;
   image?: ImageMetadata;
   svgSlug?: string;
+  /**
+   * Marks the first card on a listing page. On mobile it reveals on load with
+   * the standard animation instead of waiting for scroll, matching how the
+   * first card on pages without a heading above the grid (e.g. projects)
+   * already animates in.
+   */
+  eager?: boolean;
+  /**
+   * Stagger index for the scroll-reveal cascade. Maps to `data-reveal-delay`
+   * (1–4 → 100–400ms) so a grid of cards rises one after another instead of
+   * all at once. Pass the map index; 0 (or omitted) means no delay.
+   */
+  revealDelay?: number;
   class?: string;
 }
 
@@ -27,6 +40,8 @@ const {
   author,
   image,
   svgSlug,
+  eager = false,
+  revealDelay,
   class: className,
 } = Astro.props;
 
@@ -36,7 +51,7 @@ const estimatedWords = description.split(' ').length * 10; // Rough estimate
 const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
 ---
 
-<article class:list={["group rounded-lg border border-brand-500/30 bg-background p-6 shadow-md ring-1 ring-brand-500/20 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-brand-500 hover:shadow-lg", className]} data-reveal>
+<article class:list={["group rounded-lg border border-brand-500/30 bg-background p-6 shadow-md ring-1 ring-brand-500/20 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-brand-500 hover:shadow-lg", className]} data-reveal data-reveal-delay={revealDelay || undefined} data-reveal-eager={eager ? '' : undefined}>
 
   <a href={href} class="block">
     <div

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -59,7 +59,7 @@ const topTags = collectTopTags(posts, TAG_CLOUD_LIMIT);
           </h2>
 
           <div class="grid gap-6 sm:grid-cols-2">
-            {featuredPosts.map((post) => (
+            {featuredPosts.map((post, index) => (
               <BlogCard
                 title={post.data.title}
                 description={post.data.description}
@@ -69,6 +69,8 @@ const topTags = collectTopTags(posts, TAG_CLOUD_LIMIT);
                 author={post.data.author}
                 image={post.data.image}
                 svgSlug={post.data.svgSlug}
+                revealDelay={index % 2}
+                eager={index === 0}
               />
             ))}
           </div>
@@ -95,7 +97,7 @@ const topTags = collectTopTags(posts, TAG_CLOUD_LIMIT);
       {
         regularPosts.length > 0 ? (
           <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {regularPosts.map((post) => (
+            {regularPosts.map((post, index) => (
               <BlogCard
                 title={post.data.title}
                 description={post.data.description}
@@ -105,6 +107,8 @@ const topTags = collectTopTags(posts, TAG_CLOUD_LIMIT);
                 author={post.data.author}
                 image={post.data.image}
                 svgSlug={post.data.svgSlug}
+                revealDelay={index % 3}
+                eager={featuredPosts.length === 0 && index === 0}
               />
             ))}
           </div>

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -82,7 +82,7 @@ const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
       </div>
 
       <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {pagePosts.map((post) => (
+        {pagePosts.map((post, index) => (
           <BlogCard
             title={post.data.title}
             description={post.data.description}
@@ -92,6 +92,8 @@ const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
             author={post.data.author}
             image={post.data.image}
             svgSlug={post.data.svgSlug}
+            revealDelay={index % 3}
+            eager={index === 0}
           />
         ))}
       </div>

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -80,7 +80,7 @@ const { tag, posts, visibleTags } = Astro.props;
 
       {posts.length > 0 ? (
         <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {posts.map((post) => (
+          {posts.map((post, index) => (
             <BlogCard
               title={post.data.title}
               description={post.data.description}
@@ -90,6 +90,8 @@ const { tag, posts, visibleTags } = Astro.props;
               author={post.data.author}
               image={post.data.image}
               svgSlug={post.data.svgSlug}
+              revealDelay={index % 3}
+              eager={index === 0}
             />
           ))}
         </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -150,7 +150,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
       </div>
 
       <div class="grid gap-6 md:grid-cols-2">
-        {featuredProjects.map((project) => (
+        {featuredProjects.map((project, i) => (
           <Card
             variant="elevated"
             hover
@@ -158,6 +158,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
             href={project.data.placeholder ? undefined : `/projects/${project.id.replace(/\.mdx?$/, '')}`}
             class="group flex flex-col"
             data-reveal
+            data-reveal-delay={i || undefined}
           >
             <div class="flex flex-1 flex-col p-6">
               <div class="mb-3 flex items-start justify-between gap-4">
@@ -341,6 +342,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
             author={post.data.author}
             image={post.data.image}
             svgSlug={post.data.svgSlug}
+            revealDelay={index}
             class={index === 3 ? 'hidden sm:block lg:hidden' : undefined}
           />
         ))}

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -41,7 +41,7 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
       <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
 
         <div class="grid gap-6 md:grid-cols-2">
-          {projects.map((project) => (
+          {projects.map((project, i) => (
             <Card
               variant="elevated"
               hover
@@ -49,6 +49,7 @@ const projects = items.sort((a, b) => a.data.order - b.data.order);
               href={project.data.placeholder ? undefined : `/projects/${project.id.replace(/\.mdx?$/, '')}`}
               class="group flex flex-col"
               data-reveal
+              data-reveal-delay={i % 2 || undefined}
             >
               <div class="flex flex-1 flex-col p-6">
                 <div class="mb-3 flex items-start justify-between gap-4">


### PR DESCRIPTION
The blog and project cards had been stripped to a bare `data-reveal`, so their cascade depended on fold position and each page's eagerReveal flag — which is why the same card animated differently on the homepage versus its listing page. Restore HansMartens' explicit, index-based stagger so the cascade is deterministic and identical, verified line-by-line against the source:

- BlogCard.astro: add the `eager` and `revealDelay` props; the article now applies data-reveal-delay / data-reveal-eager.
- Homepage: blog cards revealDelay={index}; project cards data-reveal-delay={i}.
- projects/index: project cards data-reveal-delay={i % 2}.
- blog/index, blog/page/[page], blog/tag/[tag]: BlogCards pass revealDelay (index % 2 or % 3) and eager on the first card, matching HansMartens per page.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
