### PR TITLE
Add the ProofTile component

### DIFF
--- a/src/components/landing/LighthouseScoresGrid.astro
+++ b/src/components/landing/LighthouseScoresGrid.astro
@@ -11,7 +11,6 @@
  * context (e.g. inside a `data-reveal-content` prose container) so the
  * inner card stagger doesn't fight the parent's block-level reveal.
  */
-import Card from '@/components/ui/data-display/Card/Card.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 
 interface Props {
@@ -39,11 +38,9 @@ const wrapperProps = staggered ? { 'data-reveal-children': true } : {};
 
 <div class="grid grid-cols-2 gap-[var(--space-content-gap)] md:grid-cols-4" {...wrapperProps}>
   {scores.map((score, i) => (
-    <Card variant="elevated" padding="sm" hover class="h-full text-center border-t-2 border-t-brand-500/40 transition-colors duration-200 hover:border-t-brand-500">
+    <div class="bg-background-tertiary rounded-xl p-5 text-center border border-brand-500/40 ring-1 ring-brand-500/15 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-md hover:border-brand-500/80 hover:ring-brand-500/30 cursor-default h-full">
       <div class="flex flex-col items-center gap-[var(--space-stack-sm)]">
-        <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
-          <Icon name={score.icon} size="md" />
-        </div>
+        <Icon name={score.icon} class="w-10 h-10 text-brand-500" />
         <span
           class="lh-number font-display text-4xl font-bold text-brand-500"
           data-target={score.value}
@@ -52,7 +49,7 @@ const wrapperProps = staggered ? { 'data-reveal-children': true } : {};
         >0</span>
         <span class="text-base font-medium text-foreground-muted">{score.label}</span>
       </div>
-    </Card>
+    </div>
   ))}
 </div>
 

--- a/src/components/ui/data-display/ProofTile/ProofTile.astro
+++ b/src/components/ui/data-display/ProofTile/ProofTile.astro
@@ -1,0 +1,75 @@
+---
+/**
+ * ProofTile
+ * A centered tile for facts, features, and process steps: a bare brand
+ * icon — or a step number — above bold text, on the tertiary background
+ * with a soft brand border and a gentle hover lift.
+ *
+ * Two sizes:
+ * - `md` (default) — feature tile: icon, title, and a short description
+ *   in the default slot.
+ * - `sm` — compact proof tile: icon and a single bold line (the title),
+ *   vertically centered.
+ *
+ * Pass `icon` for an icon tile or `number` for a numbered step tile.
+ * Pass `href` to render the whole tile as a link.
+ */
+import type { HTMLAttributes } from 'astro/types';
+import { cn } from '@/lib/cn';
+import Icon from '@/components/ui/primitives/Icon/Icon.astro';
+import { proofTileVariants } from './proof-tile.variants';
+
+interface Props extends HTMLAttributes<'div'>, Pick<HTMLAttributes<'a'>, 'target' | 'rel'> {
+  /** Icon name, rendered bare in the brand colour above the text */
+  icon?: string;
+  /** Step number, rendered in place of an icon (process steps) */
+  number?: string | number;
+  /** Bold tile title */
+  title?: string;
+  /** Heading element for the title. Match your page's heading hierarchy. */
+  titleTag?: 'h3' | 'h4' | 'p';
+  /** Render the tile as a link */
+  href?: string;
+  size?: 'sm' | 'md';
+}
+
+const {
+  icon,
+  number,
+  title,
+  titleTag = 'h3',
+  href,
+  size = 'md',
+  class: className,
+  ...attrs
+} = Astro.props;
+
+const Element = href ? 'a' : 'div';
+const TitleTag = titleTag;
+const hasBody = Astro.slots.has('default');
+---
+
+<Element
+  class={cn(proofTileVariants({ size }), !href && 'cursor-default', className)}
+  href={href}
+  {...attrs}
+>
+  {icon && <Icon name={icon} class="w-10 h-10 text-brand-500" />}
+  {number !== undefined && (
+    <span class="font-display text-3xl font-bold text-brand-500 leading-none">{number}</span>
+  )}
+  {(title || hasBody) && (
+    <div>
+      {title && (
+        <TitleTag class={cn('font-semibold text-foreground', size === 'sm' ? 'text-sm' : 'text-base')}>
+          {title}
+        </TitleTag>
+      )}
+      {hasBody && (
+        <p class={cn('text-sm text-foreground-muted leading-relaxed', title && 'mt-1.5')}>
+          <slot />
+        </p>
+      )}
+    </div>
+  )}
+</Element>

--- a/src/components/ui/data-display/ProofTile/ProofTile.tsx
+++ b/src/components/ui/data-display/ProofTile/ProofTile.tsx
@@ -1,0 +1,67 @@
+import { type HTMLAttributes, type Ref, type ReactNode, createElement } from 'react';
+import { cn } from '@/lib/cn';
+import { proofTileVariants, type ProofTileVariants } from './proof-tile.variants';
+
+interface ProofTileProps extends Omit<HTMLAttributes<HTMLElement>, 'ref' | 'title'> {
+  ref?: Ref<HTMLElement>;
+  /** Pre-rendered icon node, shown bare in the brand colour above the text */
+  icon?: ReactNode;
+  /** Step number, rendered in place of an icon (process steps) */
+  number?: string | number;
+  /** Bold tile title */
+  title?: string;
+  /** Heading element for the title. Match your page's heading hierarchy. */
+  titleTag?: 'h3' | 'h4' | 'p';
+  /** Render the tile as a link */
+  href?: string;
+  target?: string;
+  rel?: string;
+  size?: ProofTileVariants['size'];
+  /** Short description below the title */
+  children?: ReactNode;
+}
+
+export function ProofTile({
+  ref,
+  icon,
+  number,
+  title,
+  titleTag = 'h3',
+  href,
+  size = 'md',
+  className,
+  children,
+  ...rest
+}: ProofTileProps) {
+  const Element = href ? 'a' : 'div';
+  return (
+    <Element
+      ref={ref as Ref<never>}
+      href={href}
+      className={cn(proofTileVariants({ size }), !href && 'cursor-default', className)}
+      {...rest}
+    >
+      {icon && <span className="w-10 h-10 text-brand-500 [&>svg]:w-full [&>svg]:h-full">{icon}</span>}
+      {number !== undefined && (
+        <span className="font-display text-3xl font-bold text-brand-500 leading-none">{number}</span>
+      )}
+      {(title || children) && (
+        <div>
+          {title &&
+            createElement(
+              titleTag,
+              { className: cn('font-semibold text-foreground', size === 'sm' ? 'text-sm' : 'text-base') },
+              title
+            )}
+          {children && (
+            <p className={cn('text-sm text-foreground-muted leading-relaxed', title && 'mt-1.5')}>
+              {children}
+            </p>
+          )}
+        </div>
+      )}
+    </Element>
+  );
+}
+
+export default ProofTile;

--- a/src/components/ui/data-display/ProofTile/index.ts
+++ b/src/components/ui/data-display/ProofTile/index.ts
@@ -1,0 +1,3 @@
+export { default } from './ProofTile.astro';
+export { ProofTile } from './ProofTile';
+export { proofTileVariants, type ProofTileVariants } from './proof-tile.variants';

--- a/src/components/ui/data-display/ProofTile/proof-tile.variants.ts
+++ b/src/components/ui/data-display/ProofTile/proof-tile.variants.ts
@@ -1,0 +1,26 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const proofTileVariants = cva(
+  [
+    'bg-background-tertiary rounded-xl flex flex-col items-center text-center',
+    'border border-brand-500/40 ring-1 ring-brand-500/15 shadow-sm',
+    'transition-all duration-200',
+    'hover:-translate-y-1 hover:shadow-md hover:border-brand-500/80 hover:ring-brand-500/30',
+    'h-full',
+  ],
+  {
+    variants: {
+      size: {
+        /** Compact proof tile: icon and a single bold line, vertically centered */
+        sm: 'p-5 gap-2 justify-center',
+        /** Feature tile: icon (or number), title, and a short description */
+        md: 'p-6 gap-3',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  }
+);
+
+export type ProofTileVariants = VariantProps<typeof proofTileVariants>;

--- a/src/components/ui/data-display/index.ts
+++ b/src/components/ui/data-display/index.ts
@@ -1,5 +1,6 @@
 // Data Display Components
 export * from './Card';
+export * from './ProofTile';
 export * from './Badge';
 export * from './Avatar';
 export * from './AvatarGroup';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -6,7 +6,7 @@
  *
  * Categories:
  * - form: Button, Input, Textarea, Select, Checkbox, Radio, Switch
- * - data-display: Card, Badge, Avatar, AvatarGroup, Table, Pagination, Progress, Skeleton
+ * - data-display: Card, ProofTile, Badge, Avatar, AvatarGroup, Table, Pagination, Progress, Skeleton
  * - feedback: Alert, Toast, Tooltip
  * - overlay: Dialog, Dropdown, Tabs, VerticalTabs, Accordion
  * - layout: Separator

--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -10,6 +10,7 @@ import Radio from '@/components/ui/form/Radio/Radio.astro';
 import Switch from '@/components/ui/form/Switch/Switch.astro';
 // Data Display Components
 import Card from '@/components/ui/data-display/Card/Card.astro';
+import ProofTile from '@/components/ui/data-display/ProofTile/ProofTile.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Avatar from '@/components/ui/data-display/Avatar/Avatar.astro';
 import AvatarGroup from '@/components/ui/data-display/AvatarGroup/AvatarGroup.astro';
@@ -1452,6 +1453,58 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                   Built-in translation system with SEO-friendly URLs and automatic locale detection.
                 </p>
               </Card>
+            </div>
+          </div>
+        </div>
+
+        <!-- Proof Tiles -->
+        <div class="component-showcase">
+          <div class="showcase-header">
+            <span class="showcase-label">Proof Tiles</span>
+            <span class="showcase-hint">Centered tiles for facts, features, and process steps</span>
+          </div>
+          <div class="showcase-content">
+            <div class="flex flex-col gap-5">
+              <!-- Feature tiles: icon, title, description -->
+              <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                <ProofTile icon="layout" title="Designed">
+                  Every piece speaks the same design language, so whatever you build looks right.
+                </ProofTile>
+                <ProofTile icon="zap" title="Fast">
+                  Zero JavaScript by default. Pages open instantly, on every device.
+                </ProofTile>
+                <ProofTile icon="shield-check" title="Accessible">
+                  Keyboard navigation, focus states, and semantic markup, built in from the start.
+                </ProofTile>
+              </div>
+              <!-- Compact proof tiles: icon and one bold line -->
+              <div class="grid grid-cols-2 gap-5 lg:grid-cols-4">
+                <ProofTile size="sm" icon="star" title="Loved on GitHub" />
+                <ProofTile size="sm" icon="award" title="Officially listed" href="#data" />
+                <ProofTile size="sm" icon="users" title="Built in the open" />
+                <ProofTile size="sm" icon="rocket" title="Production proven" />
+              </div>
+              <!-- Numbered step tiles: process walkthroughs -->
+              <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+                <ProofTile number="1" title="First contact">
+                  Send a message and plan a first talk.
+                </ProofTile>
+                <ProofTile number="2" title="Proposal">
+                  One clear document: scope, timeline, price.
+                </ProofTile>
+                <ProofTile number="3" title="Design & build">
+                  Follow the progress on a staging link.
+                </ProofTile>
+                <ProofTile number="4" title="Launch">
+                  Live on your own domain, in your name.
+                </ProofTile>
+              </div>
+              <p class="text-xs text-foreground-subtle">
+                <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">&lt;ProofTile icon="zap" title="Fast"&gt;Description&lt;/ProofTile&gt;</code>
+                {' '}— use <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">size="sm"</code> for compact tiles,{' '}
+                <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">number</code> for steps, and{' '}
+                <code class="rounded bg-secondary px-1.5 py-0.5 text-xs">href</code> to make a tile a link.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
A centered tile for facts, features, and process steps: a bare brand icon or a step number above bold text, on the tertiary background with a soft brand border and a gentle hover lift. Ships in both Astro and React variants with CVA sizes (md feature tile, sm compact proof tile), an optional href to render the tile as a link, and a titleTag prop to match the page's heading hierarchy.

Documented in the live component showcase with all three shapes, and the Lighthouse score grid adopts the same tile treatment in place of its old elevated card with the gradient icon chip.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
