### PR TITLE
Replace homepage Tech stack with about-page marquee; keep zebra

### DIFF
--- a/src/components/landing/TechStack.astro
+++ b/src/components/landing/TechStack.astro
@@ -1,14 +1,20 @@
 ---
 /**
- * TechStack — MDX-driven stack showcase
+ * TechStack — responsive stack showcase
  *
- * Content lives in src/content/stack/*.mdx — add, remove, or
- * edit a tool there without touching this component.
+ * Phones get a focused 2×2 grid of four core-stack cards (Astro, Tailwind CSS,
+ * TypeScript, React). Tablet and up swap those cards for the full double-row
+ * marquee (the same one the homepage uses), while the badge / title / description
+ * header stays the same across every breakpoint.
+ *
+ * The card content is driven by src/content/stack/*.mdx; the marquee pulls from
+ * the same collection — so adding or editing a tool stays a single MDX edit.
  */
 import { getCollection } from 'astro:content';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import Card from '@/components/ui/data-display/Card/Card.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
+import StackMarquee from '@/components/landing/StackMarquee.astro';
 
 interface Props {
   title?: string;
@@ -19,8 +25,13 @@ interface Props {
 
 const { title, description, badge, background = 'secondary' } = Astro.props;
 
+// Phone-only cards: a focused subset of the stack, in stack order. Tablet & up
+// show the full marquee instead, so these four only ever render on phones.
+const cardNames = ['Astro', 'Tailwind CSS', 'TypeScript', 'React'];
 const items = await getCollection('stack');
-const stack = items.sort((a, b) => a.data.order - b.data.order);
+const cards = items
+  .filter((item) => cardNames.includes(item.data.name))
+  .sort((a, b) => a.data.order - b.data.order);
 
 const bgClass = background === 'primary' ? 'bg-background' : 'bg-background-secondary';
 ---
@@ -44,8 +55,10 @@ const bgClass = background === 'primary' ? 'bg-background' : 'bg-background-seco
         )}
       </div>
     )}
-    <div class="grid grid-cols-2 gap-[var(--space-content-gap)] md:grid-cols-4" data-reveal-children>
-      {stack.map((item) => (
+
+    {/* Phones: a static 2×2 grid of the four core-stack cards. */}
+    <div class="tech-cards" data-reveal-children>
+      {cards.map((item) => (
         <div
           style={`--tech-color: oklch(${item.data.colorOklch}); --tech-bg: oklch(${item.data.colorOklch} / 0.1);`}
         >
@@ -59,6 +72,11 @@ const bgClass = background === 'primary' ? 'bg-background' : 'bg-background-seco
           </Card>
         </div>
       ))}
+    </div>
+
+    {/* Tablet & up: the full double-row marquee — the same one the homepage uses. */}
+    <div class="tech-marquee" data-reveal data-reveal-delay="1">
+      <StackMarquee duration={70} />
     </div>
   </div>
 </section>
@@ -74,5 +92,26 @@ const bgClass = background === 'primary' ? 'bg-background' : 'bg-background-seco
     border-radius: var(--radius-full);
     color: var(--color-brand-500);
     background: color-mix(in srgb, var(--color-brand-500) 10%, transparent);
+  }
+
+  /* ─── Responsive swap: four cards on phones, the double-row marquee on
+     everything else. The breakpoints mirror the homepage's "phone" definition —
+     portrait by width, and landscape phones by short height + a coarse pointer
+     (which excludes tablets and laptops) — so both pages agree on what a phone
+     is. Default (tablet/desktop) shows the marquee. ────────────────────────── */
+  .tech-marquee { display: block; }
+  .tech-cards {
+    display: none;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-content-gap);
+  }
+
+  @media (max-width: 767px) {
+    .tech-marquee { display: none; }
+    .tech-cards { display: grid; }
+  }
+  @media (orientation: landscape) and (max-height: 500px) and (pointer: coarse) {
+    .tech-marquee { display: none; }
+    .tech-cards { display: grid; }
   }
 </style>

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -64,6 +64,6 @@ const {
 
   <slot />
 
-  <!-- Footer defaults to `background` so it alternates with the secondary CTA above while the marquee is shown; on phones .home-footer reverts it to secondary (see the homepage zebra swap in index.astro) -->
-  <Footer slot="footer" layout="simple" background="default" class="home-footer" />
+  <!-- Footer is `secondary` so it alternates with the `background` CTA section above it. -->
+  <Footer slot="footer" layout="simple" background="secondary" />
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -401,29 +401,8 @@ const heroStackItems = (await getCollection('stack'))
     </div>
   </section>
 
- <!-- Tech stack marquee — its own section in the 2-tone zebra. It follows the secondary Blog section, so it flips to `background` like the next stripe. Hidden on phones (portrait + landscape) via .stack-marquee-section; when it drops out, Blog (secondary) → CTA (background) still alternate, so the zebra holds on mobile too. -->
-  <section class="stack-marquee-section relative z-10 py-[var(--space-section-md)] bg-background border-t border-border">
-    <div class="mx-auto max-w-6xl px-6 flex flex-col gap-8">
-      <div class="flex flex-col items-center gap-4 text-center" data-reveal>
-        <div class="flex flex-col items-center gap-6">
-          <Badge variant="brand" pill>Tech stack</Badge>
-          <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
-            Building with the best
-          </h2>
-        </div>
-        <p class="text-lg text-foreground-muted max-w-2xl mx-auto">
-          Modern, proven tools — only the best.
-        </p>
-      </div>
-
-      <div data-reveal data-reveal-delay="1">
-        <StackMarquee duration={70} />
-      </div>
-    </div>
-  </section>
-
- <!-- CTA — secondary by default so it alternates with the Marquee (background) above and the Footer (background) below while the marquee is shown; on phones (marquee hidden) .cta-section reverts it to background so Blog → CTA → Footer still alternates -->
-  <section class="cta-section relative z-10 py-[var(--space-section-md)] bg-background-secondary border-t border-border">
+ <!-- CTA — `background` so it alternates with the secondary Blog section above and the secondary Footer below. -->
+  <section class="relative z-10 py-[var(--space-section-md)] bg-background border-t border-border">
     <!-- Mobile: flat section, no card -->
     <div class="glitch:hidden mx-auto max-w-2xl px-6 text-center" data-reveal>
       <Badge variant="brand" pill class="mb-6">Let's talk</Badge>
@@ -508,27 +487,6 @@ const heroStackItems = (await getCollection('stack'))
     .hero-dark-gradient .hero-title-slot + div {
       max-width: 48rem;
     }
-  }
-
-  /* Mobile-phone zebra swap. On phones — portrait (caught by width) and
-     landscape (wider than the md breakpoint, so caught by short height + a
-     coarse/touch pointer, which excludes tablets and laptops) — the marquee
-     band is hidden and the CTA + footer revert to their no-marquee colours.
-     The default (tablet/desktop, marquee shown) order is:
-       Blog(secondary) → Marquee(background) → CTA(secondary) → Footer(background)
-     and on phones it collapses to:
-       Blog(secondary) → CTA(background) → Footer(secondary)
-     so every adjacent section alternates in both states. The element+class
-     selectors outrank the Tailwind bg utilities, so no !important is needed. */
-  @media (max-width: 767px) {
-    .stack-marquee-section { display: none; }
-    section.cta-section { background-color: var(--color-background); }
-    footer.home-footer { background-color: var(--color-background-secondary); }
-  }
-  @media (orientation: landscape) and (max-height: 500px) and (pointer: coarse) {
-    .stack-marquee-section { display: none; }
-    section.cta-section { background-color: var(--color-background); }
-    footer.home-footer { background-color: var(--color-background-secondary); }
   }
 
   /* ── Homepage hero tech-stack marquee ──────────────────────────────────────


### PR DESCRIPTION
Homepage:
- Remove the standalone "Tech stack" StackMarquee section.
- Preserve the zebra: flip the CTA to `background` and the footer to `secondary` so Blog -> CTA -> Footer still alternates, and drop the now-unused mobile zebra-swap CSS and helper classes.

About page (TechStack):
- Phones: show only the Astro, Tailwind CSS, TypeScript and React cards.
- Tablet and up: swap those four cards for the full double-row marquee (the same one the homepage used), keeping the badge, heading and description across every breakpoint.


Claude-Session: https://claude.ai/code/session_018KcsQwZf13KcQSsiFcZaE1

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
