### PR TITLE
Footer copyright: use the localized string on every locale

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -27,7 +27,7 @@ import { footerVariants, footerColumnGridVariants } from './footer.variants';
 import Logo from '@/components/ui/marketing/Logo/Logo.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import siteConfig from '@/config/site.config';
-import { t, getLocaleFromPath, defaultLocale } from '@/i18n';
+import { t, getLocaleFromPath } from '@/i18n';
 
 export interface NavItem {
   label: string;
@@ -70,8 +70,7 @@ interface Props extends HTMLAttributes<'footer'> {
   showCopyright?: boolean;
   /**
    * Custom copyright text (supports {year} and {siteName} placeholders).
-   * When omitted, the default locale shows the designer credit and other
-   * locales fall back to the localized `footer.copyright` string.
+   * When omitted, every locale uses the localized `footer.copyright` string.
    */
   copyright?: string;
   /** Legal links (Privacy, Terms, etc.) */
@@ -128,15 +127,11 @@ const allNavItems: NavItem[] = navItems;
 // Resolved legal links: prop wins, otherwise fall back to nav.config.ts
 const resolvedLegalLinks: LegalLink[] = legalLinks ?? getLegalLinks(locale);
 
-// Copyright resolution:
-// - An explicit `copyright` prop always wins.
-// - Otherwise the default locale keeps the full designer credit, while
-//   translated locales use the localized `footer.copyright` string (which
-//   omits the credit). Both support {year} and {siteName} placeholders.
-const defaultCopyright =
-  '© {year} {siteName}. Designed by <a href="https://hansmartens.dev" class="underline hover:text-foreground transition-colors" target="_blank" rel="noopener noreferrer">Hans Martens</a>.';
-const copyrightTemplate =
-  copyright ?? (locale === defaultLocale ? defaultCopyright : t('footer.copyright', locale));
+// Copyright resolution: an explicit `copyright` prop wins; otherwise every
+// locale uses the localized `footer.copyright` string (supports {year} and
+// {siteName} placeholders). Edit `footer.copyright` in `src/i18n/<locale>.json`
+// to change it — for example to add your own designer credit.
+const copyrightTemplate = copyright ?? t('footer.copyright', locale);
 
 // Process copyright text
 const currentYear = new Date().getFullYear();

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -110,6 +110,8 @@
     "pageNotFound": "Page not found",
     "pageNotFoundMessage": "The page you're looking for doesn't exist or has moved.",
     "goHome": "Go to homepage",
+    "metaTitle": "Page not found — Astro Rocket",
+    "metaDescription": "This page has moved, been removed, or never existed in the first place.",
     "badge": "404 — page not found",
     "titleLead": "Page not",
     "titleHighlight": "found.",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -110,6 +110,8 @@
     "pageNotFound": "Pagina niet gevonden",
     "pageNotFoundMessage": "De pagina die je zoekt bestaat niet of is verplaatst.",
     "goHome": "Naar de homepagina",
+    "metaTitle": "Pagina niet gevonden — Astro Rocket",
+    "metaDescription": "Deze pagina is verplaatst, verwijderd of heeft nooit bestaan.",
     "badge": "404 — pagina niet gevonden",
     "titleLead": "Pagina niet",
     "titleHighlight": "gevonden.",

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -35,8 +35,8 @@ const recoveryLinks = [
 ---
 
 <PageLayout
-  title="Page not found — Astro Rocket"
-  description="This page has moved, been removed, or never existed in the first place."
+  title={t('errors.metaTitle', locale)}
+  description={t('errors.metaDescription', locale)}
   noindex
   eagerReveal
 >


### PR DESCRIPTION
The footer's copyright resolved to a hardcoded "Designed by Hans Martens" credit on the default locale, bypassing the localized footer.copyright dictionary key. As a result, editing footer.copyright had no effect on the default locale, and every default-locale site shipped the author credit.

Now every locale resolves through footer.copyright (an explicit `copyright` prop still wins). Set your own credit by editing that key in src/i18n/<locale>.json or passing the prop — the shipped default is the neutral "© {year} {siteName}. All rights reserved."

Also localized the 404 page's meta title/description (errors.metaTitle / errors.metaDescription); the rest of the 404 page was already localized.

Verified: the default footer now reads "© {year} {siteName}. All rights reserved." (no hardcoded credit); lint, types, and 92 tests pass; default build green.

Refs #461


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
