### PR TITLE
Unify nav item styling between floating and fixed headers

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -901,22 +901,22 @@ const buttonId = `${menuId}-button`;
     color: var(--color-foreground);
   }
 
-  [data-header-shape="floating"] .nav-link::after {
-    content: '';
-    position: absolute;
-    bottom: 2px;
-    left: 50%;
-    right: 50%;
-    height: 2px;
-    background: currentColor;
-    border-radius: 1px;
-    transition: left 200ms, right 200ms;
+  /* Nav pills — the same treatment the fixed bar uses (bg-secondary pill on
+     the active item, softer pill on hover). While the capsule floats over the
+     hero gradient the pill is a translucent tint of the current text colour,
+     so it reads on the brand blue; once the header gains its solid background
+     on scroll ([data-scrolled]) it switches to the fixed bar's exact colours. */
+  [data-header-shape="floating"] .nav-link:hover {
+    background: color-mix(in srgb, currentColor 12%, transparent);
   }
-
-  [data-header-shape="floating"] .nav-link:hover::after,
-  [data-header-shape="floating"] .nav-link.hdr-nav-active::after {
-    left: 12px;
-    right: 12px;
+  [data-header-shape="floating"] .nav-link.hdr-nav-active {
+    background: color-mix(in srgb, currentColor 16%, transparent);
+  }
+  [data-header-shape="floating"][data-scrolled] .nav-link:hover {
+    background: color-mix(in srgb, var(--color-secondary) 70%, transparent);
+  }
+  [data-header-shape="floating"][data-scrolled] .nav-link.hdr-nav-active {
+    background: var(--color-secondary);
   }
 
   [data-header-shape="floating"][data-header-color-scheme="invert"] .hdr-invert-cta {
@@ -942,7 +942,7 @@ const buttonId = `${menuId}-button`;
     [data-header-shape="floating"] .hdr-invert-text,
     [data-header-shape="floating"] .hdr-logo-text,
     [data-header-shape="floating"] .hdr-invert-cta,
-    [data-header-shape="floating"] .nav-link::after {
+    [data-header-shape="floating"] .nav-link {
       transition: none !important;
     }
     [data-header-shape="floating"][data-header-hidden] {


### PR DESCRIPTION
The floating header used an expanding underline for hover and active nav items while the fixed bar used secondary-background pills. The floating header now uses the same pill treatment: a translucent currentColor tint while the capsule floats over the hero gradient, and the fixed bar's exact secondary colours once the header solidifies on scroll. The underline pseudo-element is gone; reduced-motion handling follows the pill transitions.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
