### PR TITLE
Add blog post: YouTube in Your Posts — the Click-to-Play Embed

### DIFF
--- a/src/assets/blog/youtube-embeds.svg
+++ b/src/assets/blog/youtube-embeds.svg
@@ -1,0 +1,19 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .bg  { fill: var(--brand-500); }
+    .ico { stroke: var(--brand-100); stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; fill: none; }
+    .txt { fill: var(--brand-50); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; font-weight: 800; }
+    .cor { stroke: var(--brand-300); stroke-width: 1.5; fill: none; stroke-opacity: 0.45; }
+  </style>
+  <rect width="1200" height="630" class="bg"/>
+  <!-- Lucide Youtube -->
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
+    <path d="M2.5 17a24.12 24.12 0 0 1 0-10 2 2 0 0 1 1.4-1.4 49.56 49.56 0 0 1 16.2 0A2 2 0 0 1 21.5 7a24.12 24.12 0 0 1 0 10 2 2 0 0 1-1.4 1.4 49.55 49.55 0 0 1-16.2 0A2 2 0 0 1 2.5 17"/>
+    <path d="m10 15 5-3-5-3z"/>
+  </g>
+  <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">youtube embeds</text>
+  <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
+  <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
+  <path d="M 36 570 L 36 594 L 60 594" class="cor"/>
+  <path d="M 1140 594 L 1164 594 L 1164 570" class="cor"/>
+</svg>

--- a/src/content/blog/en/project-gallery-video-slides.mdx
+++ b/src/content/blog/en/project-gallery-video-slides.mdx
@@ -6,6 +6,7 @@ author: "Hans Martens"
 tags: ["astro-rocket", "features", "projects", "performance"]
 featured: false
 locale: en
+uid: "video-slides"
 image: "../../../assets/blog/project-gallery-video-slides.svg"
 svgSlug: "project-gallery-video-slides"
 imageAlt: "A play button icon above the words 'video slides', on a brand-coloured background"
@@ -69,7 +70,7 @@ This is the part I actually care about, and it comes down to four decisions:
 3. **No autoplay.** Autoplaying video means downloading video on page load, which is the whole thing we're avoiding. The visitor decides.
 4. **Swiping away pauses.** A small addition to the carousel script pauses any video that's no longer the active slide, so audio never keeps playing off-screen.
 
-And one deliberate non-feature: **no YouTube or Vimeo embeds**. A third-party iframe drags in hundreds of kilobytes of player script, cookies, and consent obligations — that's a different trade-off than this theme makes. Self-hosted files keep the page yours.
+And one deliberate non-feature: **no YouTube or Vimeo embeds in galleries**. A third-party iframe drags in hundreds of kilobytes of player script, cookies, and consent obligations — that's a different trade-off than this theme makes. Self-hosted files keep the page yours. (Articles are a different story with a matching answer: the <PostLink uid="youtube-embeds">click-to-play YouTube embed</PostLink> loads nothing from YouTube until the reader presses play.)
 
 ## Keeping the file small
 

--- a/src/content/blog/en/youtube-embeds.mdx
+++ b/src/content/blog/en/youtube-embeds.mdx
@@ -1,0 +1,75 @@
+---
+title: "YouTube in Your Posts — the Click-to-Play Embed"
+description: "Embed a YouTube video in any post or page with one component. The page ships only a thumbnail; the player loads from youtube-nocookie.com when the reader presses play. Lighthouse stays at 100."
+publishedAt: 2026-07-07
+author: "Hans Martens"
+tags: ["astro-rocket", "features", "components", "performance"]
+featured: false
+locale: en
+uid: "youtube-embeds"
+image: "../../../assets/blog/youtube-embeds.svg"
+svgSlug: "youtube-embeds"
+imageAlt: "A YouTube play icon above the words 'youtube embeds', on a brand-coloured background"
+---
+
+import YouTube from '@/components/patterns/YouTube.astro';
+
+Astro Rocket includes a `YouTube` component for embedding YouTube videos in blog posts and pages. It costs the page nothing until the reader presses play: no YouTube JavaScript, no third-party cookies, no Lighthouse impact. This post shows you how to use it and how it works.
+
+## How to embed a video
+
+Import the component at the top of your `.mdx` file, then place it where the video should appear:
+
+```mdx
+import YouTube from '@/components/patterns/YouTube.astro';
+
+<YouTube id="dQw4w9WgXcQ" title="Never Gonna Give You Up" />
+```
+
+- **`id`** — the video's YouTube id: the part after `watch?v=` in the video's URL. For `https://www.youtube.com/watch?v=dQw4w9WgXcQ`, the id is `dQw4w9WgXcQ`.
+- **`title`** — the video's title. Required, because it's what screen readers announce for the play button and it becomes the player's accessible name once loaded.
+- **`class`** — optional, for extra styling.
+
+That's everything. The component works in every `.mdx` blog post and page, in any number of instances per page.
+
+## See it work
+
+Here is the component in this post — press play:
+
+<YouTube id="dQw4w9WgXcQ" title="Rick Astley — Never Gonna Give You Up" />
+
+Before you clicked, that box was only a thumbnail image and a button. You can verify it in your browser's developer tools: the page made **no request to YouTube at all**. The player, its megabyte of JavaScript, and its cookies only arrive when the reader asks for them.
+
+## Why not paste YouTube's iframe?
+
+The embed code from YouTube's share dialog works in MDX too — but it makes every visitor pay for the video, including all the visitors who never press play:
+
+- **~1 MB of player JavaScript**, downloaded and executed on page load;
+- **third-party cookies** from youtube.com, with the consent obligations that come with them;
+- a **Lighthouse performance hit** on what was a 100-scoring page;
+- a fixed-size player that doesn't adapt to the article column.
+
+The component avoids all four.
+
+## How it works
+
+1. **The page renders a facade.** At build time the component outputs the video's thumbnail (a plain, lazily-loaded image from YouTube's cookieless image CDN) and a play button. No script, no iframe, no player.
+2. **Nothing loads until the click.** When the reader presses play, the facade is swapped for the real player — served from **youtube-nocookie.com**, YouTube's privacy-enhanced domain — with autoplay, so the click that loads the player also starts the video.
+3. **The play button is a real button.** It's keyboard-operable (Enter works), its label is localized through the theme's i18n dictionary (English and Dutch ship with the theme), and focus moves to the player after the swap. With JavaScript disabled, a "Watch on YouTube" link is offered instead.
+4. **No layout shift.** The box reserves its 16:9 space up front, so nothing on the page moves when the player arrives.
+
+The result: an article with three videos ships exactly as many YouTube bytes as an article with none — zero.
+
+## Self-hosted video files
+
+If the video is your own file rather than a YouTube upload, you don't need this component. MDX accepts a native `<video>` tag directly:
+
+```html
+<video src="/videos/demo.mp4" controls preload="none" poster="/videos/demo-poster.jpg"></video>
+```
+
+And project galleries accept video slides natively — how those work is covered in the <PostLink uid="video-slides">video slides post</PostLink>.
+
+## Where it lives
+
+The component is a single file, `src/components/patterns/YouTube.astro` — no dependencies, no client framework. A live example is on the [components page](https://astrorocket.dev/components), together with every other pattern component.


### PR DESCRIPTION
Documentation-style companion post for the YouTube component: how to embed a video (props explained), a live demo inside the article, why a raw iframe costs every visitor ~1 MB plus cookies, how the click-to-play facade keeps Lighthouse at 100, and the self-hosted <video> alternative. Cover SVG follows the house template (Lucide YouTube icon, lowercase label, corner brackets).

The video-slides post gains a uid ("video-slides") so the two posts cross-link durably, and its "no YouTube or Vimeo embeds" paragraph is scoped to galleries with a pointer at the new article-embed answer — the two posts no longer contradict each other.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
