### PR TITLE
Fix keyboard accessibility in the header overlays

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -552,6 +552,8 @@ const buttonId = `${menuId}-button`;
 }
 
 <script>
+  import { trapFocus } from '@/lib/focus-trap';
+
   function initMobileMenu() {
     const menuHeaders = document.querySelectorAll<HTMLElement>('header[data-menu-id]');
     menuHeaders.forEach((header) => {
@@ -571,6 +573,7 @@ const buttonId = `${menuId}-button`;
 
       let isOpen = false;
       let isAnimating = false;
+      let releaseTrap: (() => void) | null = null;
 
       function open() {
         if (isOpen || isAnimating) return;
@@ -601,12 +604,24 @@ const buttonId = `${menuId}-button`;
           backdrop.classList.add('animate-backdrop');
         }
 
+        // Fence Tab inside the header (toggle + menu + header controls)
+        // while the drawer is open — the page behind is blurred and blocked
+        // for pointer users, so keyboard focus shouldn't reach it either.
+        releaseTrap?.();
+        releaseTrap = trapFocus(header);
+
         isAnimating = false;
       }
 
       function close() {
         if (!isOpen || isAnimating) return;
         isAnimating = true;
+
+        releaseTrap?.();
+        releaseTrap = null;
+        // Return focus to the toggle so Escape / backdrop close doesn't
+        // strand keyboard focus inside the now-hidden menu.
+        button!.focus();
 
         button!.setAttribute('aria-expanded', 'false');
         menuIcon!.classList.remove('hidden');

--- a/src/components/layout/LanguageSwitcher.astro
+++ b/src/components/layout/LanguageSwitcher.astro
@@ -216,6 +216,7 @@ const currentLanguageLabel = t('nav.currentLanguage', currentLocale);
 
       const trigger = wrapper.querySelector<HTMLButtonElement>('.lang-trigger');
       const panel = wrapper.querySelector<HTMLElement>('.lang-panel');
+      const rows = wrapper.querySelectorAll<HTMLAnchorElement>('.lang-row');
       if (!trigger || !panel) return;
 
       trigger.addEventListener('click', (e) => {
@@ -226,7 +227,25 @@ const currentLanguageLabel = t('nav.currentLanguage', currentLocale);
           panel.classList.remove('hidden');
           trigger.setAttribute('aria-expanded', 'true');
           trigger.querySelector('.lang-chevron')?.classList.add('rotate-180');
+          // WAI-ARIA menu pattern: focus the first item when the menu opens.
+          rows[0]?.focus();
         }
+      });
+
+      // role="menu" commits to the ARIA menu keyboard pattern: ArrowUp/
+      // ArrowDown move through the items (wrapping), Home/End jump to the
+      // first/last item.
+      panel.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Home' && e.key !== 'End') return;
+        const items = Array.from(rows);
+        if (!items.length) return;
+        e.preventDefault();
+        if (e.key === 'Home') { items[0].focus(); return; }
+        if (e.key === 'End') { items[items.length - 1].focus(); return; }
+        const index = items.indexOf(document.activeElement as HTMLAnchorElement);
+        const delta = e.key === 'ArrowDown' ? 1 : -1;
+        const next = index === -1 ? 0 : (index + delta + items.length) % items.length;
+        items[next].focus();
       });
     });
 
@@ -241,7 +260,14 @@ const currentLanguageLabel = t('nav.currentLanguage', currentLocale);
       });
 
       document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape') closeAllLangPanels();
+        if (e.key !== 'Escape') return;
+        // Return focus to the trigger of the panel that was open, so Escape
+        // doesn't strand keyboard focus inside a hidden menu.
+        const openPanel = document.querySelector<HTMLElement>('.lang-panel:not(.hidden)');
+        closeAllLangPanels();
+        if (openPanel) {
+          openPanel.closest('.lang-wrapper')?.querySelector<HTMLButtonElement>('.lang-trigger')?.focus();
+        }
       });
     }
   }

--- a/src/components/layout/SearchModal.astro
+++ b/src/components/layout/SearchModal.astro
@@ -116,6 +116,8 @@ const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
 </style>
 
 <script>
+  import { trapFocus } from '@/lib/focus-trap';
+
   interface PagefindResultData {
     url: string;
     excerpt: string;
@@ -132,6 +134,10 @@ const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
 
   let pagefind: Pagefind | null = null;
   let pagefindFailed = false;
+
+  // Per-modal open/close controllers so the global Cmd/Ctrl+K hotkey drives
+  // the same code path as the trigger button (focus trap + focus return).
+  const controllers = new WeakMap<HTMLElement, { open: () => void; close: () => void }>();
 
   async function loadPagefind(): Promise<Pagefind | null> {
     if (pagefind || pagefindFailed) return pagefind;
@@ -175,18 +181,28 @@ const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
       const results = modal.querySelector<HTMLElement>('.search-results');
       if (!input || !results) return;
 
+      let releaseTrap: (() => void) | null = null;
+
       const open = () => {
         modal.classList.remove('hidden');
         document.body.style.overflow = 'hidden';
         input.focus();
         input.select();
+        // Fence Tab inside the dialog while it's open — otherwise focus
+        // walks out behind the backdrop into the page underneath.
+        releaseTrap?.();
+        releaseTrap = trapFocus(modal);
       };
 
       const close = () => {
+        releaseTrap?.();
+        releaseTrap = null;
         modal.classList.add('hidden');
         document.body.style.overflow = '';
         trigger.focus();
       };
+
+      controllers.set(modal, { open, close });
 
       const renderMessage = (html: string) => {
         results.innerHTML = `<p class="px-3 py-8 text-center text-sm text-foreground-muted">${html}</p>`;
@@ -283,16 +299,13 @@ const modalId = `search-modal-${Math.random().toString(36).slice(2, 9)}`;
         if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 'k') return;
         const modal = document.querySelector<HTMLElement>('.search-modal');
         if (!modal) return;
+        const controller = controllers.get(modal);
+        if (!controller) return;
         e.preventDefault();
         if (modal.classList.contains('hidden')) {
-          modal.classList.remove('hidden');
-          document.body.style.overflow = 'hidden';
-          const input = modal.querySelector<HTMLInputElement>('.search-input');
-          input?.focus();
-          input?.select();
+          controller.open();
         } else {
-          modal.classList.add('hidden');
-          document.body.style.overflow = '';
+          controller.close();
         }
       });
     }

--- a/src/components/layout/ThemeModeDropdown.astro
+++ b/src/components/layout/ThemeModeDropdown.astro
@@ -304,7 +304,25 @@ const triggerLabel = t('theme.modeTrigger', locale, { mode: modeNames.system.toL
           panel.classList.remove('hidden');
           trigger.setAttribute('aria-expanded', 'true');
           trigger.querySelector('.ttg-chevron')?.classList.add('rotate-180');
+          // WAI-ARIA menu pattern: focus the first item when the menu opens.
+          rows[0]?.focus();
         }
+      });
+
+      // role="menu" commits to the ARIA menu keyboard pattern: ArrowUp/
+      // ArrowDown move through the items (wrapping), Home/End jump to the
+      // first/last item.
+      panel.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Home' && e.key !== 'End') return;
+        const items = Array.from(rows);
+        if (!items.length) return;
+        e.preventDefault();
+        if (e.key === 'Home') { items[0].focus(); return; }
+        if (e.key === 'End') { items[items.length - 1].focus(); return; }
+        const index = items.indexOf(document.activeElement as HTMLButtonElement);
+        const delta = e.key === 'ArrowDown' ? 1 : -1;
+        const next = index === -1 ? 0 : (index + delta + items.length) % items.length;
+        items[next].focus();
       });
 
       rows.forEach((row) => {
@@ -316,6 +334,8 @@ const triggerLabel = t('theme.modeTrigger', locale, { mode: modeNames.system.toL
           syncAllRows(next);
           syncAllTriggerLabels(next);
           closeAllModePanels();
+          // Selecting an item closes the menu — return focus to its trigger.
+          trigger.focus();
         });
       });
     });
@@ -332,7 +352,14 @@ const triggerLabel = t('theme.modeTrigger', locale, { mode: modeNames.system.toL
       });
 
       document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape') closeAllModePanels();
+        if (e.key !== 'Escape') return;
+        // Return focus to the trigger of the panel that was open, so Escape
+        // doesn't strand keyboard focus inside a hidden menu.
+        const openPanel = document.querySelector<HTMLElement>('.ttg-panel:not(.hidden)');
+        closeAllModePanels();
+        if (openPanel) {
+          openPanel.closest('.ttg-wrapper')?.querySelector<HTMLButtonElement>('.ttg-trigger')?.focus();
+        }
       });
 
       // Live-update the "Currently dark/light" sub-line when the OS flips.

--- a/src/components/layout/ThemeSelectorDropdown.astro
+++ b/src/components/layout/ThemeSelectorDropdown.astro
@@ -206,9 +206,13 @@ const themes = [
       }
     });
 
-    // Close on Escape
+    // Close on Escape — and return focus to the trigger if the panel was
+    // open, so keyboard focus isn't stranded inside the hidden panel.
     document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape') closeDropdown();
+      if (e.key !== 'Escape') return;
+      const wasOpen = !panel.classList.contains('hidden');
+      closeDropdown();
+      if (wasOpen) trigger.focus();
     });
   }
 

--- a/src/lib/focus-trap.ts
+++ b/src/lib/focus-trap.ts
@@ -1,0 +1,47 @@
+/**
+ * trapFocus — keep Tab / Shift+Tab cycling inside `container`.
+ *
+ * The standard dialog focus-trap pattern (the same one the theme's Dialog
+ * component implements internally): while active, tabbing past the last
+ * focusable descendant wraps to the first, and Shift+Tab from the first
+ * wraps to the last — so keyboard focus can't walk out behind an open
+ * overlay into page content that is visually blocked.
+ *
+ * Returns a cleanup function that releases the trap. The caller moves focus
+ * into the container on open and restores it to the opening control on
+ * close; this utility only fences Tab while active.
+ */
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function trapFocus(container: HTMLElement): () => void {
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key !== 'Tab') return;
+
+    // Query live so dynamically added content (e.g. search results) counts,
+    // and skip elements that are currently display:none inside the container.
+    const focusable = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+      (el) => el.offsetWidth > 0 || el.offsetHeight > 0 || el === document.activeElement
+    );
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    const inside = active instanceof Node && container.contains(active);
+
+    if (e.shiftKey) {
+      if (!inside || active === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else if (!inside || active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  document.addEventListener('keydown', onKeydown);
+  return () => document.removeEventListener('keydown', onKeydown);
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the keyboard-interaction gaps in the site chrome reported by @mithunsridharan in #487 — great catches from real production use:

- **Focus trapping for the search modal and the mobile menu.** A new shared `trapFocus()` utility (`src/lib/focus-trap.ts`, mirroring the Tab-cycling pattern `Dialog.astro` already implements) fences Tab/Shift+Tab inside open overlays — previously focus walked out behind the backdrop into page content pointer users can't reach. Focus returns to the opening control on every close path, and the Cmd/Ctrl+K hotkey now drives the same open/close code as the trigger button, so it traps and restores focus too.
- **ARIA menu keyboard pattern in `ThemeModeDropdown` and `LanguageSwitcher`.** Both declare `role="menu"` / `role="menuitemradio"`, which commits to the pattern, but only mouse and Tab worked. Now: first item focused on open, ArrowUp/ArrowDown with wrap-around, Home/End, and Escape/selection return focus to the trigger.
- **Escape focus-return in `ThemeSelectorDropdown`** (and the mobile drawer), so closing an overlay never strands keyboard focus inside a hidden element.

No visual changes, no new user-facing strings, no new dependencies. Verified with scripted Playwright keyboard walkthroughs against the built site: 20/20 checks on the default build (trap cycling both directions on desktop + mobile, hotkey path, arrow-key wrapping, Home/End, every focus-return) and 7/7 on an i18n-enabled build for the LanguageSwitcher.

Fixes #487

## Type of change

- [x] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm check` passes with 0 errors
- [x] `pnpm build` completes successfully
- [x] I have tested this change in the browser
- [x] No unnecessary files are included in this PR

## Screenshots (if relevant)

Behaviour-only change (keyboard interaction) — no visual differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s)_