### PR TITLE
Use a NASA rocket video as the YouTube embed demo

### DIFF
--- a/src/components/patterns/YouTube.astro
+++ b/src/components/patterns/YouTube.astro
@@ -5,7 +5,7 @@
  *
  *   import YouTube from '@/components/patterns/YouTube.astro';
  *
- *   <YouTube id="dQw4w9WgXcQ" title="Never Gonna Give You Up" />
+ *   <YouTube id="QONgJurkigk" title="NASA" />
  *
  * Renders a lightweight facade at build time — the video's thumbnail and
  * a play button — so the page ships zero YouTube JavaScript and sets no

--- a/src/content/blog/en/youtube-embeds.mdx
+++ b/src/content/blog/en/youtube-embeds.mdx
@@ -23,10 +23,10 @@ Import the component at the top of your `.mdx` file, then place it where the vid
 ```mdx
 import YouTube from '@/components/patterns/YouTube.astro';
 
-<YouTube id="dQw4w9WgXcQ" title="Never Gonna Give You Up" />
+<YouTube id="QONgJurkigk" title="NASA" />
 ```
 
-- **`id`** — the video's YouTube id: the part after `watch?v=` in the video's URL. For `https://www.youtube.com/watch?v=dQw4w9WgXcQ`, the id is `dQw4w9WgXcQ`.
+- **`id`** — the video's YouTube id: the part after `watch?v=` in the video's URL. For `https://www.youtube.com/watch?v=QONgJurkigk`, the id is `QONgJurkigk`.
 - **`title`** — the video's title. Required, because it's what screen readers announce for the play button and it becomes the player's accessible name once loaded.
 - **`class`** — optional, for extra styling.
 
@@ -36,7 +36,7 @@ That's everything. The component works in every `.mdx` blog post and page, in an
 
 Here is the component in this post — press play:
 
-<YouTube id="dQw4w9WgXcQ" title="Rick Astley — Never Gonna Give You Up" />
+<YouTube id="QONgJurkigk" title="NASA" />
 
 Before you clicked, that box was only a thumbnail image and a button. You can verify it in your browser's developer tools: the page made **no request to YouTube at all**. The player, its megabyte of JavaScript, and its cookies only arrive when the reader asks for them.
 

--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -2022,10 +2022,10 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
           </div>
           <div class="showcase-content">
             <div class="mx-auto max-w-2xl">
-              <YouTube id="dQw4w9WgXcQ" title="Rick Astley — Never Gonna Give You Up (embed demo)" />
+              <YouTube id="QONgJurkigk" title="NASA" />
               <p class="mt-4 text-sm text-foreground-muted">
                 Drop a video into any MDX post or page with
-                <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">&lt;YouTube id="dQw4w9WgXcQ" title="…" /&gt;</code>
+                <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">&lt;YouTube id="QONgJurkigk" title="…" /&gt;</code>
                 — the page ships only a thumbnail, and the player loads from privacy-friendly
                 <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">youtube-nocookie.com</code> on click.
               </p>


### PR DESCRIPTION
Swap the demo video to NASA's QONgJurkigk — a rocket video that fits the theme's branding — everywhere the demo appears: the blog post's usage snippet, id explanation, and live embed; the components-page demo and its usage snippet; and the component's doc-comment example.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
