### PR TITLE
Rewrite the video-slides post in documentation style

### DIFF
--- a/src/content/blog/en/project-gallery-video-slides.mdx
+++ b/src/content/blog/en/project-gallery-video-slides.mdx
@@ -12,9 +12,7 @@ svgSlug: "project-gallery-video-slides"
 imageAlt: "A play button icon above the words 'video slides', on a brand-coloured background"
 ---
 
-Screenshots are fine for a portfolio, but if you're showing off software — a checkout flow, an animation, anything that *moves* — thirty seconds of video says more than eight stills. A user selling a software product asked for exactly this ([#396](https://github.com/hansmartensdev/Astro-Rocket/issues/396)): product pages the way e-commerce does them, where the first slide in the gallery is a demo video and the screenshots follow.
-
-So project galleries now accept **video slides**. Both of them: the hero carousel that comes from frontmatter, and the `<ProjectGallery>` component you drop into the MDX body. And because this theme's whole promise is a 100/100/100/100 Lighthouse score out of the box, the feature is built so a video slide costs **zero bytes until the visitor presses play**.
+Project galleries accept **video slides** alongside images — in both places a gallery appears: the hero carousel that comes from frontmatter, and the `<ProjectGallery>` component you drop into the MDX body. A short video often shows software better than stills — a checkout flow, an animation, anything that *moves* — and the feature is built so a video slide costs **zero bytes until the visitor presses play**: a project page with video ships exactly as fast as one without. This post shows how to use video slides and how the performance side works.
 
 ## Using it in frontmatter
 
@@ -37,10 +35,10 @@ gallery:
 
 Two things to notice:
 
-- **The video is a root-relative path**, not an import. Video files live in `public/` (I use `public/videos/`), because Astro's asset pipeline is for images — video gets served as-is.
-- **The poster is required**, and it *is* an import-style image path like every other gallery image. That's not me being strict for fun; the poster is what makes the performance story work. More on that below.
+- **The video is a root-relative path**, not an import. Video files live in `public/` (for example `public/videos/`), because Astro's asset pipeline is for images — video gets served as-is.
+- **The poster is required.** The poster is what makes the performance model work — see [how it stays Lighthouse-neutral](#how-it-stays-lighthouse-neutral) below.
 
-The first slide is the featured one, so putting the video first gives you the e-commerce layout from the issue: demo up front, stills behind it.
+The first slide is the featured one, so putting the video first gives you a product-page layout: demo up front, stills behind it.
 
 ## Using it in the post body
 
@@ -63,20 +61,20 @@ One behavioural difference from image slides: clicking an image opens the lightb
 
 ## How it stays Lighthouse-neutral
 
-This is the part I actually care about, and it comes down to four decisions:
+Four decisions keep video slides performance-neutral:
 
 1. **`preload="none"` on every video element.** The browser downloads no video data — not even metadata — until the visitor presses play. A project page with a video slide ships exactly as many media bytes as one without.
 2. **The poster is the slide.** What you see in the carousel is the poster image, and it goes through the same `astro:assets` pipeline as a regular slide — optimised, resized, served as WebP. If the video is your first slide, the poster is your LCP candidate, and it behaves like any other optimised hero image.
-3. **No autoplay.** Autoplaying video means downloading video on page load, which is the whole thing we're avoiding. The visitor decides.
-4. **Swiping away pauses.** A small addition to the carousel script pauses any video that's no longer the active slide, so audio never keeps playing off-screen.
+3. **No autoplay.** Autoplaying video means downloading video on page load, which is the whole thing being avoided. The visitor decides.
+4. **Swiping away pauses.** The carousel script pauses any video that's no longer the active slide, so audio never keeps playing off-screen.
 
-And one deliberate non-feature: **no YouTube or Vimeo embeds in galleries**. A third-party iframe drags in hundreds of kilobytes of player script, cookies, and consent obligations — that's a different trade-off than this theme makes. Self-hosted files keep the page yours. (Articles are a different story with a matching answer: the <PostLink uid="youtube-embeds">click-to-play YouTube embed</PostLink> loads nothing from YouTube until the reader presses play.)
+Galleries intentionally do **not** support YouTube or Vimeo embeds: a third-party iframe adds hundreds of kilobytes of player script, cookies, and consent obligations, while self-hosted files keep the page under your control. For a YouTube video *in an article*, use the click-to-play <PostLink uid="youtube-embeds">YouTube embed component</PostLink> instead — it loads nothing from YouTube until the reader presses play.
 
 ## Keeping the file small
 
-A gallery demo isn't a film. A few encoding habits keep it friendly:
+A few encoding settings keep demo files small:
 
-- Keep it short — 15 to 45 seconds shows a flow; nobody watches a four-minute screen recording.
+- Keep it short — 15 to 45 seconds is enough to show a flow.
 - 1280×720 matches the carousel's aspect ratio (`aspect-video`) exactly.
 - H.264 MP4 plays everywhere. With ffmpeg:
 
@@ -85,10 +83,10 @@ ffmpeg -i recording.mov -vf "scale=1280:720" -c:v libx264 -crf 28 \
   -movflags +faststart -an public/videos/demo.mp4
 ```
 
-`-crf 28` is plenty for UI recordings, `-an` drops the audio track if your demo doesn't need one, and `+faststart` moves the metadata to the front of the file so playback starts immediately. A 30-second UI recording lands around 1–2 MB — and remember, nobody downloads it until they ask to.
+`-crf 28` is plenty for UI recordings, `-an` drops the audio track if your demo doesn't need one, and `+faststart` moves the metadata to the front of the file so playback starts immediately. A 30-second UI recording lands around 1–2 MB — and it isn't downloaded until the visitor presses play.
 
 ## Under the hood
 
-If you want to poke at it: the slide union is validated in `src/content.config.ts` (a slide is *either* `src`+`alt` *or* `video`+`poster`+`alt` — anything else fails the build), the shared `GallerySlide` type lives in `src/lib/gallery.ts`, and the rendering happens in `ProjectCarousel.astro` (hero) and `ProjectGallery.astro` (body + lightbox). No new dependencies, no client framework — the same native scroll-snap carousel, now with a `<video>` element where a slide asks for one.
+For reference: the slide union is validated in `src/content.config.ts` (a slide is *either* `src`+`alt` *or* `video`+`poster`+`alt` — anything else fails the build), the shared `GallerySlide` type lives in `src/lib/gallery.ts`, and the rendering happens in `ProjectCarousel.astro` (hero) and `ProjectGallery.astro` (body + lightbox). No new dependencies, no client framework — the same native scroll-snap carousel, with a `<video>` element where a slide asks for one.
 
-`src/content/projects/ecommerce-store.mdx` carries a ready-to-uncomment video slide if you want a starting point. Drop a file in `public/videos/`, point a slide at it, give it a poster — done.
+`src/content/projects/en/ecommerce-store.mdx` carries a ready-to-uncomment video slide as a starting point. Drop a file in `public/videos/`, point a slide at it, give it a poster — done.


### PR DESCRIPTION
Apply the blog's content policy — informational, how-to, no storytelling — to the video-slides post: the user/issue origin story in the opener is replaced with a factual introduction, and narrative asides are removed throughout. All technical content stays: frontmatter and in-body usage, the four performance decisions, encoding guidance, and the under-the-hood reference. The gallery no-embeds paragraph keeps its pointer to the click-to-play YouTube component for articles.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
