### PR TITLE
Rewrite the comments blog post to cover the Artalk provider

### DIFF
--- a/src/content/blog/en/giscus-comments.mdx
+++ b/src/content/blog/en/giscus-comments.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Comments on Blog Posts — Giscus or Cusdis, Lazy-Loaded"
-description: "Astro Rocket's blog comments are now pluggable: pick Giscus (GitHub Discussions) or the self-hostable, privacy-friendly Cusdis. Both lazy-load on scroll — skip them and you pay nothing."
+title: "Comments on Blog Posts — Giscus, Cusdis, or Artalk, Lazy-Loaded"
+description: "Astro Rocket's blog comments are pluggable: pick Giscus (GitHub Discussions), the optionally self-hostable Cusdis, or the fully self-hosted Artalk. All three lazy-load on scroll — skip them and you pay nothing."
 publishedAt: 2026-05-09
-updatedAt: 2026-06-21
+updatedAt: 2026-07-01
 author: "Hans Martens"
-tags: ["astro-rocket", "features", "blog", "comments", "giscus", "cusdis"]
+tags: ["astro-rocket", "features", "blog", "comments", "giscus", "cusdis", "artalk"]
 featured: false
 locale: en
 image: "../../../assets/blog/giscus-comments.svg"
@@ -12,25 +12,29 @@ svgSlug: "giscus-comments"
 imageAlt: "Three speech bubbles representing a comment thread, on a brand-coloured background"
 ---
 
-Astro Rocket supports comments at the bottom of blog posts. The feature is **pluggable**: a single `provider` switch picks between [Giscus](https://giscus.app) (comments stored in a GitHub Discussions thread) and [Cusdis](https://cusdis.com) (a lightweight, privacy-friendly widget you can self-host). Either way: no database to run yourself, and the same careful wiring underneath.
+Astro Rocket supports comments at the bottom of blog posts. The feature is **pluggable**: a single `provider` switch picks between [Giscus](https://giscus.app) (comments stored in a GitHub Discussions thread), [Cusdis](https://cusdis.com) (a lightweight widget you can use hosted or self-host), and [Artalk](https://artalk.js.org) (a full comment system you run entirely on your own server). Whichever you pick, the wiring underneath is the same careful setup.
 
 It's **off by default**. When disabled, no JavaScript and no network requests are added to your blog pages. When enabled, the provider's script is **lazy-loaded** — it only downloads when the reader actually scrolls toward the comments section. Readers who never scroll that far pay zero performance cost.
 
-> **Kept current.** This post originally covered only Giscus. Comments are now pluggable, and Cusdis was added as an alternative — it came out of a community request, since not everyone wants to require a GitHub account to leave a comment, and some people want to host and moderate the comment data themselves. The setup below reflects the current, two-provider system. If you're already on Giscus, nothing changed: `provider` defaults to `'giscus'`.
+> **Kept current.** This post originally covered only Giscus. Comments are now pluggable: Cusdis was added first (a lightweight, optionally self-hosted widget), and Artalk followed as a fully self-hosted option — contributed by the community in [#469](https://github.com/hansmartensdev/astro-rocket/pull/469) for people who want to own and moderate every comment on infrastructure they control. The setup below reflects the current, three-provider system. If you're already on Giscus, nothing changed: `provider` defaults to `'giscus'`.
 
-## Two providers, one switch
+## Three providers, one switch
 
-Both providers are wired the same way — server-rendered placeholder with reserved height (no layout shift), lazy-loaded on scroll, theme and language that follow the site by default. The difference is the backend:
+All three are wired the same way — server-rendered placeholder with reserved height (no layout shift), lazy-loaded on scroll, theme and language that follow the site by default. The difference is where the comments live and how much you run yourself:
 
-| | **Giscus** | **Cusdis** |
-|---|---|---|
-| Stores comments in | A GitHub Discussions thread | Cusdis (hosted) or your own instance |
-| Commenter needs an account? | Yes — a GitHub login | No — name + email, optional |
-| You moderate / back up the data? | Via GitHub Discussions | Yourself, on a host you control |
-| Reactions | 👍 ❤️ 🎉 etc. | — |
-| Best for | Dev-audience blogs already on GitHub | General audiences and self-hosters |
+| | **Giscus** | **Cusdis** | **Artalk** |
+|---|---|---|---|
+| Stores comments in | A GitHub Discussions thread | Cusdis (hosted) or your own instance | Your own Artalk server |
+| Infrastructure you run | None (GitHub hosts it) | None if hosted; a service if self-hosting | A server + database, always |
+| Commenter needs an account? | Yes — a GitHub login | No — name + email, optional | No — name + email |
+| You moderate / own the data? | Via GitHub Discussions | Hosted dashboard, or yourself | Entirely yourself, on your server |
+| Live light/dark sync | Yes (`postMessage`) | No — re-renders on toggle | Yes (`setDarkMode`) |
+| Reactions | 👍 ❤️ 🎉 etc. | — | Voting + emoji |
+| Best for | Dev-audience blogs already on GitHub | General audiences, minimal setup | Owning and self-hosting everything |
 
-Pick Giscus if your readers are developers who already have GitHub accounts and you're happy storing the thread in a public repo. Pick Cusdis if you'd rather not gate commenting behind a GitHub login, or you want to own and moderate the comment data on your own server.
+- Pick **Giscus** if your readers are developers who already have GitHub accounts and you're happy storing the thread in a public repo — there's no server to run.
+- Pick **Cusdis** if you'd rather not gate commenting behind a GitHub login and want the lightest setup — use the hosted service, or self-host later if you outgrow it.
+- Pick **Artalk** if you want to own and moderate *everything* — comment data, users, and moderation — on infrastructure you control, and you're comfortable running a small service. Unlike Giscus and Cusdis, Artalk has no hosted option: you supply the server.
 
 ## Step 1 — Set up your provider
 
@@ -49,6 +53,14 @@ Pick Giscus if your readers are developers who already have GitHub accounts and 
 3. Copy the **App ID** from the embed code it gives you (a UUID).
 4. Self-hosting? Note your instance URL — you'll set it as `host` so the widget and its API point at your server instead of `cusdis.com`.
 
+### If you choose Artalk
+
+Artalk is fully self-hosted — there's no hosted service, so you run the backend yourself (see the [Artalk docs](https://artalk.js.org/guide/deploy.html); it ships as a single Go binary or a Docker image and stores comments in SQLite/MySQL/PostgreSQL).
+
+1. Deploy an Artalk server and note its public address. In production this **must** be an `https://` URL — a plain `http://` script is blocked as mixed content on an https site and is open to tampering.
+2. In the Artalk dashboard, create a site and note its **site name** (Artalk uses it for multi-site isolation).
+3. You'll set the address as `server` and the name as `site`. That's all Artalk needs; the client JS/CSS are served from your Artalk server by default.
+
 ## Step 2 — Configure Astro Rocket
 
 Open `src/config/site.config.ts` and find `articleFeatures.comments`. Flip `enabled` to `true`, set `provider`, and fill in that provider's block:
@@ -57,7 +69,7 @@ Open `src/config/site.config.ts` and find `articleFeatures.comments`. Flip `enab
 articleFeatures: {
   comments: {
     enabled: true,
-    provider: 'giscus', // 'giscus' | 'cusdis'
+    provider: 'giscus', // 'giscus' | 'cusdis' | 'artalk'
     giscus: {
       repo: 'you/your-repo',
       repoId: 'R_kgDOAbcdef',
@@ -74,22 +86,29 @@ articleFeatures: {
       theme: '', // empty → follow the site's light/dark mode
       lang: '',  // empty → follow the site's current locale
     },
+    artalk: {
+      server: 'https://comments.example.com', // your Artalk server (https in prod)
+      site: 'My Blog', // the site name you created in Artalk
+      // jsUrl / cssUrl: optional — override to serve the client from a CDN
+      // darkMode: leave unset → follow the site's light/dark mode (live)
+      // locale: leave unset → follow the site's current locale
+    },
   },
 },
 ```
 
-Only the block matching `provider` needs real values — leave the other one as-is. Build, deploy, and every blog post now has a comments section underneath.
+Only the block matching `provider` needs real values — leave the others as-is. Build, deploy, and every blog post now has a comments section underneath.
 
-The component **fails soft**: if the selected provider isn't fully configured (Giscus missing any of its four IDs, or Cusdis missing its App ID), it renders nothing rather than breaking the page. A half-finished `enabled: true` just stays invisible until you complete setup.
+The component **fails soft**: if the selected provider isn't fully configured (Giscus missing any of its four IDs, Cusdis missing its App ID, or Artalk missing its `server` or `site`), it renders nothing rather than breaking the page. A half-finished `enabled: true` just stays invisible until you complete setup.
 
 ## Theme and language follow the site
 
-Leave `theme` and `lang` empty (the default) and the embed mirrors your site automatically:
+Leave the theme and language fields empty (the default) and the embed mirrors your site automatically:
 
-- **Theme** follows the visitor's live light/dark choice, resolved from the same [colour-mode system](/blog/colour-mode-system) the rest of the site uses. Giscus updates instantly when the visitor toggles (it has a live `postMessage` API). Cusdis has no live theme API, so on a toggle the thread is re-rendered — a brief reload. To opt out of that, set Cusdis's `theme` to `'auto'` (OS preference), `'light'`, or `'dark'`.
+- **Theme** follows the visitor's live light/dark choice, resolved from the same [colour-mode system](/blog/colour-mode-system) the rest of the site uses. Giscus and Artalk both update instantly when the visitor toggles — Giscus via its `postMessage` API, Artalk via its `setDarkMode` method. Cusdis has no live theme API, so on a toggle its thread is re-rendered — a brief reload. To opt out of site-following on Cusdis, set its `theme` to `'auto'` (OS preference), `'light'`, or `'dark'`; on Artalk, set `darkMode` to `'auto'`, `true`, or `false`.
 - **Language** follows the page's current locale, so a `/nl/blog/...` post loads the comment widget in Dutch with no extra config.
 
-Set either field to a specific value to override the site-following behaviour.
+Set the relevant field to a specific value to override the site-following behaviour.
 
 ## Per-post override
 
@@ -106,15 +125,15 @@ The site-wide setting stays on; just this post skips the comments block.
 
 ## How the lazy-loading works
 
-If the comment script were loaded on every article page-load, it would add roughly 100 KB of network traffic and a third-party iframe to every blog post. That hurts Lighthouse scores and feels especially wasteful for readers who only skim the first paragraph.
+If the comment script were loaded on every article page-load, it would add a third-party script (and, for Giscus, an iframe) to every blog post — roughly 100 KB in Giscus's case. That hurts Lighthouse scores and feels especially wasteful for readers who only skim the first paragraph.
 
 So the component does this instead, regardless of provider:
 
-1. On the server, it renders an empty `<div>` with a reserved `min-height: 360px` (so there's no layout shift when the iframe later appears).
+1. On the server, it renders an empty `<div>` with a reserved `min-height: 360px` (so there's no layout shift when the widget later appears).
 2. On the client, an `IntersectionObserver` watches that `<div>`.
 3. When the reader scrolls within `300px` of the comments area, the provider's script is appended to the DOM and the widget loads.
 
-Readers who bounce or skim → 0 KB. Readers who scroll to the bottom → the comments are ready by the time they arrive. To make that first request even faster, `BaseLayout` adds a `<link rel="preconnect">` to the active provider's host when comments are enabled, warming the DNS+TLS handshake before the script fires.
+Readers who bounce or skim → 0 KB. Readers who scroll to the bottom → the comments are ready by the time they arrive. To make that first request even faster, `BaseLayout` adds a `<link rel="preconnect">` to the active provider's host when comments are enabled, warming the DNS+TLS handshake before the script fires. (For Artalk, that's your server's origin.)
 
 ## What it costs
 
@@ -122,18 +141,18 @@ Readers who bounce or skim → 0 KB. Readers who scroll to the bottom → the co
 |---|---|
 | Comments disabled (default) | 0 KB, 0 requests |
 | Enabled, reader doesn't scroll to comments | ~0.5 KB inline JS |
-| Enabled, reader scrolls to comments | ~100 KB (Giscus) / much less (Cusdis) — async, below-the-fold, no LCP impact |
+| Enabled, reader scrolls to comments | Giscus ~100 KB; Cusdis much less; Artalk served from your own server — all async, below-the-fold, no LCP impact |
 
-The reserved `min-height` prevents CLS. The `async` load prevents render blocking. The `IntersectionObserver` prevents wasted requests. And because the comments component is a thin dispatcher, **only the provider you selected ships its client script** — the other one is never bundled.
+The reserved `min-height` prevents CLS. The `async` load prevents render blocking. The `IntersectionObserver` prevents wasted requests. And because the comments component is a thin dispatcher, **only the provider you selected ships its client script** — the others are never bundled.
 
 ## Where it lives
 
 - Dispatcher: `src/components/blog/Comments.astro` (renders the selected provider)
-- Providers: `src/components/blog/CommentsGiscus.astro` and `CommentsCusdis.astro`
+- Providers: `src/components/blog/CommentsGiscus.astro`, `CommentsCusdis.astro`, and `CommentsArtalk.astro`
 - Wiring: `src/layouts/BlogLayout.astro`
 - Config: `src/config/site.config.ts` → `articleFeatures.comments`
 - Per-post override: `comments: false` in MDX frontmatter
 
 For the full tour of `site.config.ts`, see the <PostLink uid="configuration-guide">configuration guide</PostLink>.
 
-That's the entire feature. Pick a provider, paste a few values into your config, and your blog has a real comment thread — without a database, and without a performance hit.
+That's the entire feature. Pick a provider, paste a few values into your config, and your blog has a real comment thread — without a performance hit, and (with Giscus or hosted Cusdis) without a database to run yourself.


### PR DESCRIPTION
Comments became three-provider after #469 added Artalk, but the post still described a two-provider (Giscus/Cusdis) system and claimed 'no database to run yourself' — untrue for the fully self-hosted Artalk. Update the title, description, tags, comparison table, setup steps, theme/cost sections, and file map to reflect the current system.


Claude-Session: https://claude.ai/code/session_01EmBmqhkhh8rEC8fJHBf1wQ

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
