### PR TITLE
Move README Showcase section up, directly after Overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ It ships with a full blog, a complete component library, a built-in SEO layer, d
 
 ---
 
+## Showcase
+
+Real sites built and shipped with Astro Rocket — see the **[live showcase](https://astrorocket.dev/showcase)** for the full gallery.
+
+| Site | Author | Notes |
+|------|--------|-------|
+| [LinkPress](https://linkpress.app/) | Mithun A. Sridharan | Deployed on Cloudflare |
+
+Built something with Astro Rocket? [Submit your site](https://github.com/hansmartensdev/Astro-Rocket/issues/new?template=showcase_submission.yml) — a live URL and a line about the project is all it takes.
+
+---
+
 ## What Astro Rocket has to offer
 
 | Feature | Description |
@@ -185,18 +197,6 @@ src/content/projects/nl/studio-portfolio.mdx
 #### Performance
 
 The whole system is build-time. No client-side routing, no framework hydration for the `LanguageSwitcher` — just static HTML and a tiny vanilla-JS open/close handler for the dropdown panel. Verified zero output-size delta on the disabled path between 1.2.1 and 1.3.0.
-
----
-
-## Showcase
-
-Real sites built and shipped with Astro Rocket — see the **[live showcase](https://astrorocket.dev/showcase)** for the full gallery.
-
-| Site | Author | Notes |
-|------|--------|-------|
-| [LinkPress](https://linkpress.app/) | Mithun A. Sridharan | Deployed on Cloudflare |
-
-Built something with Astro Rocket? [Submit your site](https://github.com/hansmartensdev/Astro-Rocket/issues/new?template=showcase_submission.yml) — a live URL and a line about the project is all it takes.
 
 ---
 


### PR DESCRIPTION
Social proof belongs where readers decide whether to keep reading — before the feature table, not 190 lines down next to Quick Start.


Claude-Session: https://claude.ai/code/session_01BTutcYAxeMs1DgRB5gWrKK

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
