### PR TITLE
Add projects pagination mirroring the blog (#410)

### DIFF
--- a/src/components/projects/ProjectCard.astro
+++ b/src/components/projects/ProjectCard.astro
@@ -1,0 +1,56 @@
+---
+/**
+ * Project listing card. Extracted so the projects index, paginated pages,
+ * and tag archives render identical cards from one source of truth.
+ *
+ * Placeholder projects render as a non-interactive card (no link), matching
+ * how the listing treats projects that don't have their own detail page.
+ */
+import Card from '@/components/ui/data-display/Card/Card.astro';
+import Badge from '@/components/ui/data-display/Badge/Badge.astro';
+import Icon from '@/components/ui/primitives/Icon/Icon.astro';
+import type { CollectionEntry } from 'astro:content';
+import { getProjectSlug } from '@/lib/projects';
+
+interface Props {
+  project: CollectionEntry<'projects'>;
+  /** Stagger index for the scroll-reveal cascade. */
+  index?: number;
+}
+
+const { project, index = 0 } = Astro.props;
+const { data } = project;
+---
+
+<Card
+  variant="elevated"
+  hover
+  padding="none"
+  href={data.placeholder ? undefined : `/projects/${getProjectSlug(project.id)}`}
+  class="group flex flex-col"
+  data-reveal
+  data-reveal-delay={index % 2 || undefined}
+>
+  <div class="flex flex-1 flex-col p-6">
+    <div class="mb-3 flex items-start justify-between gap-4">
+      <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
+        <Icon name="layers" size="sm" />
+      </div>
+      <Icon name="arrow-up-right" size="sm" class="text-foreground-muted group-hover:text-brand-500 transition-colors shrink-0 ml-auto" />
+    </div>
+    <div class="mb-2 flex items-baseline gap-2">
+      <h3 class="font-display text-lg font-bold text-foreground">{data.title}</h3>
+      {data.year && (
+        <span class="text-xs text-foreground-muted">{data.year}</span>
+      )}
+    </div>
+    <p class="text-sm text-foreground-muted leading-relaxed mb-4 flex-1">{data.description}</p>
+    {data.tags && data.tags.length > 0 && (
+      <div class="flex flex-wrap gap-1.5">
+        {data.tags.map((tag) => (
+          <Badge variant="brand">#{tag}</Badge>
+        ))}
+      </div>
+    )}
+  </div>
+</Card>

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -13,6 +13,9 @@ export { tagToSlug, findTagBySlug } from '@/lib/tags';
 /** How many of the most-used tags to surface in a project tag cloud. */
 export const PROJECT_TAG_CLOUD_LIMIT = 10;
 
+/** Number of projects shown per page on the projects listing. */
+export const PROJECTS_PER_PAGE = 12;
+
 /** Strip the `.md`/`.mdx` extension from a project id to get its URL slug. */
 export function getProjectSlug(projectId: string): string {
   return projectId.replace(/\.mdx?$/, '');

--- a/src/pages/projects/page/[page].astro
+++ b/src/pages/projects/page/[page].astro
@@ -1,7 +1,9 @@
 ---
 /**
- * Projects page
- * URL: /projects
+ * Paginated projects listing
+ * URL: /projects/page/<n> (page 1 lives at /projects)
+ *
+ * Mirrors the blog pagination so the two listings behave identically.
  */
 import PageLayout from '@/layouts/PageLayout.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
@@ -19,24 +21,37 @@ import {
   PROJECTS_PER_PAGE,
 } from '@/lib/projects';
 
-const projects = await getVisibleProjects();
-const topTags = collectTopProjectTags(projects, PROJECT_TAG_CLOUD_LIMIT);
+export async function getStaticPaths() {
+  const projects = await getVisibleProjects();
+  const totalPages = Math.max(1, Math.ceil(projects.length / PROJECTS_PER_PAGE));
 
-// Page 1 lives here at /projects; /projects/page/2..N handle the rest.
-const totalPages = Math.max(1, Math.ceil(projects.length / PROJECTS_PER_PAGE));
-const pageProjects = projects.slice(0, PROJECTS_PER_PAGE);
+  // Page 1 lives at /projects; only emit /projects/page/2..N from this route.
+  const pages: { params: { page: string }; props: { page: number; totalPages: number } }[] = [];
+  for (let page = 2; page <= totalPages; page++) {
+    pages.push({ params: { page: String(page) }, props: { page, totalPages } });
+  }
+  return pages;
+}
+
+const { page, totalPages } = Astro.props;
+
+const projects = await getVisibleProjects();
+const start = (page - 1) * PROJECTS_PER_PAGE;
+const pageProjects = projects.slice(start, start + PROJECTS_PER_PAGE);
+
+const topTags = collectTopProjectTags(projects, PROJECT_TAG_CLOUD_LIMIT);
 ---
 
 <PageLayout
-  title="Projects — Astro Rocket"
-  description="Selected work — websites, tools, and open-source projects built by Astro Rocket."
+  title={`Projects — Page ${page}`}
+  description={`Page ${page} of ${totalPages} — selected work, tools, and open-source projects by Astro Rocket.`}
   eagerReveal
   footerBackground="secondary"
 >
   <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>
       <Icon name="layers" size="sm" />
-      Selected work
+      Page {page} of {totalPages}
     </Badge>
 
     <h1 slot="title">Projects</h1>
@@ -46,33 +61,37 @@ const pageProjects = projects.slice(0, PROJECTS_PER_PAGE);
     </p>
   </Hero>
 
-  <!-- All projects -->
-  {projects.length > 0 && (
-    <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">
-      <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
+  <section class="bg-background-secondary py-[var(--space-section-md)] border-t border-border">
+    <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
+      <div class="flex flex-col items-center gap-4" data-reveal>
+        <a
+          href="/projects"
+          class="group inline-flex items-center gap-2 rounded-lg border border-border-strong bg-transparent px-4 py-2 text-sm font-medium text-foreground-muted hover:border-brand-500 hover:text-brand-500 transition-colors"
+        >
+          <Icon name="arrow-left" size="sm" />
+          All projects
+        </a>
 
         {topTags.length > 0 && (
-          <div class="flex flex-col items-center gap-4" data-reveal>
-            <ProjectTagList tags={topTags} class="justify-center" />
-          </div>
+          <ProjectTagList tags={topTags} class="justify-center" />
         )}
-
-        <div class="grid gap-6 md:grid-cols-2">
-          {pageProjects.map((project, i) => (
-            <ProjectCard project={project} index={i} />
-          ))}
-        </div>
-
-        <Pagination
-          currentPage={1}
-          totalPages={totalPages}
-          href={(p) => (p === 1 ? '/projects' : `/projects/page/${p}`)}
-        />
       </div>
-    </section>
-  )}
 
- <!-- CTA -->
+      <div class="grid gap-6 md:grid-cols-2">
+        {pageProjects.map((project, i) => (
+          <ProjectCard project={project} index={i} />
+        ))}
+      </div>
+
+      <Pagination
+        currentPage={page}
+        totalPages={totalPages}
+        href={(p) => (p === 1 ? '/projects' : `/projects/page/${p}`)}
+      />
+    </div>
+  </section>
+
+  <!-- CTA -->
   <section class="relative z-10 py-[var(--space-section-md)] bg-background">
     <!-- Mobile: flat section, no card -->
     <div class="glitch:hidden mx-auto max-w-2xl px-6 text-center" data-reveal>

--- a/src/pages/projects/tag/[tag].astro
+++ b/src/pages/projects/tag/[tag].astro
@@ -4,16 +4,15 @@
  * URL: /projects/tag/<slug>
  */
 import PageLayout from '@/layouts/PageLayout.astro';
+import ProjectCard from '@/components/projects/ProjectCard.astro';
 import ProjectTagList from '@/components/projects/ProjectTagList.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
-import Card from '@/components/ui/data-display/Card/Card.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import { Hero } from '@/components/hero';
 import {
   collectProjectTags,
   collectTopProjectTags,
-  getProjectSlug,
   getVisibleProjects,
   tagToSlug,
 } from '@/lib/projects';
@@ -85,38 +84,7 @@ const { tag, projects, visibleTags } = Astro.props;
       {projects.length > 0 ? (
         <div class="grid gap-6 md:grid-cols-2">
           {projects.map((project, i) => (
-            <Card
-              variant="elevated"
-              hover
-              padding="none"
-              href={project.data.placeholder ? undefined : `/projects/${getProjectSlug(project.id)}`}
-              class="group flex flex-col"
-              data-reveal
-              data-reveal-delay={i % 2 || undefined}
-            >
-              <div class="flex flex-1 flex-col p-6">
-                <div class="mb-3 flex items-start justify-between gap-4">
-                  <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
-                    <Icon name="layers" size="sm" />
-                  </div>
-                  <Icon name="arrow-up-right" size="sm" class="text-foreground-muted group-hover:text-brand-500 transition-colors shrink-0 ml-auto" />
-                </div>
-                <div class="mb-2 flex items-baseline gap-2">
-                  <h3 class="font-display text-lg font-bold text-foreground">{project.data.title}</h3>
-                  {project.data.year && (
-                    <span class="text-xs text-foreground-muted">{project.data.year}</span>
-                  )}
-                </div>
-                <p class="text-sm text-foreground-muted leading-relaxed mb-4 flex-1">{project.data.description}</p>
-                {project.data.tags && project.data.tags.length > 0 && (
-                  <div class="flex flex-wrap gap-1.5">
-                    {project.data.tags.map((t) => (
-                      <Badge variant="brand">#{t}</Badge>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </Card>
+            <ProjectCard project={project} index={i} />
           ))}
         </div>
       ) : (


### PR DESCRIPTION
- Add /projects/page/[page] route (page 1 stays at /projects), reusing the generic blog Pagination component.
- Extract a shared ProjectCard component so the index, paginated pages, and tag archives render identical cards from one source of truth.
- Add PROJECTS_PER_PAGE (12) and slice the listing accordingly; the pagination control only renders once projects exceed one page.

https://claude.ai/code/session_01MQqCj1oxdYhqkq7nv961Am

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
