### PR TITLE
Remove the "See what others built" button from the About page

### DIFF
--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -69,13 +69,8 @@ const openSource = tData<{
   heading: string;
   description: string;
   button: string;
-  /** Optional second button linking to the README's community showcase.
-   *  Remove the dictionary key to hide it — no template edit needed. */
-  showcaseButton?: string;
   cards: TitleText[];
 }>('pages.about.openSource', locale)!;
-
-const SHOWCASE_URL = `${GITHUB_URL}#showcase`;
 const cta = tData<{ badge: string; heading: string; description: string; button: string }>('pages.about.cta', locale)!;
 ---
 <PageLayout
@@ -243,12 +238,6 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
               {openSource.button}
               <Icon name="arrow-right" size="sm" />
             </Button>
-            {openSource.showcaseButton && (
-              <Button variant="outline" size="lg" href={SHOWCASE_URL} target="_blank" rel="noopener noreferrer">
-                {openSource.showcaseButton}
-                <Icon name="arrow-right" size="sm" />
-              </Button>
-            )}
           </div>
         </div>
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -261,7 +261,6 @@
         "heading": "Built in the open",
         "description": "Astro Rocket is free, open source, and MIT licensed. Browse the source, open issues, submit PRs, or just clone it and build something great.",
         "button": "View on GitHub",
-        "showcaseButton": "See what others built",
         "cards": [
           { "title": "Made by Hans Martens", "text": "Astro Rocket was designed and built by <a href=\"https://hansmartens.dev\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"underline underline-offset-2 decoration-brand-500 hover:text-brand-400 transition-colors\">Hans Martens</a> — a web designer and developer who uses it as the foundation for client projects." },
           { "title": "MIT License", "text": "Free to use in personal and commercial projects. No attribution required, though a star on GitHub is always appreciated." },

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -261,7 +261,6 @@
         "heading": "In de openbaarheid gebouwd",
         "description": "Astro Rocket is gratis, open source en MIT-gelicentieerd. Bekijk de broncode, open issues, dien PR's in, of kloon het gewoon en bouw iets moois.",
         "button": "Bekijk op GitHub",
-        "showcaseButton": "Bekijk wat anderen bouwden",
         "cards": [
           { "title": "Gemaakt door Hans Martens", "text": "Astro Rocket is ontworpen en gebouwd door <a href=\"https://hansmartens.dev\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"underline underline-offset-2 decoration-brand-500 hover:text-brand-400 transition-colors\">Hans Martens</a> — een webdesigner en -ontwikkelaar die het als basis voor klantprojecten gebruikt." },
           { "title": "MIT-licentie", "text": "Gratis te gebruiken in persoonlijke en commerciële projecten. Geen naamsvermelding vereist, al wordt een ster op GitHub altijd gewaardeerd." },


### PR DESCRIPTION
Drop the optional second button in the "Built in the open" section (it linked to the README's showcase anchor on GitHub) along with its machinery: the conditional markup, the SHOWCASE_URL constant, the optional type field, and the pages.about.openSource.showcaseButton dictionary key in both locales. The "View on GitHub" button stays.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
