### PR TITLE
Keep a descriptive About page title

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -161,7 +161,7 @@
   "pages": {
     "about": {
       "meta": {
-        "title": "About",
+        "title": "About — Astro 7 Starter Theme",
         "description": "Astro Rocket is a production-ready Astro 7 starter theme with 12 themes, 57+ components, built-in i18n, dark mode, and everything you need to launch fast."
       },
       "hero": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -161,7 +161,7 @@
   "pages": {
     "about": {
       "meta": {
-        "title": "Over",
+        "title": "Over — Astro 7 starterthema",
         "description": "Astro Rocket is een productieklaar Astro 7 starterthema met 12 thema's, 57+ componenten, ingebouwde i18n, donkere modus en alles wat je nodig hebt om snel te lanceren."
       },
       "hero": {


### PR DESCRIPTION
The previous title fix trimmed the About meta-title all the way to "About", which dropped its only SEO keywords ("Astro 7 Starter Theme") and made it the one page whose title carries no descriptor — while Home keeps its tagline and Services keeps its descriptive phrase.

Restore a brand-free descriptive title in both locales so SEO.astro still appends the site name exactly once:
  EN  "About — Astro 7 Starter Theme"  -> "… — Astro Rocket"
  NL  "Over — Astro 7 starterthema"    -> "… — Astro Rocket"

The regression test added with the title fix still holds (neither value embeds the site name).


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
