### PR TITLE
Restore blog list markers

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -889,6 +889,24 @@
     padding-left: 1.5em;
   }
 
+  /* Restore list markers. Tailwind's preflight sets `list-style: none`, which
+     left blog prose with no bullets, no ordered numbers, and no footnote
+     numbers — you couldn't tell a list was a list. */
+  .prose ul { list-style: disc; }
+  .prose ul ul { list-style: circle; }
+  .prose ul ul ul { list-style: square; }
+  .prose ol { list-style: decimal; }
+
+  /* GFM task lists stay checkbox-only — no bullet in front of the checkbox. */
+  .prose ul.contains-task-list,
+  .prose li.task-list-item {
+    list-style: none;
+  }
+
+  .prose ul.contains-task-list {
+    padding-left: 0;
+  }
+
   .prose li {
     margin: 0.5em 0;
   }


### PR DESCRIPTION
Tailwind's preflight sets `list-style: none` on all lists, which left blog prose with no bullets, no ordered numbers, and no footnote numbers — you couldn't tell a list was a list. Restore disc/decimal markers in `.prose` (nested unordered lists cycle disc/circle/square), and keep GFM task lists checkbox-only so the fix doesn't add a bullet before each checkbox.

Refs #468.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
