### PR TITLE
Fix build crash when the default locale is not "en"

### DIFF
--- a/src/content/projects/en/astro-rocket.mdx
+++ b/src/content/projects/en/astro-rocket.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Astro Rocket"
+locale: en
 description: "Astro Rocket — my free, open-source Astro 7 theme. A finished website you launch by changing the text: 12 colour themes, 57 components, a 3-state colour mode, and a 100/100/100/100 Lighthouse score out of the box."
 url: "https://astrorocket.dev"
 repo: "https://github.com/hansmartensdev/Astro-Rocket"

--- a/src/content/projects/en/blog-starter.mdx
+++ b/src/content/projects/en/blog-starter.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Blog Starter"
+locale: en
 description: "A minimal, opinionated blog starter built on Astro — fast by default, with MDX support, RSS, dark mode, and a clean reading experience."
 tags: ["Astro", "MDX", "Tailwind CSS", "Open Source"]
 featured: false

--- a/src/content/projects/en/component-library.mdx
+++ b/src/content/projects/en/component-library.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Component Library"
+locale: en
 description: "An open-source set of accessible, themeable UI components — built with Astro and Tailwind CSS, documented with live examples."
 tags: ["Astro", "TypeScript", "Tailwind CSS", "Open Source"]
 featured: false

--- a/src/content/projects/en/docs-site.mdx
+++ b/src/content/projects/en/docs-site.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Documentation Site"
+locale: en
 description: "Developer docs for an open-source CLI tool — versioned content, full-text search, and a clean reading experience across all screen sizes."
 tags: ["Astro", "MDX", "Tailwind CSS", "Open Source"]
 featured: false

--- a/src/content/projects/en/ecommerce-store.mdx
+++ b/src/content/projects/en/ecommerce-store.mdx
@@ -1,5 +1,6 @@
 ---
 title: "E-Commerce Store"
+locale: en
 description: "Custom storefront for an independent fashion brand — product pages, cart, and checkout built for performance and a smooth mobile experience."
 tags: ["Astro", "TypeScript", "Tailwind CSS", "Client Work"]
 featured: false

--- a/src/content/projects/en/saas-landing.mdx
+++ b/src/content/projects/en/saas-landing.mdx
@@ -1,5 +1,6 @@
 ---
 title: "SaaS Landing Page"
+locale: en
 description: "Marketing site for a B2B analytics platform — clear messaging, fast load times, and a conversion-focused layout."
 tags: ["Astro", "TypeScript", "Tailwind CSS", "Client Work"]
 featured: false

--- a/src/content/projects/en/studio-portfolio.mdx
+++ b/src/content/projects/en/studio-portfolio.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Studio Portfolio"
+locale: en
 description: "Complete redesign of a creative studio's portfolio — fast, focused, and built to convert visitors into clients."
 tags: ["Astro", "Tailwind CSS", "Design", "Client Work"]
 featured: true

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -29,7 +29,12 @@ export { tagToSlug, findTagBySlug };
  * (e.g. "en/welcome" → "welcome").
  */
 export function getPostSlug(postId: string, locale: string = defaultLocale): string {
-  return postId.replace(new RegExp(`^${locale}/`), '');
+  // Strip the leading locale-folder segment, leaving a single-segment slug. The
+  // prefix is normally `locale`, but we also strip any other configured locale,
+  // so a folder/locale mismatch still yields a clean slug rather than one
+  // containing a slash (which would break single-segment `[slug]` routes).
+  const localePrefix = new RegExp(`^(${[locale, ...getLocales()].join('|')})/`);
+  return postId.replace(localePrefix, '');
 }
 
 /**

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -27,7 +27,14 @@ export const PROJECTS_PER_PAGE = siteConfig.projects?.perPage ?? 12;
  * `getPostSlug` in `./blog`.
  */
 export function getProjectSlug(projectId: string, locale: string = defaultLocale): string {
-  return projectId.replace(new RegExp(`^${locale}/`), '').replace(/\.mdx?$/, '');
+  // Strip the leading locale-folder segment and any file extension, leaving a
+  // single-segment slug. The prefix is normally `locale`, but we also strip any
+  // other configured locale, so a folder/locale mismatch (e.g. content under
+  // `en/` whose `locale` field resolved to a different default) still yields a
+  // clean slug rather than one containing a slash — which would break the
+  // single-segment `[slug]` routes such as the OG-image endpoints.
+  const localePrefix = new RegExp(`^(${[locale, ...getLocales()].join('|')})/`);
+  return projectId.replace(localePrefix, '').replace(/\.mdx?$/, '');
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Setting `defaultLocale` to anything other than `en` (e.g. `nl`) crashed `astro build` with `TypeError: Missing parameter: slug` while rendering `/og/projects/<…>.svg`.

The bundled project content lives in `src/content/projects/en/` but — unlike the blog posts — did not pin `locale` in frontmatter, so each project's locale followed the schema default (`defaultLocale`). With a non-`en` default, a project's locale (e.g. `nl`) no longer matched its folder prefix (`en/`), and `getProjectSlug()` (which strips `^<locale>/`) left the prefix in place. The resulting slug `en/<name>` contains a slash, which the single-segment `[slug]` OG-image route can't represent — so the build aborted.

This PR:
- **Pins `locale: en` on the 7 bundled project files**, matching the blog convention, so projects declare their language explicitly.
- **Hardens `getProjectSlug()` / `getPostSlug()`** to strip any configured-locale folder prefix (not just the passed locale), so a folder/locale mismatch yields a clean single-segment slug instead of crashing the build.

Note: this fixes the build *crash*. A site whose `defaultLocale` is non-`en` while its content still lives in `en/` folders will simply have no content under the default locale until that content is moved/translated into the matching locale folder — which is expected and already documented.

Fixes #454

## Type of change

- [x] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm check` passes with 0 errors
- [x] `pnpm build` completes successfully — verified with `defaultLocale: 'nl'` (previously crashed) and with the default `en` config (OG slugs emit cleanly, e.g. `og/projects/astro-rocket.svg`)
- [ ] I have tested this change in the browser — N/A: this is a build-time crash; reproduced the failing build, confirmed it now completes, and the 87-test suite passes
- [x] No unnecessary files are included in this PR

## Screenshots (if relevant)

N/A — build-time fix, no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s)_