### PR TITLE
Localize the remaining hardcoded chrome strings

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -34,7 +34,7 @@ import ThemeSelector from '@/components/layout/ThemeSelector.astro';
 import ThemeSelectorDropdown from '@/components/layout/ThemeSelectorDropdown.astro';
 import LanguageSwitcher from '@/components/layout/LanguageSwitcher.astro';
 import siteConfig from '@/config/site.config';
-import { isEnabled as i18nIsEnabled, getLocaleFromPath } from '@/i18n';
+import { isEnabled as i18nIsEnabled, getLocaleFromPath, t } from '@/i18n';
 
 export interface NavItem {
   label: string;
@@ -244,11 +244,11 @@ const buttonId = `${menuId}-button`;
     {
       layout !== 'minimal' &&
         (hasNavSlot ? (
-          <nav class="hidden items-center gap-1 lg:flex" aria-label="Main navigation">
+          <nav class="hidden items-center gap-1 lg:flex" aria-label={t('nav.mainNav', locale)}>
             <slot name="nav" />
           </nav>
         ) : (
-          <nav class="hidden items-center gap-1 lg:flex" aria-label="Main navigation">
+          <nav class="hidden items-center gap-1 lg:flex" aria-label={t('nav.mainNav', locale)}>
             {navItems.map(({ label, href }) => (
               <a
                 href={href.startsWith('#') && !isLandingPage ? `/${href}` : href}
@@ -375,7 +375,7 @@ const buttonId = `${menuId}-button`;
             )}
             aria-expanded="false"
             aria-controls={menuId}
-            aria-label="Toggle menu"
+            aria-label={t('nav.toggleMenu', locale)}
           >
             <span class="menu-icon">
               <Icon name="menu" size="md" />
@@ -422,7 +422,7 @@ const buttonId = `${menuId}-button`;
               : 'border-border bg-background border-t'
           )}
           role="navigation"
-          aria-label="Mobile navigation"
+          aria-label={t('nav.mobileNav', locale)}
         >
           <slot name="mobile-menu" />
         </div>
@@ -436,14 +436,14 @@ const buttonId = `${menuId}-button`;
               : 'border-border bg-background border-t'
           )}
           role="navigation"
-          aria-label="Mobile navigation"
+          aria-label={t('nav.mobileNav', locale)}
         >
           <div class={cn(
             'mobile-menu-body py-3',
             isFloating ? 'px-3' : cn('mx-auto px-4', maxWidthClass)
           )}>
             <section class="mobile-menu-section">
-              <p class="mobile-menu-label">Navigate</p>
+              <p class="mobile-menu-label">{t('nav.sectionNavigate', locale)}</p>
               <ul class="space-y-0.5">
                 {navItems.map(({ label, href }, idx) => {
                   const active = isActive(href);
@@ -475,12 +475,12 @@ const buttonId = `${menuId}-button`;
 
             {showThemeSelector && (
               <section class="mobile-menu-section">
-                <p class="mobile-menu-label">Theme</p>
+                <p class="mobile-menu-label">{t('nav.sectionTheme', locale)}</p>
                 <div
                   class="mobile-menu-stagger flex items-center justify-between rounded-xl px-3 py-2.5"
                   style={`--stagger-index: ${navItems.length}`}
                 >
-                  <span class="text-sm text-foreground-muted">Colour theme</span>
+                  <span class="text-sm text-foreground-muted">{t('theme.colourTheme', locale)}</span>
                   <ThemeSelector />
                 </div>
               </section>
@@ -488,12 +488,12 @@ const buttonId = `${menuId}-button`;
 
             {showLanguageSwitcher && (
               <section class="mobile-menu-section">
-                <p class="mobile-menu-label">Language</p>
+                <p class="mobile-menu-label">{t('nav.sectionLanguage', locale)}</p>
                 <div
                   class="mobile-menu-stagger flex items-center justify-between rounded-xl px-3 py-2.5"
                   style={`--stagger-index: ${navItems.length + (showThemeSelector ? 1 : 0)}`}
                 >
-                  <span class="text-sm text-foreground-muted">Language</span>
+                  <span class="text-sm text-foreground-muted">{t('nav.sectionLanguage', locale)}</span>
                   <LanguageSwitcher alternates={languageAlternates} />
                 </div>
               </section>
@@ -501,7 +501,7 @@ const buttonId = `${menuId}-button`;
 
             {mobileSocialLinks.length > 0 && (
               <section class="mobile-menu-section">
-                <p class="mobile-menu-label">Connect</p>
+                <p class="mobile-menu-label">{t('nav.sectionConnect', locale)}</p>
                 <div class="flex flex-wrap items-center gap-2 px-2 pt-1 pb-2">
                   {mobileSocialLinks.map((url, sIdx) => {
                     const { icon, label } = getSocialIconData(url);

--- a/src/components/layout/SearchModal.astro
+++ b/src/components/layout/SearchModal.astro
@@ -13,12 +13,14 @@
  * - Keyboard: Cmd/Ctrl+K opens, Escape closes, ↑/↓ move through results.
  */
 import { cn } from '@/lib/cn';
+import { t, getLocaleFromPath } from '@/i18n';
 
 interface Props {
   class?: string;
 }
 
 const { class: className } = Astro.props;
+const locale = getLocaleFromPath(Astro.url.pathname);
 
 const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
 ---
@@ -38,7 +40,7 @@ const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
     )}
     aria-haspopup="dialog"
     aria-controls={modalId}
-    aria-label="Search"
+    aria-label={t('common.search', locale)}
   >
     <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
       <circle cx="11" cy="11" r="7" />
@@ -52,7 +54,7 @@ const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
     class="search-modal fixed inset-0 z-[100] hidden"
     role="dialog"
     aria-modal="true"
-    aria-label="Search"
+    aria-label={t('common.search', locale)}
     data-pagefind-ignore
   >
     <div class="search-backdrop absolute inset-0 bg-black/60 backdrop-blur-sm" data-search-close></div>
@@ -67,12 +69,12 @@ const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
         <input
           type="search"
           class="search-input w-full bg-transparent py-4 text-base text-foreground placeholder:text-foreground-subtle focus:outline-none"
-          placeholder="Search posts, projects, and pages…"
+          placeholder={t('search.placeholder', locale)}
           autocomplete="off"
           autocorrect="off"
           autocapitalize="off"
           spellcheck="false"
-          aria-label="Search query"
+          aria-label={t('search.inputLabel', locale)}
         />
         <button
           type="button"
@@ -84,9 +86,16 @@ const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
       </div>
 
       <!-- Results -->
-      <div class="search-results max-h-[55vh] overflow-y-auto overscroll-contain p-2" role="listbox" aria-label="Search results">
+      <div
+        class="search-results max-h-[55vh] overflow-y-auto overscroll-contain p-2"
+        role="listbox"
+        aria-label={t('search.resultsLabel', locale)}
+        data-i18n-hint={t('search.hint', locale)}
+        data-i18n-empty={t('search.noResults', locale)}
+        data-i18n-unavailable={t('search.unavailable', locale)}
+      >
         <p class="search-hint px-3 py-8 text-center text-sm text-foreground-muted">
-          Start typing to search the site.
+          {t('search.hint', locale)}
         </p>
       </div>
     </div>
@@ -187,7 +196,8 @@ const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
         const pf = await loadPagefind();
         if (!pf) {
           renderMessage(
-            'The search index is generated at build time and isn’t available in <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">astro dev</code>.<br />Run <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">pnpm build &amp;&amp; pnpm preview</code> to try it locally.'
+            results.dataset.i18nUnavailable ??
+              'The search index is generated at build time and isn’t available in <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">astro dev</code>.<br />Run <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">pnpm build &amp;&amp; pnpm preview</code> to try it locally.'
           );
           return;
         }
@@ -197,7 +207,8 @@ const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
         if (input.value.trim() !== query) return;
 
         if (search.results.length === 0) {
-          renderMessage(`No results for “${escapeHtml(query)}”`);
+          const tmpl = results.dataset.i18nEmpty ?? 'No results for “{query}”';
+          renderMessage(tmpl.replace('{query}', escapeHtml(query)));
           return;
         }
 
@@ -225,7 +236,7 @@ const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
         if (debounce) window.clearTimeout(debounce);
         const query = input.value.trim();
         if (!query) {
-          renderMessage('Start typing to search the site.');
+          renderMessage(results.dataset.i18nHint ?? 'Start typing to search the site.');
           return;
         }
         debounce = window.setTimeout(() => renderResults(query), 150);

--- a/src/components/layout/ThemeModeDropdown.astro
+++ b/src/components/layout/ThemeModeDropdown.astro
@@ -13,12 +13,24 @@
  * instances (header pill + mobile-menu pill) and view-transition re-mounts.
  */
 import { cn } from '@/lib/cn';
+import { t, getLocaleFromPath } from '@/i18n';
 
 interface Props {
   class?: string;
 }
 
 const { class: className } = Astro.props;
+const locale = getLocaleFromPath(Astro.url.pathname);
+
+// Localized mode names; the trigger aria-label embeds the lowercased name
+// (e.g. "Theme: system. Click to change."). The client script re-derives the
+// same labels on mode change from the data-* attributes below.
+const modeNames = {
+  system: t('theme.system', locale),
+  light: t('theme.light', locale),
+  dark: t('theme.dark', locale),
+};
+const triggerLabel = t('theme.modeTrigger', locale, { mode: modeNames.system.toLowerCase() });
 ---
 
 <div class={cn('relative ttg-wrapper', className)}>
@@ -35,7 +47,11 @@ const { class: className } = Astro.props;
     )}
     aria-haspopup="menu"
     aria-expanded="false"
-    aria-label="Theme: system. Click to change."
+    aria-label={triggerLabel}
+    data-i18n-template={t('theme.modeTrigger', locale)}
+    data-i18n-system={modeNames.system}
+    data-i18n-light={modeNames.light}
+    data-i18n-dark={modeNames.dark}
   >
     <!-- Monitor — shown when data-theme-mode="system" (also pre-bootstrap fallback) -->
     <svg class="ttg-icon ttg-icon-system h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
@@ -60,7 +76,7 @@ const { class: className } = Astro.props;
       'p-1.5 hidden'
     )}
     role="menu"
-    aria-label="Colour mode"
+    aria-label={t('theme.colourMode', locale)}
   >
     <button type="button" class="ttg-row" role="menuitemradio" aria-checked="false" data-mode="system">
       <span class="ttg-row-icon">
@@ -70,8 +86,12 @@ const { class: className } = Astro.props;
         </svg>
       </span>
       <span class="ttg-row-label">
-        <span class="ttg-row-title">System</span>
-        <span class="ttg-system-sub">Currently light</span>
+        <span class="ttg-row-title">{t('theme.system', locale)}</span>
+        <span
+          class="ttg-system-sub"
+          data-sub-light={t('theme.currentlyLight', locale)}
+          data-sub-dark={t('theme.currentlyDark', locale)}
+        >{t('theme.currentlyLight', locale)}</span>
       </span>
       <svg class="ttg-check h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M20 6L9 17l-5-5"/>
@@ -85,7 +105,7 @@ const { class: className } = Astro.props;
         </svg>
       </span>
       <span class="ttg-row-label">
-        <span class="ttg-row-title">Light</span>
+        <span class="ttg-row-title">{t('theme.light', locale)}</span>
       </span>
       <svg class="ttg-check h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M20 6L9 17l-5-5"/>
@@ -99,7 +119,7 @@ const { class: className } = Astro.props;
         </svg>
       </span>
       <span class="ttg-row-label">
-        <span class="ttg-row-title">Dark</span>
+        <span class="ttg-row-title">{t('theme.dark', locale)}</span>
       </span>
       <svg class="ttg-check h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M20 6L9 17l-5-5"/>
@@ -222,14 +242,19 @@ const { class: className } = Astro.props;
 
   function syncAllTriggerLabels(mode: Mode): void {
     document.querySelectorAll<HTMLButtonElement>('.ttg-trigger').forEach((btn) => {
-      btn.setAttribute('aria-label', `Theme: ${mode}. Click to change.`);
+      const template = btn.dataset.i18nTemplate ?? 'Theme: {mode}. Click to change.';
+      const cap = mode.charAt(0).toUpperCase() + mode.slice(1);
+      const name = btn.dataset['i18n' + cap] ?? mode;
+      btn.setAttribute('aria-label', template.replace('{mode}', name.toLowerCase()));
     });
   }
 
   function syncSystemSubLine(): void {
-    const text = osIsDark() ? 'Currently dark' : 'Currently light';
+    const dark = osIsDark();
     document.querySelectorAll<HTMLElement>('.ttg-system-sub').forEach((el) => {
-      el.textContent = text;
+      el.textContent = dark
+        ? (el.dataset.subDark ?? 'Currently dark')
+        : (el.dataset.subLight ?? 'Currently light');
     });
   }
 

--- a/src/components/layout/ThemeSelector.astro
+++ b/src/components/layout/ThemeSelector.astro
@@ -7,11 +7,14 @@
  * Usage in Header:  <ThemeSelector />
  * Pass `class` to tint the label colour for floating / inverted headers.
  */
+import { t, getLocaleFromPath } from '@/i18n';
+
 interface Props {
   class?: string;
 }
 
 const { class: className } = Astro.props;
+const locale = getLocaleFromPath(Astro.url.pathname);
 
 // All 12 themes in Tailwind color order
 const themes = [
@@ -33,7 +36,7 @@ const themes = [
 <div
   class:list={['theme-selector flex flex-wrap items-center gap-1', className]}
   role="group"
-  aria-label="Select colour theme"
+  aria-label={t('theme.selectColourTheme', locale)}
 >
   {themes.map((theme) => (
     <button
@@ -42,7 +45,7 @@ const themes = [
       data-theme-id={theme.id}
       style={`background-color:${theme.color};--swatch:${theme.color}`}
       title={theme.name}
-      aria-label={`${theme.name} theme`}
+      aria-label={t('theme.swatchLabel', locale, { name: theme.name })}
     />
   ))}
 </div>

--- a/src/components/layout/ThemeSelectorDropdown.astro
+++ b/src/components/layout/ThemeSelectorDropdown.astro
@@ -5,12 +5,14 @@
  * The mobile menu still uses the flat ThemeSelector component.
  */
 import { cn } from '@/lib/cn';
+import { t, getLocaleFromPath } from '@/i18n';
 
 interface Props {
   class?: string;
 }
 
 const { class: className } = Astro.props;
+const locale = getLocaleFromPath(Astro.url.pathname);
 
 // All 12 themes in Tailwind color order
 const themes = [
@@ -36,7 +38,7 @@ const themes = [
     id="theme-dropdown-trigger"
     aria-haspopup="true"
     aria-expanded="false"
-    aria-label="Select colour theme"
+    aria-label={t('theme.selectColourTheme', locale)}
     class={cn(
       'inline-flex items-center justify-center rounded-full border border-border-strong p-1.5',
       'text-foreground-muted hover:text-foreground hover:bg-secondary',
@@ -57,7 +59,7 @@ const themes = [
   <div
     id="theme-dropdown-panel"
     role="dialog"
-    aria-label="Colour theme"
+    aria-label={t('theme.colourTheme', locale)}
     class={cn(
       'absolute right-0 top-full mt-2 z-50',
       'w-52 rounded-xl border border-border bg-background shadow-lg',
@@ -65,14 +67,14 @@ const themes = [
       'hidden'
     )}
   >
-    <p class="text-xs font-medium text-foreground-muted mb-2.5 px-0.5">Colour theme</p>
+    <p class="text-xs font-medium text-foreground-muted mb-2.5 px-0.5">{t('theme.colourTheme', locale)}</p>
     <div class="grid grid-cols-4 gap-1.5">
       {themes.map((theme) => (
         <button
           type="button"
           class="theme-swatch-dd group flex flex-col items-center gap-1 rounded-lg p-1 hover:bg-secondary transition-colors duration-(--transition-fast) focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           data-theme-id={theme.id}
-          aria-label={`${theme.name} theme`}
+          aria-label={t('theme.swatchLabel', locale, { name: theme.name })}
         >
           <span
             class="h-4 w-4 rounded-full block"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -5,6 +5,13 @@
     "closeMenu": "Close menu",
     "selectLanguage": "Select language",
     "currentLanguage": "Current language",
+    "mainNav": "Main navigation",
+    "mobileNav": "Mobile navigation",
+    "toggleMenu": "Toggle menu",
+    "sectionNavigate": "Navigate",
+    "sectionTheme": "Theme",
+    "sectionLanguage": "Language",
+    "sectionConnect": "Connect",
     "items": {
       "services": "Services",
       "projects": "Projects",
@@ -147,11 +154,24 @@
     "error": "Failed to send message. Please try again."
   },
   "theme": {
-    "selectTheme": "Select theme",
-    "lightMode": "Light mode",
-    "darkMode": "Dark mode",
-    "systemMode": "System",
-    "toggleTheme": "Toggle theme"
+    "selectColourTheme": "Select colour theme",
+    "colourTheme": "Colour theme",
+    "colourMode": "Colour mode",
+    "modeTrigger": "Theme: {mode}. Click to change.",
+    "system": "System",
+    "light": "Light",
+    "dark": "Dark",
+    "currentlyLight": "Currently light",
+    "currentlyDark": "Currently dark",
+    "swatchLabel": "{name} theme"
+  },
+  "search": {
+    "placeholder": "Search posts, projects, and pages…",
+    "inputLabel": "Search query",
+    "resultsLabel": "Search results",
+    "hint": "Start typing to search the site.",
+    "noResults": "No results for “{query}”",
+    "unavailable": "The search index is generated at build time and isn’t available in <code class=\"rounded bg-secondary px-1.5 py-0.5 text-xs\">astro dev</code>.<br />Run <code class=\"rounded bg-secondary px-1.5 py-0.5 text-xs\">pnpm build &amp;&amp; pnpm preview</code> to try it locally."
   },
   "footer": {
     "copyright": "© {year} {siteName}. All rights reserved.",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -5,6 +5,13 @@
     "closeMenu": "Menu sluiten",
     "selectLanguage": "Selecteer taal",
     "currentLanguage": "Huidige taal",
+    "mainNav": "Hoofdnavigatie",
+    "mobileNav": "Mobiele navigatie",
+    "toggleMenu": "Menu wisselen",
+    "sectionNavigate": "Navigatie",
+    "sectionTheme": "Thema",
+    "sectionLanguage": "Taal",
+    "sectionConnect": "Volgen",
     "items": {
       "services": "Diensten",
       "projects": "Projecten",
@@ -147,11 +154,24 @@
     "error": "Verzenden mislukt. Probeer het opnieuw."
   },
   "theme": {
-    "selectTheme": "Selecteer thema",
-    "lightMode": "Lichte modus",
-    "darkMode": "Donkere modus",
-    "systemMode": "Systeem",
-    "toggleTheme": "Wissel thema"
+    "selectColourTheme": "Selecteer kleurthema",
+    "colourTheme": "Kleurthema",
+    "colourMode": "Kleurmodus",
+    "modeTrigger": "Thema: {mode}. Klik om te wijzigen.",
+    "system": "Systeem",
+    "light": "Licht",
+    "dark": "Donker",
+    "currentlyLight": "Momenteel licht",
+    "currentlyDark": "Momenteel donker",
+    "swatchLabel": "{name}-thema"
+  },
+  "search": {
+    "placeholder": "Zoek berichten, projecten en pagina's…",
+    "inputLabel": "Zoekopdracht",
+    "resultsLabel": "Zoekresultaten",
+    "hint": "Begin met typen om de site te doorzoeken.",
+    "noResults": "Geen resultaten voor “{query}”",
+    "unavailable": "De zoekindex wordt tijdens de build gegenereerd en is niet beschikbaar in <code class=\"rounded bg-secondary px-1.5 py-0.5 text-xs\">astro dev</code>.<br />Voer <code class=\"rounded bg-secondary px-1.5 py-0.5 text-xs\">pnpm build &amp;&amp; pnpm preview</code> uit om het lokaal te proberen."
   },
   "footer": {
     "copyright": "© {year} {siteName}. Alle rechten voorbehouden.",


### PR DESCRIPTION
The header, theme pickers, and search modal were the last UI chrome still rendering hardcoded English regardless of the active locale. Wire them through the i18n dictionary so a non-default locale translates the whole chrome, not most of it.

Static markup (header nav + mobile-menu section labels, the theme dropdown/selector aria-labels and row titles, the search aria-labels, placeholder and hint) now uses t(). The client scripts that set strings at runtime — SearchModal's empty/no-results/dev-unavailable messages and ThemeModeDropdown's trigger label and "Currently light/dark" sub-line — read localized strings from data-* attributes, with the English text kept as a fallback.

English dictionary values match the prior hardcoded text exactly, so the default (i18n-off) build stays byte-identical for all visible and aria text. Reuses common.search; repurposes the previously-unused theme.* keys into a UI-accurate set. Adds matching nl translations.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
