### PR TITLE
Remove text-pretty from services page body paragraphs

### DIFF
--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -62,10 +62,10 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
               Design with intention
             </h2>
           </div>
-          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
+          <p class="text-lg text-foreground-muted leading-relaxed sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             Great design starts with the people who'll use it. I design layouts shaped around your content and your audience, not around trends that age badly. Typography, spacing, and colour are chosen for clarity — not novelty.
           </p>
-          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
+          <p class="text-lg text-foreground-muted leading-relaxed sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             Every screen is considered: desktop, tablet, and the phone someone holds at the bus stop. The brand stays consistent across the whole experience, and the small details are treated as part of the design, not the polish.
           </p>
           <Button variant="outline" href="/contact" class="self-start sm:self-center glitch:self-start mt-2 sm:hidden glitch:inline-flex">
@@ -147,10 +147,10 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
               Code that earns its place
             </h2>
           </div>
-          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
+          <p class="text-lg text-foreground-muted leading-relaxed sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             I build with Astro because it ships what's needed and nothing else. The result is sites that score well in audits, feel fast in the hand, and don't grow brittle over time.
           </p>
-          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
+          <p class="text-lg text-foreground-muted leading-relaxed sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             Architecture matters as much as output: typed content, predictable component boundaries, and a build pipeline a future developer (or future you) can pick up without a guided tour.
           </p>
           <Button variant="outline" href="/projects" class="self-start sm:self-center glitch:self-start mt-2 sm:hidden glitch:inline-flex">
@@ -232,10 +232,10 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
               Fast pages, found pages
             </h2>
           </div>
-          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
+          <p class="text-lg text-foreground-muted leading-relaxed sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             Speed and search visibility aren't features to add at the end — they're constraints to honour from the first commit. Every second a page loads costs attention, ranking, and trust.
           </p>
-          <p class="text-lg text-foreground-muted leading-relaxed text-pretty sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
+          <p class="text-lg text-foreground-muted leading-relaxed sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             I work to measurable targets, not vibes. Core Web Vitals, technical SEO, and accessibility are tracked, tuned, and verified before launch — and the dashboards stay yours after handover.
           </p>
           <Button variant="outline" href="/contact" class="self-start sm:self-center glitch:self-start mt-2 sm:hidden glitch:inline-flex">


### PR DESCRIPTION
The body paragraphs in the Web Design, Web Development, and Performance sections of the services page used text-pretty (text-wrap: pretty), which wrapped awkwardly. Remove the class so they wrap with the normal browser default. text-balance is left unchanged.


Claude-Session: https://claude.ai/code/session_012PAKNe96owcpzo7RYnSMZV

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
