### PR TITLE
Fix doubled site name in page titles

### DIFF
--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -144,3 +144,36 @@ describe('i18n swapLocaleInPath()', () => {
     expect(swapLocaleInPath('/about', 'nl')).toBe('/about');
   });
 });
+
+describe('i18n meta titles never embed the site name', () => {
+  // SEO.astro renders the document <title> as `${title} — ${siteConfig.name}`,
+  // so any meta-title dictionary value that already contains the site name
+  // would render it twice (e.g. "Blog — Astro Rocket — Astro Rocket"). Every
+  // key below feeds that `title` prop and must therefore stay brand-free.
+  //
+  // The shipped brand is checked as a literal on purpose: importing
+  // site.config.ts here would pull in `astro:env/server` (see i18n.config.ts),
+  // and this guards the theme's own default dictionaries against a regression.
+  const SITE_NAME = 'Astro Rocket';
+  const METATITLE_KEYS = [
+    'blog.metaTitle',
+    'blog.pageMetaTitle',
+    'blog.tagMetaTitle',
+    'projects.metaTitle',
+    'projects.pageMetaTitle',
+    'projects.tagMetaTitle',
+    'errors.metaTitle',
+    'pages.home.meta.title',
+    'pages.about.meta.title',
+    'pages.services.meta.title',
+    'pages.contact.meta.title',
+  ];
+
+  const cases = ['en', 'nl'].flatMap((locale) =>
+    METATITLE_KEYS.map((key) => [locale, key] as [string, string])
+  );
+
+  it.each(cases)('%s "%s" does not include the site name', (locale, key) => {
+    expect(t(key, locale)).not.toContain(SITE_NAME);
+  });
+});

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -41,7 +41,7 @@
     "share": "Share:",
     "shareOn": "Share on {platform}",
     "copyLink": "Copy link",
-    "metaTitle": "Blog — Astro Rocket",
+    "metaTitle": "Blog",
     "metaDescription": "Articles on web design, development, and the web by Astro Rocket.",
     "heroBadge": "All posts",
     "heroDescription": "Articles on Astro, web performance, design systems, and building with Astro Rocket.",
@@ -75,7 +75,7 @@
     "viewProject": "View project",
     "viewSource": "View source",
     "noProjectsFound": "No projects found.",
-    "metaTitle": "Projects — Astro Rocket",
+    "metaTitle": "Projects",
     "metaDescription": "Selected work — websites, tools, and open-source projects built by Astro Rocket.",
     "heroBadge": "Selected work",
     "heroDescription": "Work I'm most proud of.",
@@ -110,7 +110,7 @@
     "pageNotFound": "Page not found",
     "pageNotFoundMessage": "The page you're looking for doesn't exist or has moved.",
     "goHome": "Go to homepage",
-    "metaTitle": "Page not found — Astro Rocket",
+    "metaTitle": "Page not found",
     "metaDescription": "This page has moved, been removed, or never existed in the first place.",
     "badge": "404 — page not found",
     "titleLead": "Page not",
@@ -161,7 +161,7 @@
   "pages": {
     "about": {
       "meta": {
-        "title": "About Astro Rocket — Astro 7 Starter Theme",
+        "title": "About",
         "description": "Astro Rocket is a production-ready Astro 7 starter theme with 12 themes, 57+ components, built-in i18n, dark mode, and everything you need to launch fast."
       },
       "hero": {
@@ -333,7 +333,7 @@
     },
     "contact": {
       "meta": {
-        "title": "Contact — Astro Rocket",
+        "title": "Contact",
         "description": "Starting something new? I design and build new websites from scratch — tell me about your project and I'll get back to you within 1 business day."
       },
       "hero": {
@@ -352,7 +352,7 @@
     },
     "home": {
       "meta": {
-        "title": "Astro Rocket — Astro 7 starter theme",
+        "title": "Astro 7 starter theme",
         "description": "A production-ready Astro 7 starter with 12 beautiful themes, 57+ components, built-in i18n, dark mode and a fast, modern foundation to build anything on."
       },
       "hero": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -41,7 +41,7 @@
     "share": "Delen:",
     "shareOn": "Deel op {platform}",
     "copyLink": "Link kopiëren",
-    "metaTitle": "Blog — Astro Rocket",
+    "metaTitle": "Blog",
     "metaDescription": "Artikelen over webdesign, ontwikkeling en het web door Astro Rocket.",
     "heroBadge": "Alle berichten",
     "heroDescription": "Artikelen over Astro, webprestaties, designsystemen en bouwen met Astro Rocket.",
@@ -75,7 +75,7 @@
     "viewProject": "Bekijk project",
     "viewSource": "Bekijk broncode",
     "noProjectsFound": "Geen projecten gevonden.",
-    "metaTitle": "Projecten — Astro Rocket",
+    "metaTitle": "Projecten",
     "metaDescription": "Geselecteerd werk — websites, tools en open-source projecten gebouwd door Astro Rocket.",
     "heroBadge": "Geselecteerd werk",
     "heroDescription": "Werk waar ik het meest trots op ben.",
@@ -110,7 +110,7 @@
     "pageNotFound": "Pagina niet gevonden",
     "pageNotFoundMessage": "De pagina die je zoekt bestaat niet of is verplaatst.",
     "goHome": "Naar de homepagina",
-    "metaTitle": "Pagina niet gevonden — Astro Rocket",
+    "metaTitle": "Pagina niet gevonden",
     "metaDescription": "Deze pagina is verplaatst, verwijderd of heeft nooit bestaan.",
     "badge": "404 — pagina niet gevonden",
     "titleLead": "Pagina niet",
@@ -161,7 +161,7 @@
   "pages": {
     "about": {
       "meta": {
-        "title": "Over Astro Rocket — Astro 7 starterthema",
+        "title": "Over",
         "description": "Astro Rocket is een productieklaar Astro 7 starterthema met 12 thema's, 57+ componenten, ingebouwde i18n, donkere modus en alles wat je nodig hebt om snel te lanceren."
       },
       "hero": {
@@ -333,7 +333,7 @@
     },
     "contact": {
       "meta": {
-        "title": "Contact — Astro Rocket",
+        "title": "Contact",
         "description": "Iets nieuws van plan? Ik ontwerp en bouw nieuwe websites vanaf nul — vertel me over je project en ik reageer binnen 1 werkdag."
       },
       "hero": {
@@ -352,7 +352,7 @@
     },
     "home": {
       "meta": {
-        "title": "Astro Rocket — Astro 7 starterthema",
+        "title": "Astro 7 starterthema",
         "description": "Een productieklaar Astro 7 starterthema met 12 prachtige thema's, 57+ componenten, ingebouwde i18n, donkere modus en een snelle, moderne basis om alles op te bouwen."
       },
       "hero": {


### PR DESCRIPTION
The document <title> is assembled once in SEO.astro as `${title} — ${siteConfig.name}`, but six meta-title strings in the i18n dictionaries already ended with (or contained) the site name, so those pages rendered it twice — e.g. "Blog — Astro Rocket — Astro Rocket", "Contact — Astro Rocket — Astro Rocket", and the home/about titles repeated "Astro Rocket".

Strip the embedded brand from those keys in both en.json and nl.json so SEO.astro appends the site name exactly once:
  blog.metaTitle, projects.metaTitle, errors.metaTitle,
  pages.home.meta.title, pages.about.meta.title, pages.contact.meta.title

Home keeps its tagline ("Astro 7 starter theme — Astro Rocket") and the others become clean "<Page> — Astro Rocket" titles. The descriptive services title and the paginated/tag titles carried no brand and are unchanged.

Add an i18n regression test asserting no meta-title value embeds the site name, for every locale.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
