### PR TITLE
Keep the purple palette inside the sRGB gamut

### DIFF
--- a/src/components/layout/ThemeSelector.astro
+++ b/src/components/layout/ThemeSelector.astro
@@ -28,7 +28,7 @@ const themes = [
   { id: 'blue',    name: 'Blue',    color: 'oklch(62.5% 0.22 255)'  },
   { id: 'indigo',  name: 'Indigo',  color: 'oklch(60%   0.24 264)'  },
   { id: 'violet',  name: 'Violet',  color: 'oklch(62.5% 0.26 277)'  },
-  { id: 'purple',  name: 'Purple',  color: 'oklch(62.5% 0.25 303)'  },
+  { id: 'purple',  name: 'Purple',  color: 'oklch(59.7% 0.251 296)' },
   { id: 'magenta', name: 'Magenta', color: 'oklch(58%   0.28 330)'  },
 ];
 ---

--- a/src/components/layout/ThemeSelectorDropdown.astro
+++ b/src/components/layout/ThemeSelectorDropdown.astro
@@ -26,7 +26,7 @@ const themes = [
   { id: 'blue',    name: 'Blue',    color: 'oklch(62.5% 0.22 255)'  },
   { id: 'indigo',  name: 'Indigo',  color: 'oklch(60%   0.24 264)'  },
   { id: 'violet',  name: 'Violet',  color: 'oklch(62.5% 0.26 277)'  },
-  { id: 'purple',  name: 'Purple',  color: 'oklch(62.5% 0.25 303)'  },
+  { id: 'purple',  name: 'Purple',  color: 'oklch(59.7% 0.251 296)' },
   { id: 'magenta', name: 'Magenta', color: 'oklch(58%   0.28 330)'  },
 ];
 ---

--- a/src/styles/themes/purple.css
+++ b/src/styles/themes/purple.css
@@ -11,15 +11,21 @@
 
 html[data-theme="purple"] {
   /* -------------------------------------------------------------------------
-     Brand Scale Override — Purple (hue 292)
+     Brand Scale Override — Purple
      Inspired by Tailwind purple-*. Vivid and full of character.
+     The 50–500 steps are written as the sRGB colours they actually
+     render as: the previous higher-chroma values sat outside the sRGB
+     gamut, so browsers clipped them — and gradients that interpolated
+     through that out-of-gamut zone showed a visible hue band (see the
+     homepage hero). These values are identical on screen and keep
+     gradients inside the displayable range.
      ------------------------------------------------------------------------- */
-  --brand-50:  oklch(97.5% 0.02  292);
-  --brand-100: oklch(94.5% 0.05  292);
-  --brand-200: oklch(86%   0.13  292);
-  --brand-300: oklch(76%   0.21  292);
-  --brand-400: oklch(68%   0.26  292);
-  --brand-500: oklch(62%   0.28  292);
+  --brand-50:  oklch(97.5% 0.013 295);
+  --brand-100: oklch(94.2% 0.031 296);
+  --brand-200: oklch(84.7% 0.087 298);
+  --brand-300: oklch(73.8% 0.157 298);
+  --brand-400: oklch(65.1% 0.215 298);
+  --brand-500: oklch(59.7% 0.251 296);
   --brand-600: oklch(52.5% 0.25  292);
   --brand-700: oklch(44.5% 0.20  292);
   --brand-800: oklch(36%   0.15  292);


### PR DESCRIPTION
The purple theme's 50-500 brand steps specified oklch colours more saturated than sRGB can display, so browsers clipped them. The clipped colours are what everyone has always seen — but gradients interpolating through the out-of-gamut zone clipped pixel by pixel along the gamut surface, which bent the hue and drew a visible band across the top of the homepage hero. The other themes stay in gamut, which is why only purple showed it.

The 50-500 steps are now written as the exact colours they already rendered as (measured via canvas), so nothing changes visually, while gradients get real in-gamut endpoints and interpolate cleanly. The 600-900 steps were already in gamut and are untouched. The purple swatch in both theme selectors is aligned to the true brand-500.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
