### PR TITLE
Update site copy from Astro 6 to Astro 7

### DIFF
--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -207,7 +207,7 @@ export interface SiteConfig {
 const siteConfig: SiteConfig = {
   name: 'Astro Rocket',
   description:
-    'Astro Rocket — A production-ready Astro 6 starter with 12 beautiful themes, 57+ components, built-in i18n, dark mode and a fast, modern foundation to build anything on.',
+    'Astro Rocket — A production-ready Astro 7 starter with 12 beautiful themes, 57+ components, built-in i18n, dark mode and a fast, modern foundation to build anything on.',
   url: SITE_URL || 'https://astrorocket.dev',
   ogImage: '/og-default.svg',
   author: 'Hans Martens',

--- a/src/content/authors/team.json
+++ b/src/content/authors/team.json
@@ -1,6 +1,6 @@
 {
   "name": "Astro Rocket",
-  "bio": "Astro Rocket is a free, open-source Astro 6 starter theme. Built for speed, accessibility, and developer experience — clone it and start shipping.",
+  "bio": "Astro Rocket is a free, open-source Astro 7 starter theme. Built for speed, accessibility, and developer experience — clone it and start shipping.",
   "social": {
     "github": "https://github.com",
     "linkedin": "https://linkedin.com",

--- a/src/content/faqs/general-en.json
+++ b/src/content/faqs/general-en.json
@@ -1,6 +1,6 @@
 {
   "question": "What is Astro Rocket?",
-  "answer": "Astro Rocket is a free, open-source website theme built on Astro 6 and Tailwind CSS v4. It includes a full component library, a blog with MDX support, built-in dark mode, SEO, and everything else you need to ship a fast, modern website without starting from scratch.",
+  "answer": "Astro Rocket is a free, open-source website theme built on Astro 7 and Tailwind CSS v4. It includes a full component library, a blog with MDX support, built-in dark mode, SEO, and everything else you need to ship a fast, modern website without starting from scratch.",
   "category": "general",
   "order": 1,
   "locale": "en"

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -14,8 +14,8 @@ import TechStack from '@/components/landing/TechStack.astro';
 import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 ---
 <PageLayout
-  title="About Astro Rocket — Astro 6 Starter Theme"
-  description="Astro Rocket is a production-ready Astro 6 starter theme with 12 themes, 57+ components, built-in i18n, dark mode, and everything you need to launch fast."
+  title="About Astro Rocket — Astro 7 Starter Theme"
+  description="Astro Rocket is a production-ready Astro 7 starter theme with 12 themes, 57+ components, built-in i18n, dark mode, and everything you need to launch fast."
   footerBackground="secondary"
 >
   <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
@@ -26,12 +26,12 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
     <h1 slot="title">
       <span class="text-foreground [-webkit-text-fill-color:currentColor]">Astro Rocket —</span><br />
       <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)]">
-        <TypingEffect words={["Astro 6 Starter", "Production-Ready", "12 Themes", "57+ Components", "Dark Mode", "Built-in i18n", "Zero Config SEO"]} />
+        <TypingEffect words={["Astro 7 Starter", "Production-Ready", "12 Themes", "57+ Components", "Dark Mode", "Built-in i18n", "Zero Config SEO"]} />
       </span>
     </h1>
 
     <p slot="description">
-      A free, production-ready Astro 6 starter theme with everything you need to build fast, modern websites — without starting from scratch.
+      A free, production-ready Astro 7 starter theme with everything you need to build fast, modern websites — without starting from scratch.
     </p>
   </Hero>
 
@@ -48,7 +48,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
             </h2>
           </div>
           <p class="text-lg text-foreground-muted leading-relaxed sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
-            Astro Rocket is a production-ready starter theme built on Astro 6. It ships with a full component library, 12 hand-crafted themes, dark mode, built-in i18n, and a blog — so you can focus on building your project, not the boilerplate.
+            Astro Rocket is a production-ready starter theme built on Astro 7. It ships with a full component library, 12 hand-crafted themes, dark mode, built-in i18n, and a blog — so you can focus on building your project, not the boilerplate.
           </p>
           <p class="text-lg text-foreground-muted leading-relaxed sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0">
             It's free, MIT licensed, and listed on the official Astro themes directory. Clone it, customise it, and ship something you're proud of.
@@ -63,7 +63,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
                   <Icon name="rocket" size="md" />
                 </div>
                 <div>
-                  <h3 class="text-base font-semibold text-foreground">Astro 6</h3>
+                  <h3 class="text-base font-semibold text-foreground">Astro 7</h3>
                   <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
                     Built on the latest Astro release.
                   </p>
@@ -180,7 +180,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
             <div class="flex-1 min-w-0">
               <h3 class="text-base font-semibold text-foreground">Modern from the Ground Up</h3>
               <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
-                Astro 6, Tailwind CSS 4, and a clean architecture that's easy to extend and maintain.
+                Astro 7, Tailwind CSS 4, and a clean architecture that's easy to extend and maintain.
               </p>
             </div>
           </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -45,8 +45,8 @@ const heroStackItems = (await getCollection('stack'))
 ---
 
 <LandingLayout
-  title="Astro Rocket — Astro 6 starter theme"
-  description="A production-ready Astro 6 starter with 12 beautiful themes, 57+ components, built-in i18n, dark mode and a fast, modern foundation to build anything on."
+  title="Astro Rocket — Astro 7 starter theme"
+  description="A production-ready Astro 7 starter with 12 beautiful themes, 57+ components, built-in i18n, dark mode and a fast, modern foundation to build anything on."
   image="/og-default.svg"
   includePersonSchema={true}
   includeProfessionalServiceSchema={true}
@@ -61,7 +61,7 @@ const heroStackItems = (await getCollection('stack'))
     </h1>
 
     <p slot="description">
-      Astro 6 starter with 12 beautiful themes, 57+ components, dark mode and a fast, modern foundation to build anything on.
+      Astro 7 starter with 12 beautiful themes, 57+ components, dark mode and a fast, modern foundation to build anything on.
     </p>
 
    <Fragment slot="actions">


### PR DESCRIPTION
Sweep the remaining "Astro 6" self-references the framework upgrade missed (the original pass only covered Markdown files): the homepage hero description, title and meta; the about page (hero, typing effect, tech-stack card, and body copy); the default site description in site.config.ts; and the bundled FAQ and author content.

Historical CHANGELOG entries (the 1.0.0 launch note and the 1.5.0 "Upgraded to Astro 6.4.4" line) are intentionally left untouched.


Claude-Session: https://claude.ai/code/session_01A6jm8cNEPaPGfgybpB9taK

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
