### PR TITLE
Use on-invert tokens for hero text in light mode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -341,24 +341,24 @@
     isolation: isolate;
     background: linear-gradient(to bottom, var(--color-brand-500) 0%, #000 100%);
   }
+  /* The hero panel stays dark in light mode, so its text colours come from
+     the active theme's on-invert tokens (text on inverted surfaces) rather
+     than hard-coded values — this keeps the hero correct across all colour
+     themes. */
   html:not(.dark) .hero-dark-gradient {
-    --color-foreground:           oklch(91% 0.008 250);
-    --color-foreground-secondary: oklch(82% 0.012 250);
-    --color-foreground-muted:     oklch(68% 0.01 250);
+    --color-foreground:           var(--on-invert);
+    --color-foreground-secondary: var(--on-invert-secondary);
+    --color-foreground-muted:     var(--on-invert-muted);
     --color-background:           var(--surface-invert);
     --color-secondary:            var(--surface-invert-secondary);
     --color-secondary-hover:      var(--surface-invert-tertiary);
-    --color-ring:                 oklch(91% 0.008 250);
+    --color-ring:                 var(--on-invert);
   }
 
-  /* H1 spans: first span uses remapped foreground (near-white), remaining
-     spans use pure #fff. Mirrors the dark-mode treatment. */
-  html:not(.dark) .hero-dark-gradient h1 > span:first-of-type {
+  /* H1 spans: one colour for every span, matching dark mode's uniform
+     treatment. */
+  html:not(.dark) .hero-dark-gradient h1 > span {
     color: var(--color-foreground);
-    -webkit-text-fill-color: currentColor;
-  }
-  html:not(.dark) .hero-dark-gradient h1 > span:not(:first-of-type) {
-    color: #fff;
     -webkit-text-fill-color: currentColor;
   }
 


### PR DESCRIPTION
The homepage hero keeps its dark gradient panel in light mode, but its remapped text colours were hard-coded near-whites with a blue hue — a leftover from when blue was the default theme. They now use the active theme's on-invert tokens, so the hero text is correct on every colour theme.

This also removes the light-mode-only split that rendered the first H1 span in the remapped near-white and the remaining spans in pure #fff: two different whites on one heading. All spans now share one colour, matching dark mode's uniform treatment.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
