### PR TITLE
Add Claude to the homepage hero marquee

### DIFF
--- a/src/components/ui/primitives/Icon/Icon.astro
+++ b/src/components/ui/primitives/Icon/Icon.astro
@@ -48,7 +48,7 @@ const iconMap: Record<string, string> = {
   'brand-github':     'simple-icons:github',
   'brand-vercel':     'simple-icons:vercel',
   'brand-mdx':        'simple-icons:mdx',
-  'brand-claude':     'simple-icons:anthropic',
+  'brand-claude':     'simple-icons:claude',
 };
 
 const resolvedName = iconMap[name] ?? `lucide:${name}`;

--- a/src/components/ui/primitives/Icon/Icon.tsx
+++ b/src/components/ui/primitives/Icon/Icon.tsx
@@ -46,7 +46,7 @@ const iconMap: Record<string, string> = {
   'brand-github':     'simple-icons:github',
   'brand-vercel':     'simple-icons:vercel',
   'brand-mdx':        'simple-icons:mdx',
-  'brand-claude':     'simple-icons:anthropic',
+  'brand-claude':     'simple-icons:claude',
 };
 
 export function Icon({

--- a/src/content/stack/claude.mdx
+++ b/src/content/stack/claude.mdx
@@ -1,0 +1,9 @@
+---
+name: "Claude"
+description: "AI pair programming with Claude Code — plan, write, and ship features right from the terminal."
+version: "latest"
+url: "https://claude.com/claude-code"
+icon: "brand-claude"
+colorOklch: "67.2% 0.131 39"
+order: 7
+---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,10 +27,10 @@ const posts = (await getCollection('blog', ({ data }) => data.locale === default
   .slice(0, 4);
 
 // Hero marquee — a focused subset of the tech stack, in this order, pulled from
-// the same `stack` collection so icons and links stay single-sourced. Six logos
+// the same `stack` collection so icons and links stay single-sourced. Seven logos
 // are wide enough to fill the constrained hero width and loop seamlessly on their
 // own; the Tech-stack section further down still shows the full stack.
-const heroStackOrder = ['Astro', 'Tailwind CSS', 'TypeScript', 'React', 'GitHub', 'Vercel'];
+const heroStackOrder = ['Astro', 'Tailwind CSS', 'TypeScript', 'React', 'GitHub', 'Vercel', 'Claude'];
 const heroStackItems = (await getCollection('stack'))
   .filter((e) => heroStackOrder.includes(e.data.name))
   .sort((a, b) => heroStackOrder.indexOf(a.data.name) - heroStackOrder.indexOf(b.data.name))


### PR DESCRIPTION
Point the `brand-claude` icon at the Claude symbol (simple-icons:claude) rather than the Anthropic wordmark, add a single-source `claude` stack entry, and include "Claude" in the hero marquee order so the Claude symbol and text scroll alongside the rest of the stack. As the marquee is fed from the shared stack collection, Claude also appears in the "Building with the best" tech-stack section.


Claude-Session: https://claude.ai/code/session_01727XYuAMUQK2YYMyRJxQqQ

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
