### PR TITLE
Use ProofTile across the demo pages

### DIFF
--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -15,6 +15,7 @@ import PageLayout from '@/layouts/PageLayout.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Card from '@/components/ui/data-display/Card/Card.astro';
+import ProofTile from '@/components/ui/data-display/ProofTile/ProofTile.astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import { Hero } from '@/components/hero';
 import TypingEffect from '@/components/ui/TypingEffect.astro';
@@ -116,19 +117,11 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
         <!-- Right: theme facts card -->
         <div class="flex flex-col h-full" data-reveal data-reveal-eager data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="flex-1 flex flex-col justify-center">
-            <div class="grid grid-cols-2 sm:grid-cols-3 glitch:grid-cols-2 gap-x-6 gap-y-8">
+            <div class="grid grid-cols-2 sm:grid-cols-3 glitch:grid-cols-2 gap-3 auto-rows-fr">
               {intro.facts.map((fact) => (
-                <div class="flex flex-col items-center text-center gap-3">
-                  <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
-                    <Icon name={fact.icon} size="md" />
-                  </div>
-                  <div>
-                    <h3 class="text-base font-semibold text-foreground">{fact.title}</h3>
-                    <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
-                      {fact.description}
-                    </p>
-                  </div>
-                </div>
+                <ProofTile size="sm" icon={fact.icon} title={fact.title}>
+                  {fact.description}
+                </ProofTile>
               ))}
             </div>
           </Card>
@@ -151,21 +144,11 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
           {principles.lead}
         </p>
       </div>
-      <div class="grid gap-6 sm:gap-8 sm:grid-cols-3">
+      <div class="grid gap-6 sm:grid-cols-3">
         {principles.items.map((item, i) => (
-          <Card hover data-reveal data-reveal-delay={i || undefined}>
-            <div class="flex items-start gap-4 sm:flex-col sm:items-center sm:gap-3 sm:text-center lg:flex-row lg:items-start lg:gap-4 lg:text-left">
-              <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
-                <Icon name={item.icon} size="md" />
-              </div>
-              <div class="flex-1 min-w-0">
-                <h3 class="text-base font-semibold text-foreground">{item.title}</h3>
-                <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
-                  {item.description}
-                </p>
-              </div>
-            </div>
-          </Card>
+          <ProofTile icon={item.icon} title={item.title} data-reveal data-reveal-delay={i || undefined}>
+            {item.description}
+          </ProofTile>
         ))}
       </div>
     </div>

--- a/src/components/pages/views/HomeView.astro
+++ b/src/components/pages/views/HomeView.astro
@@ -15,6 +15,7 @@ import { Hero } from '@/components/hero';
 import Button from '@/components/ui/form/Button/Button.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Card from '@/components/ui/data-display/Card/Card.astro';
+import ProofTile from '@/components/ui/data-display/ProofTile/ProofTile.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import BlogCard from '@/components/blog/BlogCard.astro';
 import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
@@ -212,23 +213,15 @@ const basedInDisplay = `${city ?? 'Your City'}${country ? `, ${country}` : ''}`;
 
       <div class="grid gap-6 sm:grid-cols-3">
         {servicesSection.cards.map((card, i) => (
-          <Card hover href={servicesUrl} class="group flex flex-col" data-reveal data-reveal-delay={i || undefined}>
-            <div class="flex items-start gap-4 sm:flex-col sm:items-center sm:gap-3 sm:text-center lg:flex-row lg:items-start lg:gap-4 lg:text-left">
-              <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
-                <Icon name={card.icon} size="sm" />
-              </div>
-              <div class="flex-1 min-w-0">
-                <h3 class="text-base font-semibold text-foreground">{card.title}</h3>
-                <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
-                  {card.description}
-                </p>
-                <span class="inline-flex items-center gap-1 text-sm font-medium text-brand-500 mt-3 group-hover:gap-2 transition-all">
-                  {servicesSection.learnMore}
-                  <Icon name="arrow-right" size="sm" />
-                </span>
-              </div>
-            </div>
-          </Card>
+          <ProofTile
+            href={servicesUrl}
+            icon={card.icon}
+            title={card.title}
+            data-reveal
+            data-reveal-delay={i || undefined}
+          >
+            {card.description}
+          </ProofTile>
         ))}
       </div>
     </div>

--- a/src/components/pages/views/ServicesView.astro
+++ b/src/components/pages/views/ServicesView.astro
@@ -12,6 +12,7 @@ import PageLayout from '@/layouts/PageLayout.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Card from '@/components/ui/data-display/Card/Card.astro';
+import ProofTile from '@/components/ui/data-display/ProofTile/ProofTile.astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import { Hero } from '@/components/hero';
 import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
@@ -280,19 +281,9 @@ const aboutUrl = localizedPath('/about', locale);
 
       <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
         {processSection.steps.map((step, i) => (
-          <Card hover data-reveal data-reveal-delay={i || undefined}>
-            <div class="flex flex-col items-center text-center gap-3">
-              <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 font-bold text-base shrink-0">
-                {i + 1}
-              </div>
-              <div>
-                <h3 class="text-base font-semibold text-foreground">{step.title}</h3>
-                <p class="text-sm text-foreground-muted leading-relaxed mt-1.5">
-                  {step.description}
-                </p>
-              </div>
-            </div>
-          </Card>
+          <ProofTile number={i + 1} title={step.title} data-reveal data-reveal-delay={i || undefined}>
+            {step.description}
+          </ProofTile>
         ))}
       </div>
     </div>


### PR DESCRIPTION
The centered icon-card grids on the demo pages adopt the ProofTile component introduced in #503: the homepage services cards (the whole tile now carries the link, replacing the separate learn-more line), the services process steps (numbered tiles), the about principles, and the about facts card (compact sm tiles).

Horizontal row contexts deliberately keep their gradient icon chips — the FAQ card headers, the what's-included card headers, the contact channel rows, and the portfolio card marks — so the rule is simple: centered grids are tiles, inline rows are chips.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
