### PR TITLE
feat: homepage hero tech-stack marquee + mobile portrait logos

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -49,12 +49,31 @@ const hasTitleSlot = Astro.slots.has('title');
 const hasDescriptionSlot = Astro.slots.has('description');
 const hasActionsSlot = Astro.slots.has('actions');
 const hasAsideSlot = Astro.slots.has('aside');
+const hasBottomSlot = Astro.slots.has('bottom');
 
 // Compute alignment based on layout
 const alignment = layout === 'centered' ? 'text-center items-center' : 'text-left items-start';
 
+// When a bottom slot is used in a full-height hero, lay the section out as a flex
+// column so the slot can be pushed to the floor (mt-auto) while the CONTENT stays
+// at the top — leftover height then opens up BETWEEN them (the roomy "Chrome
+// look"). The column `gap` is a GUARANTEED minimum gap, so the slot never crowds
+// the content on short windows. Tunable per hero via --hero-floor-gap (default 4rem).
+const isFlooredBottom = fullHeight && hasBottomSlot;
+
 // Compute classes
-const sectionClasses = cn(heroSectionVariants({ size }), fullHeight && 'min-h-[100dvh]', className);
+const sectionClasses = cn(
+  heroSectionVariants({ size }),
+  // Full-viewport hero: stretch to at least the viewport height. Uses svh (stable
+  // small viewport) rather than dvh so the hero does NOT resize as the mobile
+  // browser's address bar shows/hides on scroll; capped so it never grows too tall
+  // on large monitors.
+  fullHeight && 'min-h-[min(100svh,60rem)]',
+  // Floored bottom slot (e.g. the homepage tech-stack marquee): flex column so the
+  // slot floats to the floor with a guaranteed minimum gap above it.
+  isFlooredBottom && 'flex flex-col gap-[var(--hero-floor-gap,4rem)]',
+  className
+);
 
 const contentClasses = cn(
   'z-10 flex flex-col',
@@ -172,6 +191,20 @@ const gridClasses = cn(
       </div>
     )}
   </div>
+
+  {/* Bottom slot — e.g. the homepage tech-stack marquee, in place of the scroll
+      indicator. In a full-height hero it's the last flex child, pushed to the
+      floor with mt-auto so the content stays at the top and leftover height opens
+      up between them; the section's column `gap` guarantees a minimum gap so it
+      never crowds on short windows. Outside full-height it falls back to absolute. */}
+  {hasBottomSlot && (
+    <div class={cn(
+      'hero-bottom-slot z-10 w-full',
+      isFlooredBottom ? 'relative mt-auto' : 'absolute inset-x-0 bottom-0'
+    )}>
+      <slot name="bottom" />
+    </div>
+  )}
 </section>
 
 <style>

--- a/src/components/ui/primitives/Icon/Icon.astro
+++ b/src/components/ui/primitives/Icon/Icon.astro
@@ -45,6 +45,8 @@ const iconMap: Record<string, string> = {
   'brand-tailwind':   'simple-icons:tailwindcss',
   'brand-typescript': 'simple-icons:typescript',
   'brand-react':      'simple-icons:react',
+  'brand-github':     'simple-icons:github',
+  'brand-vercel':     'simple-icons:vercel',
   'brand-mdx':        'simple-icons:mdx',
   'brand-claude':     'simple-icons:anthropic',
 };

--- a/src/components/ui/primitives/Icon/Icon.tsx
+++ b/src/components/ui/primitives/Icon/Icon.tsx
@@ -43,6 +43,8 @@ const iconMap: Record<string, string> = {
   'brand-tailwind':   'simple-icons:tailwindcss',
   'brand-typescript': 'simple-icons:typescript',
   'brand-react':      'simple-icons:react',
+  'brand-github':     'simple-icons:github',
+  'brand-vercel':     'simple-icons:vercel',
   'brand-mdx':        'simple-icons:mdx',
   'brand-claude':     'simple-icons:anthropic',
 };

--- a/src/content/stack/github.mdx
+++ b/src/content/stack/github.mdx
@@ -1,0 +1,9 @@
+---
+name: "GitHub"
+description: "Version control and the home for every project, with CI running on each push."
+version: "latest"
+url: "https://github.com"
+icon: "brand-github"
+colorOklch: "20% 0 0"
+order: 6
+---

--- a/src/content/stack/vercel.mdx
+++ b/src/content/stack/vercel.mdx
@@ -1,0 +1,9 @@
+---
+name: "Vercel"
+description: "Zero-config deployment with edge functions and an instant global CDN — git push and it's live."
+version: "latest"
+url: "https://vercel.com"
+icon: "brand-vercel"
+colorOklch: "0% 0 0"
+order: 5
+---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,6 +25,22 @@ const posts = (await getCollection('blog', ({ data }) => data.locale === default
     return b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf();
   })
   .slice(0, 4);
+
+// Hero marquee — a focused subset of the tech stack, in this order, pulled from
+// the same `stack` collection so icons and links stay single-sourced. Six logos
+// are wide enough to fill the constrained hero width and loop seamlessly on their
+// own; the Tech-stack section further down still shows the full stack.
+const heroStackOrder = ['Astro', 'Tailwind CSS', 'TypeScript', 'React', 'GitHub', 'Vercel'];
+const heroStackItems = (await getCollection('stack'))
+  .filter((e) => heroStackOrder.includes(e.data.name))
+  .sort((a, b) => heroStackOrder.indexOf(a.data.name) - heroStackOrder.indexOf(b.data.name))
+  .map((e) => ({
+    name: e.data.name,
+    icon: e.data.icon,
+    url: e.data.url,
+    version: e.data.version,
+    colorOklch: e.data.colorOklch,
+  }));
 ---
 
 <LandingLayout
@@ -35,7 +51,7 @@ const posts = (await getCollection('blog', ({ data }) => data.locale === default
   includeProfessionalServiceSchema={true}
 >
   <!-- Hero -->
-  <Hero layout="centered" size="xl" class="hero-dark-gradient" showScrollIndicator fullHeight>
+  <Hero layout="centered" size="xl" class="hero-dark-gradient" fullHeight>
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">Available for new projects</Badge>
 
     <h1 slot="title" class="!text-[clamp(2rem,11.2vw,3rem)] sm:!text-5xl md:!text-6xl lg:!text-7xl">
@@ -58,6 +74,31 @@ const posts = (await getCollection('blog', ({ data }) => data.locale === default
         <Icon name="arrow-right" size="sm" />
       </Button>
     </Fragment>
+
+    <!-- Tech-stack marquee floored into the hero in place of the scroll indicator:
+         the content stays at the top and the marquee sits low near the bottom, with
+         a roomy gap above it (a guaranteed minimum gap, so it never crowds the
+         CTAs). Constrained to the content width; one decorative row; hidden on
+         phones. cardWidth="auto" lets each card hug its logo + name so the logos sit
+         close together; StackMarquee repeats the set to fill the row so the loop
+         stays seamless. -->
+    <div slot="bottom" class="mx-auto w-full max-w-6xl px-6">
+      <!-- Tablet & up: the animated tech-stack marquee. -->
+      <div class="hp-hero-marquee" aria-hidden="true">
+        <StackMarquee items={heroStackItems} rows={1} duration={55} pauseOnHover={false} linked={false} cardWidth="auto" gap="1rem" />
+      </div>
+      <!-- Portrait phone: a static, non-animated row of the four core-stack logos.
+           No marquee machinery — no duplicated track and no infinite animation — so
+           there's zero ongoing compositor/battery cost on mobile. Logos only,
+           non-interactive, with a one-time fade-in to match the marquee's entrance. -->
+      <div class="hp-hero-logos" aria-hidden="true">
+        {heroStackItems.slice(0, 4).map((item) => (
+          <span class="hp-hero-logo">
+            <Icon name={item.icon} size="lg" />
+          </span>
+        ))}
+      </div>
+    </div>
   </Hero>
 
   <!-- Services Section -->
@@ -487,6 +528,96 @@ const posts = (await getCollection('blog', ({ data }) => data.locale === default
     .stack-marquee-section { display: none; }
     section.cta-section { background-color: var(--color-background); }
     footer.home-footer { background-color: var(--color-background-secondary); }
+  }
+
+  /* ── Homepage hero tech-stack marquee ──────────────────────────────────────
+     A decorative tech-stack strip floored into the hero in place of the scroll
+     indicator. It must stay secondary to the H1 / description / CTAs, so we strip
+     the card "box" (brand border, glow ring, panel surface) and let the
+     brand-coloured logos float on the hero gradient as light accents. The logos
+     keep their brand colour and soft chip; only the surrounding chrome is removed. */
+  .hp-hero-marquee .stack-marquee-item > * {
+    background: transparent;   /* drop the card panel */
+    border-color: transparent; /* drop the brand border */
+    box-shadow: none;          /* drop the brand glow ring */
+    padding-left: var(--space-3);  /* tighter now there's no box, so logos sit closer */
+    padding-right: var(--space-3);
+  }
+  /* Lighter, calmer tool names so the colourful logos lead the eye. */
+  .hp-hero-marquee .stack-marquee-item .font-display {
+    font-weight: 500;
+    color: var(--color-foreground-muted);
+  }
+
+  /* Floored into the hero: the marquee is the section's last flex child, pushed to
+     the floor (mt-auto, in Hero.astro). The CONTENT stays at the top and the
+     leftover hero height opens up BETWEEN the CTAs and the marquee — the roomy
+     "Chrome look". The section's column `gap` (--hero-floor-gap) is a GUARANTEED
+     MINIMUM gap, so on shorter windows the marquee can never crowd the buttons;
+     taller windows simply get more room. padding-bottom is the breathing room
+     beneath it. */
+  section.hero-dark-gradient {
+    --hero-floor-gap: var(--space-16); /* 4rem — minimum gap above the marquee */
+    padding-bottom: var(--space-16); /* 4rem — breathing room below it */
+  }
+  .hp-hero-marquee {
+    pointer-events: none; /* decorative; never intercepts taps */
+  }
+
+  /* Entrance: the marquee sits outside the content stagger container, so it fades
+     in on its own once the hero has settled (a vertical slide would fight the
+     logos' horizontal scroll). */
+  @media (prefers-reduced-motion: no-preference) {
+    .hp-hero-marquee {
+      animation: hp-hero-marquee-fade 0.6s ease-out 1.2s backwards;
+    }
+  }
+  @keyframes hp-hero-marquee-fade {
+    from { opacity: 0.01; }
+    to   { opacity: 1; }
+  }
+
+  /* Hidden on phones — portrait (width) and landscape (short + coarse pointer),
+     matching the tech-stack section's behaviour. Shown from tablet up. */
+  @media (max-width: 767px) {
+    .hp-hero-marquee { display: none; }
+  }
+  @media (orientation: landscape) and (max-height: 500px) and (pointer: coarse) {
+    .hp-hero-marquee { display: none; }
+  }
+
+  /* Portrait-phone static stack logos — the lightweight counterpart to the
+     marquee. Hidden by default and shown only on portrait phones, exactly where
+     the marquee is hidden. A centered, non-interactive row: no links and no
+     animation loop, so it costs nothing after paint. */
+  .hp-hero-logos {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    pointer-events: none;
+  }
+  @media (max-width: 767px) and (orientation: portrait) {
+    .hp-hero-logos { display: flex; }
+  }
+
+  .hp-hero-logo {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    border-radius: 9999px;
+    color: var(--color-brand-500);
+    background: color-mix(in oklch, var(--color-brand-500) 12%, transparent);
+  }
+
+  /* One-time fade-in only (reuses the marquee's keyframe); nothing loops. */
+  @media (prefers-reduced-motion: no-preference) {
+    .hp-hero-logos {
+      animation: hp-hero-marquee-fade 0.6s ease-out 1.2s backwards;
+    }
   }
 </style>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -411,7 +411,7 @@ const heroStackItems = (await getCollection('stack'))
           </h2>
         </div>
         <p class="text-lg text-foreground-muted max-w-2xl mx-auto">
-          I use the best of the modern web to build websites.
+          Modern, proven tools — only the best.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

Syncs the HansMartens homepage hero treatment into Astro Rocket: the tech-stack marquee now floors into the hero, with a lightweight static logo row for portrait phones. Also updates the standalone tech-stack section copy.

## Changes

**Hero marquee (in the hero)**
- `Hero.astro` — added a `bottom` slot. In a full-height hero it lays out as a flex column so the slot floors to the bottom (`mt-auto`) with a guaranteed minimum gap above it (the "floored marquee in place of the scroll indicator" treatment). Also switched `fullHeight` from `100dvh` to `min(100svh,60rem)` so the floored content doesn't jump as the mobile address bar shows/hides. **Purely additive** — existing props (`showGlow`/`showBlob`/`showGrid`/`showHeroHalo`/`split`) and the other Hero usages are untouched.
- `index.astro` — floors an animated **6-logo** strip (Astro, Tailwind, TypeScript, React, GitHub, Vercel) on tablet+, with the card chrome stripped so logos float on the gradient. Dropped `showScrollIndicator` (the marquee replaces it).

**4 icons — mobile portrait variant**
- On portrait phones (where the marquee is hidden), a **static, non-animated row of the 4 core logos** (Astro, Tailwind, TypeScript, React) renders instead — no animation/battery cost after paint.

**Supporting**
- `Icon.astro` + `Icon.tsx` — added `brand-github` → `simple-icons:github` and `brand-vercel` → `simple-icons:vercel`.
- `stack` collection — added `github.mdx` + `vercel.mdx` so the 6-logo marquee stays single-sourced from the same collection.

**Copy**
- Tech-stack section description updated to "Modern, proven tools — only the best." (pill "Tech stack" and H2 "Building with the best" unchanged).

## Notes
- Kept the standalone "Building with the best" tech-stack section (additive — not removed). Since GitHub + Vercel were added to the `stack` collection, that section now also shows all 6 logos.

## Verification
- `pnpm check` — 0 errors
- `pnpm build` — success (new icons resolve via the SVG sprite)
- `pnpm lint` — clean
- Confirmed in the built HTML: hero marquee (6 logos), portrait row (4 logos, correct order), floored flex layout, and the scroll-indicator element removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oJ3cFmjyHSmPdEZBRQDCB

---
_Generated by [Claude Code](https://claude.ai/code/session_013oJ3cFmjyHSmPdEZBRQDCB)_