### PR TITLE
Add 2rem bottom padding under hero stack logos on mobile portrait

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -598,7 +598,7 @@ const heroStackItems = (await getCollection('stack'))
     pointer-events: none;
   }
   @media (max-width: 767px) and (orientation: portrait) {
-    .hp-hero-logos { display: flex; }
+    .hp-hero-logos { display: flex; padding-bottom: 2rem; }
   }
 
   .hp-hero-logo {


### PR DESCRIPTION
Adds 2rem of padding beneath the static four-logo row in the homepage hero. Scoped to the existing mobile-portrait media query, the only breakpoint where these logos are shown.


Claude-Session: https://claude.ai/code/session_01317CbVdeaxjFn2hn2oBQbR

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
