### PR TITLE
Sharpen the theme description: a complete component library for building beautiful websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>Astro Rocket</strong> — A production-ready Astro 7 starter theme. Change the text, launch your site.
+  <strong>Astro Rocket</strong> — A free, open-source Astro 7 theme: a complete component library for building beautiful websites.
 </p>
 
 <p align="center">
@@ -28,7 +28,7 @@
 
 ## Overview
 
-Astro Rocket is a **launch-ready starter theme** for web designers, developers, bloggers, and anyone who needs a portfolio website. Every page is already built and styled — you change the text and content, and your site is ready to go live.
+Astro Rocket is a **free, open-source Astro theme** built around a complete component library: 57 designed, accessible, TypeScript components that all speak one design language — so whatever you build with them looks right. Around that library it brings everything a real website needs: pages to start from, a full blog, search, SEO, i18n, dark mode, and 12 colour themes. It's made for web designers, developers, bloggers, and anyone who wants to build a beautiful website without starting from zero. Use all of it or only the parts you need — the website you build on it is yours.
 
 It ships with a full blog, a complete component library, a built-in SEO layer, dark mode, a contact form, and 12 colour themes you can switch with one click. It's built on Astro 7 and Tailwind CSS v4.
 

--- a/src/components/landing/Credibility.astro
+++ b/src/components/landing/Credibility.astro
@@ -32,7 +32,7 @@ const stats = [
 
       <div class="text-foreground-secondary space-y-4 text-lg leading-relaxed">
         <p>
-          Astro Rocket is a ready-to-go starter — no CLI wizard, no configuration maze. Clone the repo and you have a full production-grade site in minutes.
+          Astro Rocket is a ready-to-go theme — no CLI wizard, no configuration maze. Clone the repo and you have a complete, production-grade foundation in minutes.
         </p>
         <p>
           Swap out the content, adjust the design tokens, and deploy. Everything is already wired: routing, components, blog, i18n support, dark mode, and SEO.

--- a/src/components/landing/FeatureTabs.tsx
+++ b/src/components/landing/FeatureTabs.tsx
@@ -163,7 +163,7 @@ export default {
   'nav.home': 'Home',
   'nav.about': 'About',
   'hero.title': 'Ship faster with Astro Rocket',
-  'hero.subtitle': 'The modern Astro starter',
+  'hero.subtitle': 'The modern Astro theme',
 } as const;
 
 // Usage in components

--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -242,7 +242,7 @@ export interface SiteConfig {
 const siteConfig: SiteConfig = {
   name: 'Astro Rocket',
   description:
-    'Astro Rocket — A production-ready Astro 7 starter with 12 beautiful themes, 57+ components, built-in i18n, dark mode and a fast, modern foundation to build anything on.',
+    'Astro Rocket — A free, open-source Astro 7 theme: a complete component library for building beautiful websites, with 12 colour themes, 57+ components, built-in i18n, and dark mode.',
   url: SITE_URL || 'https://astrorocket.dev',
   ogImage: '/og-default.svg',
   author: 'Hans Martens',

--- a/src/content/authors/team.json
+++ b/src/content/authors/team.json
@@ -1,6 +1,6 @@
 {
   "name": "Astro Rocket",
-  "bio": "Astro Rocket is a free, open-source Astro 7 starter theme. Built for speed, accessibility, and developer experience — clone it and start shipping.",
+  "bio": "Astro Rocket is a free, open-source Astro 7 theme built around a complete component library. Made for speed, accessibility, and developer experience — clone it and build something beautiful.",
   "social": {
     "github": "https://github.com",
     "linkedin": "https://linkedin.com",

--- a/src/content/blog/en/animations-in-astro-rocket.mdx
+++ b/src/content/blog/en/animations-in-astro-rocket.mdx
@@ -323,4 +323,4 @@ Three things hold this together at the quality of a paid animation toolkit:
 
 **Cascade precedence is explicit.** The animation rules live outside every Tailwind `@layer`, which makes them unlayered CSS — and unlayered rules win over any `@layer`-scoped utility. No Tailwind class can accidentally override a `transition` or `animation` the system depends on.
 
-The full system lives in `src/styles/global.css`, and the observer script in `src/layouts/BaseLayout.astro`. See the [Astro Rocket project page](/projects/astro-rocket) for the full picture of what ships in the starter.
+The full system lives in `src/styles/global.css`, and the observer script in `src/layouts/BaseLayout.astro`. See the [Astro Rocket project page](/projects/astro-rocket) for the full picture of what ships in the theme.

--- a/src/content/projects/en/astro-rocket.mdx
+++ b/src/content/projects/en/astro-rocket.mdx
@@ -30,7 +30,7 @@ I made it for the people I know best: designers, freelancers, and developers who
   <LighthouseScoresGrid />
 </div>
 
-The whole point was a starter that scores **100 on all four Lighthouse categories — Performance, Accessibility, Best Practices, and SEO — out of the box**, on both mobile and desktop. And not on a stripped-back demo page: the full site, with the animations, the theme switcher, the typed headline, and the contact form all running.
+The whole point was a theme that scores **100 on all four Lighthouse categories — Performance, Accessibility, Best Practices, and SEO — out of the box**, on both mobile and desktop. And not on a stripped-back demo page: the full site, with the animations, the theme switcher, the typed headline, and the contact form all running.
 
 That score isn't something I bolt on at the end. It comes from Astro shipping **zero JavaScript by default** and me refusing to undo that. If you want the plain-language version of what the four numbers mean, I wrote it up in [the Lighthouse post](https://hansmartens.dev/blog/lighthouse-score-explained).
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -187,20 +187,20 @@
   "pages": {
     "about": {
       "meta": {
-        "title": "About — Astro 7 Starter Theme",
-        "description": "Astro Rocket is a production-ready Astro 7 starter theme with 12 themes, 57+ components, built-in i18n, dark mode, and everything you need to launch fast."
+        "title": "About — Free Open-Source Astro 7 Theme",
+        "description": "Astro Rocket is a free, open-source Astro 7 theme built around a complete component library: 57 designed components, 12 colour themes, built-in i18n, and dark mode."
       },
       "hero": {
         "badge": "About",
         "titleLead": "Astro Rocket —",
-        "typingWords": ["Astro 7 Starter", "Production-Ready", "12 Themes", "57+ Components", "Dark Mode", "Built-in i18n", "Zero Config SEO"],
-        "description": "A free, production-ready Astro 7 starter theme with everything you need to build fast, modern websites — without starting from scratch."
+        "typingWords": ["Astro 7 Theme", "Component Library", "12 Themes", "57+ Components", "Dark Mode", "Built-in i18n", "Zero Config SEO"],
+        "description": "A free, open-source Astro 7 theme — a complete component library for building beautiful websites, without starting from zero."
       },
       "intro": {
         "badge": "Free & Open Source",
         "heading": "A solid foundation for any project",
         "paragraphs": [
-          "Astro Rocket is a production-ready starter theme built on Astro 7. It ships with a full component library, 12 hand-crafted themes, dark mode, built-in i18n, and a blog — so you can focus on building your project, not the boilerplate.",
+          "Astro Rocket is a free, open-source theme built on Astro 7, designed around a complete component library: 57 designed components, 12 hand-crafted colour themes, dark mode, built-in i18n, and a blog — so you can build a beautiful website instead of boilerplate.",
           "It's free, MIT licensed, and listed on the official Astro themes directory. Clone it, customise it, and ship something you're proud of."
         ],
         "facts": [
@@ -378,15 +378,15 @@
     },
     "home": {
       "meta": {
-        "title": "Astro 7 starter theme",
-        "description": "A production-ready Astro 7 starter with 12 beautiful themes, 57+ components, built-in i18n, dark mode and a fast, modern foundation to build anything on."
+        "title": "Free open-source Astro 7 theme",
+        "description": "A free, open-source Astro 7 theme: a complete component library for building beautiful websites — 12 colour themes, 57+ components, built-in i18n, and dark mode."
       },
       "hero": {
         "badge": "Available for new projects",
         "titleLine1": "Astro Rocket —",
         "titleLine2": "Web Designer",
         "titleLine3": "& Developer",
-        "description": "Astro 7 starter with 12 beautiful themes, 57+ components, dark mode and a fast, modern foundation to build anything on.",
+        "description": "A free Astro 7 theme: 57+ designed components, 12 beautiful colour themes, dark mode — a complete component library to build anything on.",
         "github": "Get it on GitHub",
         "getStarted": "Get started"
       },

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -187,20 +187,20 @@
   "pages": {
     "about": {
       "meta": {
-        "title": "Over — Astro 7 starterthema",
-        "description": "Astro Rocket is een productieklaar Astro 7 starterthema met 12 thema's, 57+ componenten, ingebouwde i18n, donkere modus en alles wat je nodig hebt om snel te lanceren."
+        "title": "Over — Gratis open-source Astro 7 thema",
+        "description": "Astro Rocket is een gratis, open-source Astro 7 thema gebouwd rond een complete componentbibliotheek: 57 ontworpen componenten, 12 kleurthema's, ingebouwde i18n en donkere modus."
       },
       "hero": {
         "badge": "Over",
         "titleLead": "Astro Rocket —",
-        "typingWords": ["Astro 7 Starter", "Productieklaar", "12 Thema's", "57+ Componenten", "Donkere modus", "Ingebouwde i18n", "Zero-config SEO"],
-        "description": "Een gratis, productieklaar Astro 7 starterthema met alles wat je nodig hebt om snelle, moderne websites te bouwen — zonder vanaf nul te beginnen."
+        "typingWords": ["Astro 7 Thema", "Componentbibliotheek", "12 Thema's", "57+ Componenten", "Donkere modus", "Ingebouwde i18n", "Zero-config SEO"],
+        "description": "Een gratis, open-source Astro 7 thema — een complete componentbibliotheek om mooie websites mee te bouwen, zonder vanaf nul te beginnen."
       },
       "intro": {
         "badge": "Gratis & open source",
         "heading": "Een stevige basis voor elk project",
         "paragraphs": [
-          "Astro Rocket is een productieklaar starterthema gebouwd op Astro 7. Het wordt geleverd met een volledige componentbibliotheek, 12 met de hand gemaakte thema's, donkere modus, ingebouwde i18n en een blog — zodat jij je kunt richten op je project in plaats van op de boilerplate.",
+          "Astro Rocket is een gratis, open-source thema gebouwd op Astro 7, ontworpen rond een complete componentbibliotheek: 57 ontworpen componenten, 12 met de hand gemaakte kleurthema's, donkere modus, ingebouwde i18n en een blog — zodat je een mooie website bouwt in plaats van boilerplate.",
           "Het is gratis, MIT-gelicentieerd en vermeld in de officiële Astro-themamap. Kloon het, pas het aan en lanceer iets waar je trots op bent."
         ],
         "facts": [
@@ -378,15 +378,15 @@
     },
     "home": {
       "meta": {
-        "title": "Astro 7 starterthema",
-        "description": "Een productieklaar Astro 7 starterthema met 12 prachtige thema's, 57+ componenten, ingebouwde i18n, donkere modus en een snelle, moderne basis om alles op te bouwen."
+        "title": "Gratis open-source Astro 7 thema",
+        "description": "Een gratis, open-source Astro 7 thema: een complete componentbibliotheek om mooie websites mee te bouwen — 12 kleurthema's, 57+ componenten, ingebouwde i18n en donkere modus."
       },
       "hero": {
         "badge": "Beschikbaar voor nieuwe projecten",
         "titleLine1": "Astro Rocket —",
         "titleLine2": "Webdesigner",
         "titleLine3": "& Ontwikkelaar",
-        "description": "Astro 7 starter met 12 prachtige thema's, 57+ componenten, donkere modus en een snelle, moderne basis om alles op te bouwen.",
+        "description": "Een gratis Astro 7 thema: 57+ ontworpen componenten, 12 prachtige kleurthema's, donkere modus — een complete componentbibliotheek om alles op te bouwen.",
         "github": "Bekijk op GitHub",
         "getStarted": "Aan de slag"
       },

--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -112,7 +112,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
               </h2>
 
               <p slot="description">
-                A modern starter kit for production websites.
+                A complete component library for production websites.
               </p>
 
               <Fragment slot="actions">
@@ -584,7 +584,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
             <Footer
               layout="columns"
               columns={4}
-              tagline="Modern starter kit for production websites"
+              tagline="A complete component library for production websites"
               socialLinks={[
                 { platform: 'github', href: '#' },
                 { platform: 'twitter', href: '#' },
@@ -1681,7 +1681,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 { id: '001', product: 'Astro Rocket Pro', price: '$49', stock: '120' },
                 { id: '002', product: 'Astro Rocket Team', price: '$99', stock: '85' },
                 { id: '003', product: 'Astro Rocket Enterprise', price: '$249', stock: '42' },
-                { id: '004', product: 'Astro Rocket Starter', price: 'Free', stock: '∞' },
+                { id: '004', product: 'Astro Rocket Theme', price: 'Free', stock: '∞' },
               ]}
             />
           </div>
@@ -1874,7 +1874,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
           <div class="showcase-content">
             <Accordion
               items={[
-                { title: 'What is Astro Rocket?', content: 'Astro Rocket is a modern Astro starter template with Tailwind CSS v4, React islands, and a comprehensive component library. It includes everything you need to build production-ready websites.' },
+                { title: 'What is Astro Rocket?', content: 'Astro Rocket is a modern Astro theme built around a complete component library, with Tailwind CSS v4 and React islands. It includes everything you need to build beautiful, production-ready websites.' },
                 { title: 'Is it free to use?', content: 'Yes! Astro Rocket is open source and completely free. You can use it for personal and commercial projects without any restrictions.' },
                 { title: 'How do I customize the theme?', content: 'Astro Rocket uses CSS custom properties (design tokens) for theming. Edit the token files in src/styles/tokens/ to customize colors, spacing, typography, and more.' },
               ]}


### PR DESCRIPTION
## What does this PR do?

Astro Rocket has grown far beyond the starter it began as, but the README and demo copy still described it that way. This updates the wording everywhere it appears, so the description matches what the theme actually offers today: a free, open-source Astro 7 theme built around a complete component library — 57 designed, accessible components that all speak one design language — with pages to start from, a full blog, search, SEO, opt-in i18n, dark mode, and 12 colour themes around it.

Copy changes, in both shipped locales (`en` + `nl`):

- README strapline and Overview
- Homepage and About hero copy, meta titles/descriptions, and the About typing words
- Author bio (`team.json`) and site description (`site.config.ts`)
- Credibility section, FeatureTabs subtitle, and the component-showcase demo strings

The "Blog Starter" demo project keeps its name — that one genuinely is a starter.

**Also adds one blog post:** the full LetterGlitch build tutorial (`letter-glitch-astro-7`), documenting the `LetterGlitchBand` component that ships with the theme — the canvas effect, the Astro wrapper, and the reasoning behind the desktop-only breakpoint. Moved here from the creator's personal blog and adapted to speak from the theme's perspective.

Fixes # — n/a

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [x] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm check` passes with 0 errors
- [x] `pnpm build` completes successfully
- [x] I have tested this change in the browser
- [x] No unnecessary files are included in this PR

## Screenshots (if relevant)

Copy and content changes — layout and components are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST