### PR TITLE
Park the README Showcase section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,6 @@ It ships with a full blog, a complete component library, a built-in SEO layer, d
 
 ---
 
-## Showcase
-
-Real sites built and shipped with Astro Rocket:
-
-| Site | Author | Notes |
-|------|--------|-------|
-| [LinkPress](https://linkpress.app/) | Mithun A. Sridharan | Deployed on Cloudflare |
-
-Built something with Astro Rocket? [Submit your site](https://github.com/hansmartensdev/Astro-Rocket/issues/new?template=showcase_submission.yml) — a live URL and a line about the project is all it takes.
-
----
-
 ## What Astro Rocket has to offer
 
 | Feature | Description |


### PR DESCRIPTION
Remove the Showcase section for now — with a single entry it reads as an empty gallery rather than social proof. The showcase returns when there is a curated set of sites to feature properly (screenshots, several entries). The showcase-submission issue template stays as a passive intake for future entries.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
