### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.8.0] — 2026-06-21
+
 ### Added
 
 - **Blog comments are now pluggable — added a [Cusdis](https://cusdis.com) provider alongside Giscus** — `articleFeatures.comments` gained a `provider` switch (`'giscus' | 'cusdis'`) and a `cusdis` config block (`appId`, optional `host` for self-hosting, `theme`, `lang`). Cusdis is a lightweight, privacy-friendly, optionally self-hosted comment system; it's wired with the same care as the existing Giscus integration — server-rendered placeholder with reserved height (no CLS), **lazy-loaded** on scroll so readers who don't reach the comments pay zero network cost, and theme/locale that follow the site by default. The `Comments` component is now a thin dispatcher that renders one of `CommentsGiscus`/`CommentsCusdis`, so only the selected provider's client script ships, and `BaseLayout`'s `preconnect` points at the active provider's host. Existing sites are unaffected: `provider` defaults to `'giscus'`. Note: Cusdis has no live theme API (unlike Giscus's `postMessage`), so in adaptive mode a light/dark toggle re-renders the thread (a brief reload) — set `theme` to `'auto'`/`'light'`/`'dark'` to opt out. Requested in #423. (#423)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-rocket",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Astro Rocket — A production-ready Astro 6 theme built on Tailwind CSS v4",
   "type": "module",
   "author": "Hans Martens",


### PR DESCRIPTION
Bump version 1.7.0 → 1.8.0 and roll the accumulated [Unreleased] changelog entries under a dated 1.8.0 heading. A minor release: backward-compatible features and localization (#414, #421, #422, #423, #437, #438) with no breaking changes.


Claude-Session: https://claude.ai/code/session_01DHNFMApaQmMW4NEmGPei7Y

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
