### PR TITLE
Rewrite the i18n blog post to match the current system

### DIFF
--- a/src/content/blog/en/i18n-in-astro-rocket.mdx
+++ b/src/content/blog/en/i18n-in-astro-rocket.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Going Multilingual: Native i18n in Astro Rocket"
-description: "How Astro Rocket's opt-in i18n works end to end — locale routing, the t() helper, an auto-localized blog, projects, and navigation — and the exact steps to ship a multilingual site."
+description: "How Astro Rocket's opt-in i18n works — locale routing, the t()/tData() dictionary, and an auto-localized blog, projects, pages, and chrome — plus how to ship a multilingual site."
 publishedAt: 2026-05-11
-updatedAt: 2026-06-21
+updatedAt: 2026-07-01
 author: "Hans Martens"
 tags: ["astro-rocket", "i18n", "internationalization", "tutorial"]
 featured: false
@@ -13,11 +13,11 @@ svgSlug: "i18n-in-astro-rocket"
 imageAlt: "Globe icon centred on a brand-coloured background with the label 'i18n'"
 ---
 
-Astro Rocket ships native, opt-in internationalization. You can run your site in two — or twenty — languages without leaving the theme: no scaffolding CLI, no plugins, no separate package. Since launch the system has grown into a complete multilingual layer that localizes not just your pages but the **whole blog, the projects section, the navigation, the logo, and every built-in UI string**, all generated at build time.
+Astro Rocket ships native, opt-in internationalization. You can run your site in two — or twenty — languages without leaving the theme: no scaffolding CLI, no plugins, no separate package. The system localizes your **pages, the whole blog, the projects section, the navigation, the logo, and every built-in UI string** — right down to the search dialog and its runtime messages — all generated at build time.
 
 This is the complete, current guide: what the feature is, what it costs (nothing if you leave it off), and exactly how to turn it on and ship an English-plus-Dutch site.
 
-> **Kept current.** The i18n system has matured considerably since it first shipped, much of it from community feedback. If you followed an earlier version of this guide, note one thing that changed: extra language dictionaries are now **auto-loaded** — you no longer edit `src/i18n/index.ts` to register them.
+> **Kept current.** The i18n system has matured a lot since it first shipped, much of it from community feedback. Two things changed that earlier versions of this guide got wrong: extra language dictionaries are now **auto-loaded** (you no longer edit `src/i18n/index.ts` to register them), and the built-in pages — Home, About, Services, Contact — are now **localized from the dictionary**, not by hand-copying page files. If you previously created `src/pages/<locale>/about.astro` copies, delete them; they now collide with the generated locale routes.
 
 If you want the broader picture of how the theme is structured first, the <PostLink uid="configuration-guide">configuration guide</PostLink> covers `site.config.ts`, themes, and layout switches; the [SEO post](/blog/seo-in-astro-rocket) covers everything in the `<head>` that i18n extends with `hreflang`.
 
@@ -27,9 +27,9 @@ Five pieces make up the system. Once you know what each one does, the rest of th
 
 1. **One config file** (`src/config/i18n.config.ts`) — the master switch and your list of locales.
 2. **Locale-prefixed routing** — [Astro's native i18n routing](https://docs.astro.build/en/guides/internationalization/), wired in conditionally. Your default locale stays at the root; the rest live under a prefix like `/nl/`.
-3. **JSON dictionaries** (`src/i18n/<locale>.json`) — the translated UI strings, read through a `t()` helper.
-4. **Locale-aware content collections** — your blog, projects, and pages carry a `locale` field and live in per-locale folders.
-5. **Automatic localized routes** — once content exists in a locale, the theme generates that locale's blog and projects sections for you, with every internal link staying inside the locale.
+3. **JSON dictionaries** (`src/i18n/<locale>.json`) — read through a `t()` / `tData()` helper. They hold both the shared UI strings *and* the copy for the built-in pages.
+4. **Locale-aware content collections** — your blog and projects carry a `locale` field and live in per-locale folders.
+5. **Automatic localized routes** — once a locale exists, the theme generates that locale's built-in pages, blog, and projects for you, with every internal link staying inside the locale.
 
 Everything is resolved at **build time**. There's no client-side routing, no framework hydration, and no language-detection middleware — so turning i18n on doesn't change Astro Rocket's performance posture.
 
@@ -52,14 +52,15 @@ Turn it on and the whole machinery wakes up.
 
 ## What you get when you flip it on
 
-Six things start working as soon as i18n is active:
+As soon as i18n is active:
 
-1. **Locale-prefixed routes.** With `prefixDefaultLocale: false` (the default), your default locale stays at the site root — the English "About" page is still `/about`. Additional locales live under a prefix — a Dutch "About" is `/nl/about`.
+1. **Locale-prefixed routes.** With `prefixDefaultLocale: false` (the default), your default locale stays at the site root — the English "About" is still `/about`. Additional locales live under a prefix — a Dutch "About" is `/nl/about`.
 2. **A `LanguageSwitcher` dropdown** in the header and mobile menu, automatically. It lists every configured locale and links to the matching version of the page the visitor is on.
-3. **An automatically localized blog** — index, posts, pagination, and tag archives — for every locale you add content to. No per-locale page files to write.
-4. **An automatically localized projects section**, the same way.
-5. **Localized chrome** — the navigation, logo, footer, forms, 404 page, and every shared UI string follow the active locale.
-6. **`hreflang` alternates** (plus an `x-default`) in the `<head>` of every page, pointing at each locale's real version of that URL per [Google's recommendation](https://developers.google.com/search/docs/specialty/international/localized-versions).
+3. **The built-in pages in every locale** — Home, About, Services, and Contact render from the dictionary, so they light up the moment a locale is configured (translated or falling back to your default copy).
+4. **An automatically localized blog** — index, posts, pagination, and tag archives — for every locale you add content to. No per-locale page files to write.
+5. **An automatically localized projects section**, the same way.
+6. **Localized chrome** — navigation, logo, footer, the theme and search controls, forms, the 404 page, and every shared UI string follow the active locale.
+7. **`hreflang` alternates** (plus an `x-default`) in the `<head>` of every page, pointing at each locale's real version of that URL per [Google's recommendation](https://developers.google.com/search/docs/specialty/international/localized-versions).
 
 ## Step 1 — enable the feature
 
@@ -84,14 +85,14 @@ Three things to know:
 - **`locales`** is the master list. Order doesn't affect routing, but it controls the order of items in the `LanguageSwitcher` dropdown.
 - **`localeNames`** are the display labels in the dropdown. Use the language's own name (`Nederlands`, not "Dutch") — that's standard practice and respectful to visitors switching from a language they can read.
 
-Save the file. The `LanguageSwitcher` now appears in your header. Clicking "Nederlands" still lands you on English pages until Dutch content exists — that's the next step.
+Save the file. The `LanguageSwitcher` appears in your header, and — because Astro Rocket ships a full Dutch dictionary — `/nl`, `/nl/about`, `/nl/services`, and `/nl/contact` already render in Dutch. Your blog and projects show a localized (but empty) `/nl/blog` and `/nl/projects` index until you add content in that locale, which is the next step.
 
 ## Step 2 — translate your content
 
-Astro Rocket splits content into two camps, and they're handled differently:
+Content in Astro Rocket falls into two tiers, and the difference is the whole trick to understanding i18n here:
 
-- **Collection content** (blog posts and projects) — you only add files; the **routing is automatic**.
-- **Standalone pages** (Home, About, Contact, Services) — these are plain page files, so you create one per locale.
+- **Auto-localized** — the **built-in pages, blog, and projects**. You translate copy (or drop in files); the **routing is automatic**.
+- **Manual** — only **your own custom pages**. Those are plain Astro page files, so you create one per locale.
 
 ### Blog posts — just add files
 
@@ -115,27 +116,51 @@ That's the entire job. **You do not create any blog page files.** Drop posts in 
 
 Every in-locale link — post cards, tag chips, pagination, breadcrumbs, related posts — resolves **inside** that locale instead of falling back to the default-locale URL. The `defaultLocale` keeps its prefix-free URLs (`/blog`). A locale with no posts yet still renders an empty `/<locale>/blog` index, so the `LanguageSwitcher` never lands on a 404.
 
-> **Upgrading?** If you previously hand-built `src/pages/<locale>/blog*` wrapper files to work around the old behavior, delete them — they now collide with the generated routes.
-
 ### Projects — same story
 
 Projects work exactly like the blog. Drop translations in `src/content/projects/<locale>/` (the bundled projects live in `src/content/projects/en/`) and the localized projects section is generated for you: the index (`/nl/projects`), each project (`/nl/projects/<slug>`), pagination (`/nl/projects/page/N`), and tag archives (`/nl/projects/tag/<tag>`).
 
 Projects share one slug across locales — keep the same filename in each locale folder (e.g. `en/studio-portfolio.mdx` ↔ `nl/studio-portfolio.mdx`) and the theme pairs them automatically for `hreflang` and the `LanguageSwitcher`. (Blog posts can instead use locale-specific slugs paired by a canonical `uid` — more on that below.)
 
-### Standalone pages — one file per locale
+### The built-in pages — translate the dictionary
 
-[Astro is filesystem-routed](https://docs.astro.build/en/basics/astro-pages/), so a Dutch "About" page is just a new file at `src/pages/nl/about.astro`:
+Home, About, Services, and Contact are the least work of all, because they don't have per-locale files at all. Each one is a thin route that renders a shared **View** component (`AboutView`, `ContactView`, and so on), and every word that view displays comes from the `pages.*` keys in `src/i18n/<locale>.json`. The default-locale route (`/about`) and the locale-prefixed route (`/nl/about`) render the *same* view — the only difference is which locale's dictionary entries it reads:
 
-| URL              | Source file                            |
-|------------------|----------------------------------------|
-| `/about`         | `src/pages/about.astro`                |
-| `/contact`       | `src/pages/contact.astro`              |
-| `/nl/`           | `src/pages/nl/index.astro` *(create)*  |
-| `/nl/about`      | `src/pages/nl/about.astro` *(create)*  |
-| `/nl/contact`    | `src/pages/nl/contact.astro` *(create)* |
+```astro
+---
+// src/pages/[locale]/about.astro — generated for every non-default locale
+import AboutView from '@/components/pages/views/AboutView.astro';
+import { getSecondaryLocales } from '@/i18n';
 
-The simplest Dutch page is a copy of the English source with the visible text translated. A `src/pages/nl/index.astro` can be as minimal as:
+export function getStaticPaths() {
+  return getSecondaryLocales().map((locale) => ({ params: { locale } }));
+}
+const { locale } = Astro.params;
+---
+<AboutView locale={locale} />
+```
+
+So localizing these pages is the same job as translating any other UI string — you edit JSON, not markup:
+
+```json
+// src/i18n/nl.json
+{
+  "pages": {
+    "about": {
+      "meta": { "title": "Over", "description": "…" },
+      "hero": { "badge": "Over", "titleLead": "Astro Rocket —", "description": "…" }
+    }
+  }
+}
+```
+
+The moment `nl` is in your `locales` list, `/nl`, `/nl/about`, `/nl/services`, and `/nl/contact` are generated for you. Any `pages.*` key you haven't translated yet falls back to the English copy, so the page is always complete and never blank.
+
+> **Don't create `src/pages/nl/about.astro`.** The locale route (`src/pages/[locale]/about.astro`) already generates that URL; a hand-written copy collides with it and fails the build. Translate the `pages.about.*` keys instead.
+
+### Your own pages — one file per locale
+
+For pages you add yourself — anything beyond the four built-ins — you're in plain [Astro filesystem routing](https://docs.astro.build/en/basics/astro-pages/). A Dutch version of a custom `/pricing` page is a new file at `src/pages/nl/pricing.astro`:
 
 ```astro
 ---
@@ -143,19 +168,16 @@ import MarketingLayout from '@/layouts/MarketingLayout.astro';
 ---
 
 <MarketingLayout
-  title="Welkom bij Astro Rocket"
-  description="Een productieklaar Astro 7 starter-thema."
+  title="Prijzen"
+  description="Onze abonnementen en tarieven."
 >
   <section class="container py-24">
-    <h1 class="text-5xl font-bold">Hallo, wereld.</h1>
-    <p class="mt-4 text-lg text-foreground-muted">
-      Dit is de Nederlandse versie van de homepagina.
-    </p>
+    <h1 class="text-5xl font-bold">Prijzen</h1>
   </section>
 </MarketingLayout>
 ```
 
-You don't need to pass a `locale` prop — the layout and every component derive the active locale from the URL via `getLocaleFromPath()`. You also don't have to translate every standalone page on day one: a page that doesn't exist in Dutch simply isn't reachable at its Dutch URL. For a soft launch, start with the homepage, About, and Contact; add the rest as you write them. (Your blog and projects, by contrast, light up automatically the moment their content exists.)
+You don't pass a `locale` prop — the layout and every component derive the active locale from the URL via `getLocaleFromPath()`. You also don't have to translate every custom page on day one: a page that doesn't exist in Dutch simply isn't reachable at its Dutch URL. If a custom page has a lot of copy, you can follow the same View-plus-dictionary pattern the built-in pages use so its text lives in the dictionary too — but for most one-off pages, a translated file is the simplest path.
 
 ## Step 3 — translate the built-in UI strings
 
@@ -190,16 +212,34 @@ const locale = getLocaleFromPath(Astro.url.pathname);
 
 Missing keys fall back to the default locale's value, then to the key itself — so partial translations are visible but never break the page. The `{minutes}` placeholder is filled via the `vars` argument: `t('blog.readingTime', locale, { minutes: 5 })` → `"5 min leestijd"`.
 
-This same dictionary drives the theme's own chrome for you — the skip-to-content link, the back-to-top button, pagination labels, "Related posts", the share buttons, the contact and newsletter forms (including their client-side status messages), and the 404 page all read from it. Translate the keys and the whole site speaks the new language; you don't touch component code.
+### Strings vs. structured copy: `t()` and `tData()`
+
+`t()` returns a single string. For copy that's naturally a list or an object — the feature cards on the About page, an FAQ, a set of steps — use **`tData()`**, which returns the raw (typed) JSON value instead of a string:
+
+```astro
+---
+import { tData, getLocaleFromPath } from '@/i18n';
+const locale = getLocaleFromPath(Astro.url.pathname);
+const facts = tData<{ icon: string; title: string; description: string }[]>(
+  'pages.about.intro.facts',
+  locale,
+);
+---
+{facts?.map((f) => <Card title={f.title}>{f.description}</Card>)}
+```
+
+Same key-based lookup and the same default-locale fallback as `t()` — it just hands you arrays and objects, so a whole section's content can live in the dictionary alongside its strings. This is exactly how the built-in pages keep every word translatable.
+
+This same dictionary drives the theme's own chrome for you — the skip-to-content link, the back-to-top button, the header and mobile-menu navigation (labels *and* aria-labels), the colour-theme and light/dark pickers, the search dialog (including the "start typing" and "no results" messages its script shows at runtime), pagination labels, "Related posts", the table-of-contents heading, the share buttons, and the contact and newsletter forms (including their client-side status messages), plus the 404 page. Translate the keys and the whole site speaks the new language; you don't touch component code.
 
 ### Adding a third language
 
-Adding a language is two steps now — no code edits:
+Adding a language is two steps — no code edits:
 
 1. Create `src/i18n/<code>.json` (say, `de.json`) mirroring the structure of `en.json`. It's discovered and loaded automatically — **no import or registration in `src/i18n/index.ts`**.
 2. Add the locale code to `locales` in `i18n.config.ts` (and give it a `localeNames` entry) so it gets served.
 
-That's the whole onboarding. Then translate content into `src/content/blog/de/`, `src/content/projects/de/`, and add `src/pages/de/*` for the standalone pages you want.
+That's the whole onboarding. The built-in pages appear in German immediately (falling back to English for any key you haven't translated yet); then translate content into `src/content/blog/de/` and `src/content/projects/de/`, and add `src/pages/de/*` for any custom pages you want.
 
 ## Step 4 — localize the navigation, logo, and footer
 
@@ -215,7 +255,7 @@ So for most sites, translating the `nav.items.*` keys is all the navigation need
   locales: { nl: { href: '/over-ons' } } },
 ```
 
-With i18n off, none of this runs and the nav renders exactly as written.
+The footer copyright follows the same dictionary: it reads `footer.copyright` in every locale (edit that key — or pass a `copyright` prop — to change the line). With i18n off, none of this runs and the nav renders exactly as written.
 
 ## How URLs work
 
@@ -229,7 +269,7 @@ The `LanguageSwitcher` and the `hreflang` tags link to each translation's **real
 1. **Identical slug across locales** — `/blog/hello-world` ↔ `/nl/blog/hello-world`, paired automatically with zero config.
 2. **Locale-specific slugs** — more natural for SEO (`/nl/blog/hallo-wereld`). Give both posts the same canonical `uid` in frontmatter (the same id `<PostLink>` uses) and the theme links them correctly across locales and advertises the right URL in `hreflang`.
 
-Either way, a locale with no translation of the current post is dropped from `hreflang`, and the switcher sends the visitor to that locale's blog index instead of a dead URL — so switching language never 404s. (Standalone pages resolve alternates by swapping the locale segment, which is correct when their paths match across locales.)
+Either way, a locale with no translation of the current post is dropped from `hreflang`, and the switcher sends the visitor to that locale's blog index instead of a dead URL — so switching language never 404s. (The built-in and standalone pages resolve alternates by swapping the locale segment, which is correct when their paths match across locales.)
 
 ## SEO checklist
 
@@ -243,7 +283,7 @@ When i18n is on, Astro Rocket's `SEO` component automatically emits the right ta
 
 That tells Google which version corresponds to which locale, and which to show when no language matches. Two things to keep right:
 
-- **Reciprocity.** A page reachable in one locale should be reachable in the others for the `hreflang` loop to hold. Your auto-localized blog and projects handle this for you; for standalone pages, missing translations simply don't get an alternate (which is fine — Google just won't see a translation that doesn't exist).
+- **Reciprocity.** A page reachable in one locale should be reachable in the others for the `hreflang` loop to hold. Your built-in pages, blog, and projects handle this for you; for custom pages, missing translations simply don't get an alternate (which is fine — Google just won't see a translation that doesn't exist).
 - **Your sitemap reflects the locale URLs.** The [`@astrojs/sitemap`](https://docs.astro.build/en/guides/integrations-guide/sitemap/) integration handles this automatically when i18n is configured.
 
 Run a [Lighthouse](https://developer.chrome.com/docs/lighthouse/) SEO audit after deploying — with i18n correctly configured you should score 100/100 on the SEO section without extra work.
@@ -256,7 +296,7 @@ Run a [Lighthouse](https://developer.chrome.com/docs/lighthouse/) SEO audit afte
 src/content/blog/en/  →  src/content/blog/zh-CN/
 ```
 
-The locale code in `i18n.config.ts` and the folder name under `src/content/blog/` (and `src/content/projects/`) must match — the folder name is what the route resolves to. With that done, a non-English default works end to end: the blog index, posts, pagination, tag archives, RSS feed, and dynamic OG images all follow the configured default rather than assuming English.
+The locale code in `i18n.config.ts` and the folder name under `src/content/blog/` (and `src/content/projects/`) must match — the folder name is what the route resolves to. The bundled posts and projects carry an explicit `locale` field for exactly this reason, and the build validates the pairing, so a non-English default works end to end: the built-in pages, blog index, posts, pagination, tag archives, RSS feed, and dynamic OG images all follow the configured default rather than assuming English.
 
 ## Turning it back off
 
@@ -274,9 +314,9 @@ Deploy. The `LanguageSwitcher` disappears, `hreflang` tags stop emitting, the `/
 The system covers the full surface of a marketing-plus-blog site today. A few things remain on the roadmap:
 
 - **Optional browser-locale detection.** The `detectBrowserLocale` flag is wired into the config; redirect-on-first-visit logic can be added without changing the API.
-- **Per-page locale-slug mapping** for standalone pages that want fully localized URLs in addition to translated content.
+- **Per-page locale-slug mapping** for custom pages that want fully localized URLs in addition to translated content.
 - **A pure-CSS `LanguageSwitcher`** using `<details>`, removing the small inline JS the dropdown panel needs today.
 
-This feature exists, and has matured, because the community asked. It started with [#207](https://github.com/hansmartensdev/Astro-Rocket/issues/207); the auto-loaded dictionaries, locale-validated schemas, non-English default locale, automatic blog and projects routing, and localized navigation all came from real-world reports and requests ([#414](https://github.com/hansmartensdev/Astro-Rocket/issues/414), [#415](https://github.com/hansmartensdev/Astro-Rocket/issues/415), [#418](https://github.com/hansmartensdev/Astro-Rocket/issues/418), [#419](https://github.com/hansmartensdev/Astro-Rocket/issues/419), [#422](https://github.com/hansmartensdev/Astro-Rocket/issues/422), [#437](https://github.com/hansmartensdev/Astro-Rocket/issues/437), [#438](https://github.com/hansmartensdev/Astro-Rocket/issues/438)). Thanks to everyone who filed them. If you build something with the i18n system and hit a rough edge, [open an issue](https://github.com/hansmartensdev/Astro-Rocket/issues) — the next iteration will come the same way.
+This feature exists, and has matured, because the community asked. It started with [#207](https://github.com/hansmartensdev/Astro-Rocket/issues/207); the auto-loaded dictionaries, locale-validated schemas, non-English default locale, dictionary-driven pages, automatic blog and projects routing, and fully localized chrome all came from real-world reports and requests ([#414](https://github.com/hansmartensdev/Astro-Rocket/issues/414), [#415](https://github.com/hansmartensdev/Astro-Rocket/issues/415), [#418](https://github.com/hansmartensdev/Astro-Rocket/issues/418), [#419](https://github.com/hansmartensdev/Astro-Rocket/issues/419), [#422](https://github.com/hansmartensdev/Astro-Rocket/issues/422), [#437](https://github.com/hansmartensdev/Astro-Rocket/issues/437), [#438](https://github.com/hansmartensdev/Astro-Rocket/issues/438)). Thanks to everyone who filed them. If you build something with the i18n system and hit a rough edge, [open an issue](https://github.com/hansmartensdev/Astro-Rocket/issues) — the next iteration will come the same way.
 
 For now: flip the flag, add your content in a second language, translate the dictionary, and ship it. The complete reference is in the [Internationalization (i18n) section of the README](https://github.com/hansmartensdev/Astro-Rocket#internationalization-i18n) — keep it open while you set up your second locale.


### PR DESCRIPTION
"Going Multilingual: Native i18n" predated the View-pattern refactor of the built-in pages, so its "standalone pages — one file per locale" instructions were not just outdated but build-breaking: a hand-written src/pages/<locale>/about.astro now collides with the generated [locale] route.

- Recast content translation as two tiers: auto-localized (built-in pages, blog, projects) vs manual (only your own custom pages).
- Document that Home/About/Services/Contact render shared View components from the pages.* dictionary keys, and add the tData() helper alongside t() for structured copy.
- Refresh the localized-chrome list (header/menu labels + aria-labels, theme pickers, the search dialog's runtime messages, TOC, forms).
- Note the footer copyright follows the dictionary and the non-en default build is validated end to end.
- Bump updatedAt; trim the description to the 200-char schema limit.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
