### PR TITLE
Remove text-pretty from About and Open Source paragraphs

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -47,10 +47,10 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
               A solid foundation for any project
             </h2>
           </div>
-          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
+          <p class="text-lg text-foreground-muted leading-relaxed sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             Astro Rocket is a production-ready starter theme built on Astro 6. It ships with a full component library, 12 hand-crafted themes, dark mode, built-in i18n, and a blog — so you can focus on building your project, not the boilerplate.
           </p>
-          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
+          <p class="text-lg text-foreground-muted leading-relaxed sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             It's free, MIT licensed, and listed on the official Astro themes directory. Clone it, customise it, and ship something you're proud of.
           </p>
         </div>
@@ -340,7 +340,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
           <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
             Built in the open
           </h2>
-          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
+          <p class="text-lg text-foreground-muted leading-relaxed sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             Astro Rocket is free, open source, and MIT licensed. Browse the source, open issues, submit PRs, or just clone it and build something great.
           </p>
           <Button variant="outline" size="lg" href="https://github.com/hansmartensdev/astro-rocket" target="_blank" rel="noopener noreferrer" class="self-start sm:self-center glitch:self-start mt-2">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -320,10 +320,10 @@ const heroStackItems = (await getCollection('stack'))
               <span class="text-brand-500">and blogger.</span>
             </h2>
           </div>
-          <p class="text-lg text-foreground-muted leading-relaxed text-pretty mb-4 sm:mb-0 sm:max-w-xl glitch:mb-4 glitch:max-w-none">
+          <p class="text-lg text-foreground-muted leading-relaxed mb-4 sm:mb-0 sm:max-w-xl glitch:mb-4 glitch:max-w-none">
            Sixteen years of hands-on experience{siteConfig.address?.city ? `, based in ${siteConfig.address.city}${siteConfig.address.country ? `, ${siteConfig.address.country}` : ''}` : ''} and available for clients worldwide. I build with Astro because it aligns with how I think about the web: lean, purposeful, and built to last.
           </p>
-          <p class="text-lg text-foreground-muted leading-relaxed text-pretty mb-8 sm:max-w-xl glitch:max-w-none sm:hidden glitch:block">
+          <p class="text-lg text-foreground-muted leading-relaxed mb-8 sm:max-w-xl glitch:max-w-none sm:hidden glitch:block">
            On the blog, I share the ideas and decisions that shape my work.
           </p>
            <Button variant="outline" href="/about" class="self-start sm:self-center glitch:self-start sm:hidden glitch:inline-flex">


### PR DESCRIPTION
The body paragraphs in the homepage "About me" section and the about page "Free & Open Source" and "Open Source" sections used text-pretty (text-wrap: pretty), which wrapped awkwardly. Remove the class so these paragraphs wrap with the normal browser default.


Claude-Session: https://claude.ai/code/session_012PAKNe96owcpzo7RYnSMZV

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
