### PR TITLE
Slow down the homepage Tech stack marquee

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -416,7 +416,7 @@ const heroStackItems = (await getCollection('stack'))
       </div>
 
       <div data-reveal data-reveal-delay="1">
-        <StackMarquee />
+        <StackMarquee duration={70} />
       </div>
     </div>
   </section>


### PR DESCRIPTION
The 2-row tech-stack marquee ran on the component default of 40s per loop, which felt too fast. Pass an explicit duration of 70s so both rows (row 2 derives a touch faster at 66s) scroll more calmly.


Claude-Session: https://claude.ai/code/session_01UXqUhMQ2mrmro4oKfcLGGg

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
