### PR TITLE
Showcase CTA: adopt the LetterGlitchBand pattern used on other pages

### DIFF
--- a/src/components/pages/views/ShowcaseView.astro
+++ b/src/components/pages/views/ShowcaseView.astro
@@ -18,6 +18,7 @@ import Button from '@/components/ui/form/Button/Button.astro';
 import { buttonVariants } from '@/components/ui/form/Button/button.variants';
 import { cn } from '@/lib/cn';
 import { Hero } from '@/components/hero';
+import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 import { t, tData, defaultLocale } from '@/i18n';
 import { showcaseEntries, showcaseSubmitUrl, showcaseRepoUrl } from '@/config/showcase.config';
 
@@ -117,8 +118,9 @@ const screenshotPending = t('pages.showcase.screenshotPending', locale);
   </section>
 
   <!-- Submit CTA -->
-  <section class="py-[var(--space-section-md)] bg-background border-t border-border">
-    <div class="mx-auto max-w-2xl px-6 text-center" data-reveal>
+  <section class="relative z-10 py-[var(--space-section-md)] bg-background border-t border-border">
+    <!-- Mobile: flat section, no card -->
+    <div class="glitch:hidden mx-auto max-w-2xl px-6 text-center" data-reveal>
       <Badge variant="brand" pill class="mb-6">{submit.badge}</Badge>
       <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
         {submit.heading}
@@ -137,5 +139,25 @@ const screenshotPending = t('pages.showcase.screenshotPending', locale);
         </Button>
       </div>
     </div>
+
+    <!-- Desktop: contained LetterGlitch band with glass card -->
+    <LetterGlitchBand>
+      <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
+        {submit.heading}
+      </h2>
+      <p class="text-lg text-foreground-muted mb-8 text-balance">
+        {submit.description}
+      </p>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <Button size="lg" href={showcaseSubmitUrl} target="_blank" rel="noopener noreferrer" class="hero-btn-brand">
+          {submit.primary}
+          <Icon name="arrow-right" size="sm" />
+        </Button>
+        <Button size="lg" variant="outline" href={showcaseRepoUrl} target="_blank" rel="noopener noreferrer">
+          <Icon name="github" size="sm" />
+          {submit.secondary}
+        </Button>
+      </div>
+    </LetterGlitchBand>
   </section>
 </PageLayout>


### PR DESCRIPTION
Same dual-variant structure as the About and Services CTAs: flat centered section on mobile (glitch:hidden), contained LetterGlitch band with the glass card on desktop, with the brand/outline button pair.


Claude-Session: https://claude.ai/code/session_01BTutcYAxeMs1DgRB5gWrKK

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
