### PR TITLE
Keep tag links inside the active locale on article and project heroes

### DIFF
--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -61,7 +61,7 @@ const readingTime = getReadingTime(body ?? description);
 
     <!-- Tags (directly below the abstract, where the issue marked them) -->
     {tags.length > 0 && (
-      <TagList tags={tags} class="mb-[var(--space-stack-lg)]" />
+      <TagList tags={tags} locale={locale} class="mb-[var(--space-stack-lg)]" />
     )}
 
     <!-- Meta info -->

--- a/src/components/projects/ProjectHero.astro
+++ b/src/components/projects/ProjectHero.astro
@@ -7,6 +7,7 @@ import ProjectTagList from '@/components/projects/ProjectTagList.astro';
 import HeroGrid from '@/components/effects/HeroGrid.astro';
 import HeroBeam from '@/components/effects/HeroBeam.astro';
 import type { GallerySlide } from '@/lib/gallery';
+import { getLocaleFromPath } from '@/i18n';
 
 interface Props {
   title: string;
@@ -41,6 +42,9 @@ const slides: GallerySlide[] =
       ? [{ src: image, alt: imageAlt || title }]
       : [];
 const hasMedia = slides.length > 0;
+
+// Tag links must stay inside the active locale (`/<locale>/projects/tag/…`).
+const locale = getLocaleFromPath(Astro.url.pathname);
 ---
 
 <header class="relative isolate overflow-hidden pt-[var(--space-page-top-sm)] pb-[var(--space-section-md)]">
@@ -65,7 +69,7 @@ const hasMedia = slides.length > 0;
         </p>
 
         {tags.length > 0 && (
-          <ProjectTagList tags={tags} class="mb-[var(--space-stack-lg)]" />
+          <ProjectTagList tags={tags} locale={locale} class="mb-[var(--space-stack-lg)]" />
         )}
 
         {meta.length > 0 && (


### PR DESCRIPTION
Fixes #499. On a non-default-locale blog post, the tag pills under the title linked to the default locale's tag archive (/blog/tag/…) instead of the locale's own (/<locale>/blog/tag/…) — TagList supports a locale prop, but ArticleHero never passed it. Project pages had the identical gap: ProjectHero rendered ProjectTagList without a locale.

Pass the locale in both heroes (ProjectHero now derives it from the URL like every other localized component). Default single-locale builds are unchanged — the default locale produces the same unprefixed URLs as before. Verified against an i18n-enabled build with temporary nl content: tag links on /nl/blog/<post> and /nl/projects/<slug> are correctly /nl/-prefixed, and the default build's links are byte- identical.

Reported by Dixin, who also pinpointed the component.


Claude-Session: https://claude.ai/code/session_01WQidD3Aap8RURdDBxEXN1s

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
