### PR TITLE
Add a click-to-play YouTube embed component for MDX content

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Built something with Astro Rocket? [Submit your site](https://github.com/hansmar
 | **12 Colour Themes** | All 12 colour swatches are shown in the header dropdown — click one and the logo badge, blog image gradients, and every brand color update live instantly. No file edits, no rebuilds. The selector can be removed from the header once you've settled on a color. |
 | **Scroll Progress Bar** | A thin 2px brand-coloured bar on the header edge that fills as you scroll. Enabled on the homepage (above the floating header), blog index, and post pages (below the solid header). Controlled via `showScrollProgress` and `scrollProgressPosition` props on the Header component. |
 | **Design Tokens** | Three-tier token architecture (reference → semantic → component) |
-| **57 Components** | 33 UI, 7 patterns, 1 hero, 4 layout, 4 blog, 7 landing, 3 SEO — all accessible with TypeScript |
+| **58 Components** | 33 UI, 8 patterns, 1 hero, 4 layout, 4 blog, 7 landing, 3 SEO — all accessible with TypeScript |
 | **Auto Logo & Favicon** | First letter of your site name on brand color — generated automatically from `site.config.ts`, no design tools needed. Prefer your own logo? Set `branding.logo.image` to a file in `public/`. |
 | **Icon System** | Unified `Icon` component (Astro + React) — 350+ [Lucide](https://lucide.dev) UI icons and 3000+ [Simple Icons](https://simpleicons.org) brand icons via Iconify |
 | **Typing Effect** | Animated typing effect in the hero section |
@@ -76,6 +76,7 @@ Built something with Astro Rocket? [Submit your site](https://github.com/hansmar
 | **Independent Footer Menu** | Header and footer navigation configured separately in `nav.config.ts` (`navItems`, `footerNavItems`, `legalLinks`) — add a Privacy or Imprint link to the footer without cluttering the main nav |
 | **Static Search (Pagefind)** | Site-wide search in the header — a ⌘K / Ctrl+K modal powered by a [Pagefind](https://pagefind.app) index generated at build time. Zero JS until the modal opens; works on every deploy target. Hide it with `showSearch={false}` on the Header |
 | **Project Galleries** | Multiple images per project: a `gallery` array in frontmatter swaps the hero image for a swipeable carousel, and the `<ProjectGallery>` MDX component renders an in-body carousel with a click-to-zoom lightbox. See [Project Galleries](#project-galleries) |
+| **YouTube Embeds (Click-to-Play)** | `<YouTube id="…" title="…" />` in any MDX post or page renders a lightweight thumbnail facade — **zero YouTube JavaScript and no third-party cookies until the reader presses play**, then the player loads from privacy-friendly `youtube-nocookie.com`. Keeps article pages at Lighthouse 100; self-hosted files just use a native `<video>` tag |
 | **React Islands** | Optional client-side interactivity where needed |
 
 ### Internationalization (i18n)
@@ -477,7 +478,7 @@ Foreground tokens are documented with their contrast ratios inline. When customi
 
 ## Components
 
-Astro Rocket includes 57 components across 7 categories. All UI components use [class-variance-authority (CVA)](https://cva.style) for type-safe variant management.
+Astro Rocket includes 58 components across 7 categories. All UI components use [class-variance-authority (CVA)](https://cva.style) for type-safe variant management.
 
 ### UI Components (31)
 
@@ -552,7 +553,7 @@ Astro Rocket includes 57 components across 7 categories. All UI components use [
 | SocialProof | Testimonial and trust indicator cards |
 | TerminalDemo | Animated terminal demonstration (React) |
 
-### Pattern Components (7)
+### Pattern Components (8)
 
 | Component | Description |
 |-----------|-------------|
@@ -563,6 +564,7 @@ Astro Rocket includes 57 components across 7 categories. All UI components use [
 | PasswordInput | Password input with visibility toggle |
 | StatCard | Statistics display card |
 | EmptyState | Empty state placeholder with icon and action |
+| YouTube | Privacy-friendly click-to-play video embed for MDX posts and pages |
 
 ### Other Categories
 

--- a/src/components/patterns/YouTube.astro
+++ b/src/components/patterns/YouTube.astro
@@ -1,0 +1,114 @@
+---
+/**
+ * YouTube — privacy-friendly, click-to-play video embed for MDX posts
+ * and pages.
+ *
+ *   import YouTube from '@/components/patterns/YouTube.astro';
+ *
+ *   <YouTube id="dQw4w9WgXcQ" title="Never Gonna Give You Up" />
+ *
+ * Renders a lightweight facade at build time — the video's thumbnail and
+ * a play button — so the page ships zero YouTube JavaScript and sets no
+ * third-party cookies. Only when the reader presses play does the real
+ * player load, from the privacy-friendly youtube-nocookie.com domain
+ * (the same "zero bytes until play" approach the project galleries use).
+ * Without JavaScript, a "watch on YouTube" link is offered instead.
+ */
+import { t, getLocaleFromPath } from '@/i18n';
+
+interface Props {
+  /** The YouTube video id — the part after `watch?v=` in the URL */
+  id: string;
+  /** The video's title — announced to screen readers and set on the player */
+  title: string;
+  class?: string;
+}
+
+const { id, title, class: className } = Astro.props;
+const locale = getLocaleFromPath(Astro.url.pathname);
+
+// hqdefault.jpg exists for every video (maxresdefault does not). It's a
+// 4:3 frame with letterbox bars; object-fit: cover crops them away in the
+// 16:9 box. The thumbnail is a plain image from YouTube's cookieless CDN.
+const thumbnail = `https://i.ytimg.com/vi/${id}/hqdefault.jpg`;
+const watchUrl = `https://www.youtube.com/watch?v=${id}`;
+---
+
+<div
+  class:list={[
+    'yt-embed not-prose relative my-8 aspect-video overflow-hidden rounded-xl border border-border bg-background-secondary',
+    className,
+  ]}
+  data-yt-id={id}
+  data-yt-title={title}
+>
+  <img
+    src={thumbnail}
+    alt=""
+    loading="lazy"
+    decoding="async"
+    class="absolute inset-0 h-full w-full object-cover"
+  />
+  <button
+    type="button"
+    class="yt-play group absolute inset-0 flex cursor-pointer items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    aria-label={t('video.playLabel', locale, { title })}
+  >
+    <span
+      class="flex h-16 w-16 items-center justify-center rounded-full border border-border-strong bg-background/90 text-brand-500 shadow-lg backdrop-blur-sm transition-transform duration-(--transition-normal) group-hover:scale-110"
+      aria-hidden="true"
+    >
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M8 5.14v13.72c0 .82.9 1.32 1.6.89l10.98-6.86a1.05 1.05 0 0 0 0-1.78L9.6 4.25c-.7-.43-1.6.07-1.6.89Z" />
+      </svg>
+    </span>
+  </button>
+  <noscript>
+    <a
+      href={watchUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="absolute bottom-3 right-3 rounded-full border border-border-strong bg-background/90 px-3 py-1.5 text-sm font-medium text-foreground"
+    >
+      {t('video.watchOn', locale)}
+    </a>
+  </noscript>
+</div>
+
+<script>
+  function initYouTubeEmbeds() {
+    document.querySelectorAll<HTMLElement>('.yt-embed:not([data-yt-init])').forEach((embed) => {
+      embed.dataset.ytInit = 'true';
+
+      const button = embed.querySelector<HTMLButtonElement>('.yt-play');
+      if (!button) return;
+
+      button.addEventListener(
+        'click',
+        () => {
+          const id = embed.dataset.ytId;
+          if (!id) return;
+          // Swap the facade for the real player only on explicit interaction,
+          // via the cookieless embed domain. autoplay=1 starts it immediately
+          // so the click isn't wasted.
+          const iframe = document.createElement('iframe');
+          iframe.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(id)}?autoplay=1`;
+          iframe.title = embed.dataset.ytTitle || 'YouTube video';
+          iframe.allow =
+            'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+          iframe.allowFullscreen = true;
+          iframe.className = 'absolute inset-0 h-full w-full';
+          iframe.style.border = '0';
+          embed.replaceChildren(iframe);
+          // The button that held focus is gone — hand focus to the player.
+          iframe.focus();
+        },
+        { once: true }
+      );
+    });
+  }
+
+  initYouTubeEmbeds();
+  document.addEventListener('astro:page-load', initYouTubeEmbeds);
+  document.addEventListener('astro:after-swap', initYouTubeEmbeds);
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -175,6 +175,10 @@
     "noResults": "No results for “{query}”",
     "unavailable": "The search index is generated at build time and isn’t available in <code class=\"rounded bg-secondary px-1.5 py-0.5 text-xs\">astro dev</code>.<br />Run <code class=\"rounded bg-secondary px-1.5 py-0.5 text-xs\">pnpm build &amp;&amp; pnpm preview</code> to try it locally."
   },
+  "video": {
+    "playLabel": "Play video: {title}",
+    "watchOn": "Watch on YouTube"
+  },
   "footer": {
     "copyright": "© {year} {siteName}. All rights reserved.",
     "builtWith": "Built with Astro Rocket",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -175,6 +175,10 @@
     "noResults": "Geen resultaten voor “{query}”",
     "unavailable": "De zoekindex wordt tijdens de build gegenereerd en is niet beschikbaar in <code class=\"rounded bg-secondary px-1.5 py-0.5 text-xs\">astro dev</code>.<br />Voer <code class=\"rounded bg-secondary px-1.5 py-0.5 text-xs\">pnpm build &amp;&amp; pnpm preview</code> uit om het lokaal te proberen."
   },
+  "video": {
+    "playLabel": "Video afspelen: {title}",
+    "watchOn": "Bekijk op YouTube"
+  },
   "footer": {
     "copyright": "© {year} {siteName}. Alle rechten voorbehouden.",
     "builtWith": "Gebouwd met Astro Rocket",

--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -42,6 +42,7 @@ import SearchInput from '@/components/patterns/SearchInput.astro';
 import PasswordInput from '@/components/patterns/PasswordInput.astro';
 import StatCard from '@/components/patterns/StatCard.astro';
 import EmptyState from '@/components/patterns/EmptyState.astro';
+import YouTube from '@/components/patterns/YouTube.astro';
 // Landing Components
 import StackMarquee from '@/components/landing/StackMarquee.astro';
 ---
@@ -1929,7 +1930,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
         </div>
         <div>
           <h2 class="font-display text-2xl font-bold text-foreground">Patterns</h2>
-          <p class="text-foreground-muted mt-1">Pre-composed component patterns for common UI needs — search, passwords, stats, and empty states.</p>
+          <p class="text-foreground-muted mt-1">Pre-composed component patterns for common UI needs — search, passwords, stats, empty states, and video embeds.</p>
         </div>
       </div>
 
@@ -2009,6 +2010,25 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 title="No results found"
                 description="Try adjusting your search or filters to find what you're looking for."
               />
+            </div>
+          </div>
+        </div>
+
+        <!-- YouTube -->
+        <div class="component-showcase">
+          <div class="showcase-header">
+            <span class="showcase-label">YouTube Embed</span>
+            <span class="showcase-hint">Click-to-play facade — zero YouTube bytes until the reader presses play</span>
+          </div>
+          <div class="showcase-content">
+            <div class="mx-auto max-w-2xl">
+              <YouTube id="dQw4w9WgXcQ" title="Rick Astley — Never Gonna Give You Up (embed demo)" />
+              <p class="mt-4 text-sm text-foreground-muted">
+                Drop a video into any MDX post or page with
+                <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">&lt;YouTube id="dQw4w9WgXcQ" title="…" /&gt;</code>
+                — the page ships only a thumbnail, and the player loads from privacy-friendly
+                <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">youtube-nocookie.com</code> on click.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Refs #488. Embedding a video previously meant pasting YouTube's raw iframe into MDX — non-responsive, ~1 MB of third-party JavaScript loaded eagerly, and YouTube cookies set for every visitor, wrecking the page's performance and privacy posture.

New patterns component:

  import YouTube from '@/components/patterns/YouTube.astro';
  <YouTube id="dQw4w9WgXcQ" title="…" />

At build time it renders only a facade — the video's thumbnail and a play button — so the page ships zero YouTube JavaScript and sets no third-party cookies. On click (or Enter — the facade is a real button with a localized aria-label), the player loads from the cookieless youtube-nocookie.com domain with autoplay, and focus moves to it. A noscript fallback links to the video on YouTube. Same "zero bytes until play" approach the project galleries already use.

Localized labels via new video.* dictionary keys (en + nl). Demoed on the /components page under Patterns; README component counts and feature table updated (58 components, 8 patterns).

Verified with a Playwright walkthrough of the built site: 9/9 checks — facade markup, zero requests to YouTube player domains before interaction, keyboard activation, correct nocookie iframe swap.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
