### PR TITLE
Remove Velocity CLI footnote from i18n section

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,6 @@ src/content/projects/nl/studio-portfolio.mdx
 
 The whole system is build-time. No client-side routing, no framework hydration for the `LanguageSwitcher` — just static HTML and a tiny vanilla-JS open/close handler for the dropdown panel. Verified zero output-size delta on the disabled path between 1.2.1 and 1.3.0.
 
-#### Comparing to Southwell Media's CLI
-
-[`create-velocity-astro`](https://github.com/southwellmedia/create-velocity-astro) is the upstream Velocity CLI for scaffolding a fresh project with i18n. **It is not needed for Astro Rocket** — the equivalent feature is built in here. If you ever do run it, run it in an **empty directory**: it scaffolds a fresh Velocity project and will overwrite an existing directory (including a cloned Astro Rocket repo) if you confirm the "Directory already exists" prompt.
-
 ---
 
 ## Quick Start


### PR DESCRIPTION
## What does this PR do?

Removes the "Comparing to Southwell Media's CLI" footnote from the README's i18n section. This commit was pushed just after #475 merged, so it needed its own PR.

The note dated from when the README recommended the upstream `create-velocity-astro` CLI for i18n. With native i18n built in since 1.3.0 and no other reference to the CLI anywhere in the README or site content, it documented a tool readers would never encounter here — and its heading contradicted the "originally forked, now its own theme" framing introduced in #475.

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [x] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm check` passes with 0 errors
- [x] `pnpm build` completes successfully
- [ ] I have tested this change in the browser (README-only change, no runtime surface)
- [x] No unnecessary files are included in this PR

## Screenshots (if relevant)

Not relevant — README-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149M16yVC9sUbpMsq9mDtFC

---
_Generated by [Claude Code](https://claude.ai/code/session_0149M16yVC9sUbpMsq9mDtFC)_