### PR TITLE
Rename the showcase project to "Astro Rocket Theme"

### DIFF
--- a/src/content/projects/en/astro-rocket.mdx
+++ b/src/content/projects/en/astro-rocket.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Astro Rocket"
+title: "Astro Rocket Theme"
 locale: en
 description: "Astro Rocket — my free, open-source Astro 7 theme. A finished website you launch by changing the text: 12 colour themes, 57 components, a 3-state colour mode, and a 100/100/100/100 Lighthouse score out of the box."
 url: "https://astrorocket.dev"


### PR DESCRIPTION
The demo project that showcases the theme was titled exactly "Astro Rocket", so its page rendered <title>Astro Rocket — Astro Rocket</title> once SEO.astro appended the site name — the same accidental doubling the recent chrome-title fix removed, but coming from content rather than the i18n dictionaries.

Rename its display title to "Astro Rocket Theme" so the page reads "Astro Rocket Theme — Astro Rocket" and the heading/card name it clearly. The slug is derived from the filename, so /projects/astro-rocket/ is unchanged.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
