### PR TITLE
Localize blog and article dates to the active locale

### DIFF
--- a/src/__tests__/format-date.test.ts
+++ b/src/__tests__/format-date.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate } from '../lib/utils';
+
+// Date is constructed in local time (not parsed from a UTC string) so the
+// formatted day is stable regardless of the runner's timezone.
+const date = new Date(2026, 5, 24); // 24 June 2026
+
+describe('formatDate()', () => {
+  it('formats in long English for the default locale', () => {
+    expect(formatDate(date, 'en')).toBe('June 24, 2026');
+  });
+
+  it('formats day-first, lowercase month in Dutch', () => {
+    expect(formatDate(date, 'nl')).toBe('24 juni 2026');
+  });
+
+  it('formats with year/month/day markers in Chinese (zh-CN)', () => {
+    expect(formatDate(date, 'zh-CN')).toBe('2026年6月24日');
+  });
+
+  it('falls back to the site default locale when none is passed', () => {
+    // Default config defaultLocale is 'en' → long English format
+    expect(formatDate(date)).toBe('June 24, 2026');
+  });
+});

--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -2,6 +2,7 @@
 import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro';
 import { formatDate } from '@/lib/utils';
+import { getLocaleFromPath } from '@/i18n';
 import Logo from '@/components/ui/marketing/Logo/Logo.astro';
 import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
 import TagList from '@/components/blog/TagList.astro';
@@ -31,6 +32,8 @@ const {
   imageAlt,
   svgSlug,
 } = Astro.props;
+
+const locale = getLocaleFromPath(Astro.url.pathname);
 
 // Estimate reading time
 const wordsPerMinute = 200;
@@ -74,7 +77,7 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
           <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
         </svg>
         <time datetime={publishedAt.toISOString()}>
-          {formatDate(publishedAt)}
+          {formatDate(publishedAt, locale)}
         </time>
       </div>
 
@@ -86,7 +89,7 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
               <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
             </svg>
             <time datetime={updatedAt.toISOString()}>
-              Updated {formatDate(updatedAt)}
+              Updated {formatDate(updatedAt, locale)}
             </time>
           </div>
         </>

--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -2,6 +2,7 @@
 import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro';
 import { formatDate } from '@/lib/utils';
+import { getLocaleFromPath } from '@/i18n';
 import Logo from '@/components/ui/marketing/Logo/Logo.astro';
 import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
 
@@ -44,6 +45,8 @@ const {
   revealDelay,
   class: className,
 } = Astro.props;
+
+const locale = getLocaleFromPath(Astro.url.pathname);
 
 // Estimate reading time (rough estimate based on average words)
 const wordsPerMinute = 200;
@@ -97,7 +100,7 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
         <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
         </svg>
-        {formatDate(publishedAt)}
+        {formatDate(publishedAt, locale)}
       </time>
 
       <span class="flex items-center gap-1">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,11 @@
+import { defaultLocale } from '@/i18n';
+
 /**
- * Format a date for display
+ * Format a date for display. Defaults to the site's default locale so dates
+ * read correctly per language (e.g. "24 juni 2026" on a Dutch page, "2026年6月24日"
+ * on a Chinese one); callers that know the active locale should pass it.
  */
-export function formatDate(date: Date, locale = 'en-US'): string {
+export function formatDate(date: Date, locale: string = defaultLocale): string {
   return new Intl.DateTimeFormat(locale, {
     year: 'numeric',
     month: 'long',


### PR DESCRIPTION
formatDate defaulted to en-US, so dates rendered in US English on every locale (e.g. "June 24, 2026" on a Dutch or Chinese page). The two date surfaces — BlogCard and ArticleHero — now resolve the active locale from the URL (via getLocaleFromPath, as ContactForm already does) and pass it to formatDate. formatDate's default is now the site's defaultLocale rather than en-US, so any future caller is locale-correct too.

Dates now follow the page locale: "24 juni 2026" (nl), "2026年6月24日" (zh-CN). With i18n off the output is unchanged — 'en' and 'en-US' produce the same long-form date. Adds formatDate unit tests covering en/nl/zh-CN.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
