### PR TITLE
Fix blog reading-time: use real post body, count CJK, localize label

### DIFF
--- a/src/__tests__/reading-time.test.ts
+++ b/src/__tests__/reading-time.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { getReadingTime } from '../lib/utils';
+
+describe('getReadingTime()', () => {
+  it('counts Latin-script words at ~200 wpm', () => {
+    const text = Array(400).fill('word').join(' '); // 400 words → 2 min
+    expect(getReadingTime(text)).toBe(2);
+  });
+
+  it('counts CJK characters per-character instead of collapsing to 1 word', () => {
+    // A whitespace split would see one "word" → 1 min. Character counting at
+    // 400 cpm should give 800 / 400 = 2 minutes.
+    const chinese = '中'.repeat(800);
+    expect(getReadingTime(chinese)).toBe(2);
+  });
+
+  it('gives a realistic estimate for space-less CJK prose', () => {
+    const chinese = '你好世界'.repeat(300); // 1200 chars → 3 min
+    expect(getReadingTime(chinese)).toBe(3);
+  });
+
+  it('excludes fenced code blocks from the estimate', () => {
+    const body = 'word '.repeat(200) + '\n```\n' + 'x '.repeat(1000) + '\n```\n';
+    // ~200 real words → 1 min; the 1000 "words" inside the code fence are ignored
+    expect(getReadingTime(body)).toBe(1);
+  });
+
+  it('always returns at least 1 minute, even for empty content', () => {
+    expect(getReadingTime('hi')).toBe(1);
+    expect(getReadingTime('')).toBe(1);
+  });
+});

--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -1,8 +1,8 @@
 ---
 import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro';
-import { formatDate } from '@/lib/utils';
-import { getLocaleFromPath } from '@/i18n';
+import { formatDate, getReadingTime } from '@/lib/utils';
+import { t, getLocaleFromPath } from '@/i18n';
 import Logo from '@/components/ui/marketing/Logo/Logo.astro';
 import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
 import TagList from '@/components/blog/TagList.astro';
@@ -19,6 +19,8 @@ interface Props {
   image?: ImageMetadata;
   imageAlt?: string;
   svgSlug?: string;
+  /** Raw post body, used to estimate reading time (CJK-aware). */
+  body?: string;
 }
 
 const {
@@ -31,14 +33,15 @@ const {
   image,
   imageAlt,
   svgSlug,
+  body,
 } = Astro.props;
 
 const locale = getLocaleFromPath(Astro.url.pathname);
 
-// Estimate reading time
-const wordsPerMinute = 200;
-const estimatedWords = description.split(' ').length * 15;
-const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
+// Reading time from the actual post body (falls back to the description if no
+// body is passed). Counts CJK characters, so space-less languages such as
+// Chinese, Japanese, and Korean aren't all estimated as "1 min".
+const readingTime = getReadingTime(body ?? description);
 ---
 
 <header class="article-hero relative isolate overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section)]">
@@ -102,7 +105,7 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
         <svg class="h-5 w-5 text-foreground-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
-        <span>{readingTime} min read</span>
+        <span>{t('blog.readingTime', locale, { minutes: readingTime })}</span>
       </div>
     </div>
   </div>

--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -1,8 +1,8 @@
 ---
 import { Image } from 'astro:assets';
 import type { ImageMetadata } from 'astro';
-import { formatDate } from '@/lib/utils';
-import { getLocaleFromPath } from '@/i18n';
+import { formatDate, getReadingTime } from '@/lib/utils';
+import { t, getLocaleFromPath } from '@/i18n';
 import Logo from '@/components/ui/marketing/Logo/Logo.astro';
 import BlogImageSVG from '@/components/blog/BlogImageSVG.astro';
 
@@ -30,6 +30,8 @@ interface Props {
    */
   revealDelay?: number;
   class?: string;
+  /** Raw post body, used to estimate reading time (CJK-aware). */
+  body?: string;
 }
 
 const {
@@ -44,14 +46,15 @@ const {
   eager = false,
   revealDelay,
   class: className,
+  body,
 } = Astro.props;
 
 const locale = getLocaleFromPath(Astro.url.pathname);
 
-// Estimate reading time (rough estimate based on average words)
-const wordsPerMinute = 200;
-const estimatedWords = description.split(' ').length * 10; // Rough estimate
-const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
+// Reading time from the actual post body (falls back to the description if no
+// body is passed). Counts CJK characters, so space-less languages such as
+// Chinese, Japanese, and Korean aren't all estimated as "1 min".
+const readingTime = getReadingTime(body ?? description);
 ---
 
 <article class:list={["group rounded-lg border border-brand-500/30 bg-background p-6 shadow-md ring-1 ring-brand-500/20 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-brand-500 hover:shadow-lg", className]} data-reveal data-reveal-delay={revealDelay || undefined} data-reveal-eager={eager ? '' : undefined}>
@@ -107,7 +110,7 @@ const readingTime = Math.max(1, Math.ceil(estimatedWords / wordsPerMinute));
         <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
-        {readingTime} min read
+        {t('blog.readingTime', locale, { minutes: readingTime })}
       </span>
     </div>
 

--- a/src/components/blog/RelatedPosts.astro
+++ b/src/components/blog/RelatedPosts.astro
@@ -56,6 +56,7 @@ const relatedPosts = allPosts
           author={post.data.author}
           image={post.data.image}
           svgSlug={post.data.svgSlug}
+          body={post.body}
         />
       ))}
     </div>

--- a/src/components/blog/views/BlogIndexView.astro
+++ b/src/components/blog/views/BlogIndexView.astro
@@ -84,6 +84,7 @@ const topTags = collectTopTags(posts, BLOG_TAG_CLOUD_LIMIT);
                 author={post.data.author}
                 image={post.data.image}
                 svgSlug={post.data.svgSlug}
+                body={post.body}
                 revealDelay={index % 2}
                 eager={index === 0}
               />
@@ -122,6 +123,7 @@ const topTags = collectTopTags(posts, BLOG_TAG_CLOUD_LIMIT);
                 author={post.data.author}
                 image={post.data.image}
                 svgSlug={post.data.svgSlug}
+                body={post.body}
                 revealDelay={index % 3}
                 eager={featuredPosts.length === 0 && index === 0}
               />

--- a/src/components/blog/views/BlogPageView.astro
+++ b/src/components/blog/views/BlogPageView.astro
@@ -96,6 +96,7 @@ const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
             author={post.data.author}
             image={post.data.image}
             svgSlug={post.data.svgSlug}
+            body={post.body}
             revealDelay={index % 3}
             eager={index === 0}
           />

--- a/src/components/blog/views/BlogTagView.astro
+++ b/src/components/blog/views/BlogTagView.astro
@@ -83,6 +83,7 @@ const blogHref = getBlogBaseUrl(locale);
               author={post.data.author}
               image={post.data.image}
               svgSlug={post.data.svgSlug}
+              body={post.body}
               revealDelay={index % 3}
               eager={index === 0}
             />

--- a/src/components/pages/views/HomeView.astro
+++ b/src/components/pages/views/HomeView.astro
@@ -418,6 +418,7 @@ const basedInDisplay = `${city ?? 'Your City'}${country ? `, ${country}` : ''}`;
             author={post.data.author}
             image={post.data.image}
             svgSlug={post.data.svgSlug}
+            body={post.body}
             revealDelay={index}
             class={index === 3 ? 'hidden sm:block lg:hidden' : undefined}
           />

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -46,6 +46,8 @@ interface Props {
   toc?: boolean;
   /** Per-post override: hide comments on this post */
   comments?: boolean;
+  /** Raw post body, forwarded to ArticleHero for the reading-time estimate. */
+  body?: string;
 }
 
 const {
@@ -64,6 +66,7 @@ const {
   headings = [],
   toc: tocOverride,
   comments: commentsOverride,
+  body,
 } = Astro.props;
 
 // Resolve opt-in features (site config + per-post overrides).
@@ -164,6 +167,7 @@ const languageAlternates = Object.fromEntries(
     image={image}
     imageAlt={imageAlt}
     svgSlug={svgSlug}
+    body={body}
   />
 
   <article class="pt-8 pb-[var(--space-section-md)]">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,13 +13,46 @@ export function formatDate(date: Date, locale: string = defaultLocale): string {
   }).format(date);
 }
 
+/** Latin-script reading speed, words per minute. */
+const WORDS_PER_MINUTE = 200;
 /**
- * Calculate reading time for content
+ * CJK reading speed, characters per minute. CJK scripts (Chinese, Japanese,
+ * Korean) aren't space-delimited, so they're counted per character rather than
+ * per whitespace-separated "word".
+ */
+const CJK_CHARS_PER_MINUTE = 400;
+/**
+ * Characters from space-less East Asian scripts: Hiragana, Katakana, the CJK
+ * Unified Ideographs (incl. Extension A) and Compatibility blocks, Hangul
+ * syllables, and halfwidth Katakana.
+ */
+const CJK_PATTERN = /[぀-ヿ㐀-䶿一-鿿豈-﫿가-힯ｦ-ﾟ]/g;
+
+/**
+ * Estimate reading time in minutes from a piece of content (typically a post's
+ * raw body). CJK characters are counted individually and every other script by
+ * whitespace-delimited words, each at its own reading speed — so a Chinese or
+ * Japanese post no longer collapses to "1 min" the way a naive `split(' ')`
+ * would. Light markup stripping keeps the estimate focused on prose rather than
+ * code, HTML/JSX, or MDX import lines. Always returns at least 1.
  */
 export function getReadingTime(content: string): number {
-  const wordsPerMinute = 200;
-  const words = content.trim().split(/\s+/).length;
-  return Math.ceil(words / wordsPerMinute);
+  const text = (content ?? '')
+    .replace(/^\s*(?:import|export)\s.*$/gm, ' ') // MDX import/export statements
+    .replace(/```[\s\S]*?```/g, ' ') // fenced code blocks
+    .replace(/`[^`]*`/g, ' ') // inline code
+    .replace(/<[^>]+>/g, ' ') // HTML / JSX tags
+    .replace(/[#>*_~]/g, ' '); // common Markdown markers
+
+  const cjkChars = (text.match(CJK_PATTERN) || []).length;
+  const words = text
+    .replace(CJK_PATTERN, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length;
+
+  const minutes = words / WORDS_PER_MINUTE + cjkChars / CJK_CHARS_PER_MINUTE;
+  return Math.max(1, Math.ceil(minutes));
 }
 
 /**

--- a/src/pages/[locale]/blog/[...slug].astro
+++ b/src/pages/[locale]/blog/[...slug].astro
@@ -50,6 +50,7 @@ const { Content, headings } = await render(post);
   headings={headings}
   toc={post.data.toc}
   comments={post.data.comments}
+  body={post.body}
 >
   <Content components={{ PostLink }} />
 </BlogLayout>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -43,6 +43,7 @@ const { Content, headings } = await render(post);
   headings={headings}
   toc={post.data.toc}
   comments={post.data.comments}
+  body={post.body}
 >
   <Content components={{ PostLink }} />
 </BlogLayout>


### PR DESCRIPTION
## What does this PR do?

Blog reading-time estimates were derived from the post **description** (`description.split(' ').length * 15` in `ArticleHero`, `* 10` in `BlogCard`), so they didn't reflect the actual article length — and `split(' ')` returns `1` for space-less scripts (Chinese, Japanese, Korean), so every CJK post showed **"1 min read."** The label was also hardcoded English despite the existing `blog.readingTime` translation key.

This PR:
- **Rewrites `getReadingTime()`** to count CJK characters individually and other scripts by whitespace-delimited words, each at its own speed (200 wpm / 400 cpm), with light markup stripping — and runs it on the real post body.
- **Threads the post body** to `ArticleHero` (via `BlogLayout` + the two post routes) and to `BlogCard` (via all six listing call sites), replacing the description-based guesses.
- **Localizes the label** via `t('blog.readingTime', locale, { minutes })` (e.g. "5 min leestijd" on a Dutch page).
- Adds reading-time unit tests: Latin words, CJK characters, code-block exclusion, and the 1-minute floor.

Example: the getting-started post now estimates **4 min** (783-word body) instead of **2 min** (20-word description); a Chinese post is counted by characters instead of collapsing to "1 min".

Fixes #456

## Type of change

- [x] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm check` passes with 0 errors
- [x] `pnpm build` completes successfully — default `en` build verified; the reading time renders from the body (e.g. "4 min read")
- [ ] I have tested this change in the browser — N/A: computation/markup change; verified via a real-post before/after and the 92-test suite (5 new reading-time tests covering the CJK case)
- [x] No unnecessary files are included in this PR

## Screenshots (if relevant)

N/A — text/computation change, no visual redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s)_