### PR TITLE
Offset anchor scrolling so the fixed header no longer hides targets

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -164,6 +164,11 @@
   html {
     font-family: var(--font-sans);
     scroll-behavior: smooth;
+    /* Offset in-page anchor jumps (Table of Contents links, footnote
+       references, `#id` links) so the target lands *below* the fixed header
+       instead of behind it. The bar header is 4rem tall (h-16); ~1rem extra
+       gives it breathing room. */
+    scroll-padding-top: 5rem;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     overflow-x: clip;


### PR DESCRIPTION
Refs #474. Clicking a Table-of-Contents heading or a footnote reference scrolled the target to the very top, where the fixed 4rem header covered it — so readers couldn't see what they'd jumped to. Add scroll-padding-top: 5rem to the base html rule so in-page anchor jumps (and any #id link) land just below the header. CSS-only, no JS — the approach GitHub uses; smooth scrolling was already enabled. The services page keeps its own deliberate flush override.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
