### PR TITLE
Make violet the default colour theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Astro Rocket uses a three-tier design token system with OKLCH colors for percept
 
 Astro Rocket ships with 12 colour themes, all based on Tailwind's color palette. All 12 are shown as colour swatches in the header dropdown (`ThemeSelectorDropdown`) on desktop and in the mobile menu (`ThemeSelector`). Clicking a swatch applies the theme instantly — the logo badge, blog image gradients, and every brand color on the page update live. No file edits, no rebuilds. This is a key difference from the original Velocity theme, where switching theme requires editing a CSS import file and rebuilding.
 
-The 12 themes in order: Orange, Amber, Lime, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, Purple (default), and Magenta. The `themes` array in `src/components/layout/ThemeSelector.astro` controls which swatches are shown and in what order. You can also **remove the selector from the header entirely** once you've settled on a color — just remove `showThemeSelector` from the layout file.
+The 12 themes in order: Orange, Amber, Lime, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet (default), Purple, and Magenta. The `themes` array in `src/components/layout/ThemeSelector.astro` controls which swatches are shown and in what order. You can also **remove the selector from the header entirely** once you've settled on a color — just remove `showThemeSelector` from the layout file.
 
 The theme files live in `src/styles/themes/`:
 
@@ -414,7 +414,7 @@ State contract:
 Defaults are seeded directly on the `<html>` element in `src/layouts/BaseLayout.astro` so JS-disabled visitors still see a sensible state:
 
 ```html
-<html lang="en" class="scroll-smooth dark" data-theme="purple" data-theme-mode="system">
+<html lang="en" class="scroll-smooth dark" data-theme="violet" data-theme-mode="system">
 ```
 
 Flash-of-wrong-theme is prevented by an inline `<script>` in `<head>` that runs synchronously before body paint, reads `localStorage.theme`, and reconciles `data-theme-mode` + `.dark`. The same script also re-applies on `astro:before-swap` / `astro:after-swap` to handle view transitions, and subscribes once to the OS-preference media query.

--- a/public/readme-hero.svg
+++ b/public/readme-hero.svg
@@ -1,6 +1,6 @@
 <svg width="880" height="260" viewBox="0 0 880 260" fill="none" xmlns="http://www.w3.org/2000/svg">
   <!-- Background -->
-  <rect width="880" height="260" fill="#a855f7"/>
+  <rect width="880" height="260" fill="#6b65ff"/>
 
   <!-- Lucide Rocket — scale(5), visual centre at (440, 100) -->
   <g transform="translate(379, 41) scale(5)"
@@ -16,7 +16,7 @@
         text-anchor="middle"
         font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif"
         font-weight="800" font-size="62" letter-spacing="-1.5"
-        fill="#faf5ff">Astro Rocket</text>
+        fill="#f3f6ff">Astro Rocket</text>
 
   <!-- Corner marks -->
   <path d="M 30 50 L 30 30 L 50 30"     stroke="#93c5fd" stroke-width="1.5" fill="none" stroke-opacity="0.45"/>

--- a/public/readme-lighthouse.svg
+++ b/public/readme-lighthouse.svg
@@ -5,16 +5,16 @@
   <defs>
     <style>
       .card-bg     { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
-      .card-accent { fill: #a855f7; opacity: 0.45; }
-      .icon-stroke { stroke: #a855f7; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; }
-      .num         { font-family: system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; font-weight: 800; font-size: 44px; fill: #a855f7; text-anchor: middle; }
+      .card-accent { fill: #6b65ff; opacity: 0.45; }
+      .icon-stroke { stroke: #6b65ff; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+      .num         { font-family: system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; font-weight: 800; font-size: 44px; fill: #6b65ff; text-anchor: middle; }
       .label       { font-family: system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; font-weight: 500; font-size: 14px; fill: #64748b; text-anchor: middle; }
       .num-glow    { filter: drop-shadow(0 0 14px rgba(59,130,246,0.45)); }
     </style>
 
     <linearGradient id="iconGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%"  stop-color="#a855f7" stop-opacity="0.20"/>
-      <stop offset="100%" stop-color="#a855f7" stop-opacity="0.05"/>
+      <stop offset="0%"  stop-color="#6b65ff" stop-opacity="0.20"/>
+      <stop offset="100%" stop-color="#6b65ff" stop-opacity="0.05"/>
     </linearGradient>
 
     <symbol id="card" viewBox="0 0 180 180">

--- a/src/components/layout/ThemeSelector.astro
+++ b/src/components/layout/ThemeSelector.astro
@@ -87,7 +87,7 @@ const themes = [
 
 <script>
   const STORAGE_KEY = 'color-theme';
-  const DEFAULT_THEME = 'purple';
+  const DEFAULT_THEME = 'violet';
 
   function getActiveTheme(): string {
     try {

--- a/src/components/layout/ThemeSelectorDropdown.astro
+++ b/src/components/layout/ThemeSelectorDropdown.astro
@@ -107,7 +107,7 @@ const themes = [
 
 <script>
   const STORAGE_KEY = 'color-theme';
-  const DEFAULT_THEME = 'purple';
+  const DEFAULT_THEME = 'violet';
 
   function getActiveTheme(): string {
     try {

--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -348,7 +348,7 @@ const siteConfig: SiteConfig = {
       svg: '/favicon.svg',
     },
     colors: {
-      themeColor: '#a855f7',
+      themeColor: '#6b65ff',
       backgroundColor: '#ffffff',
     },
   },

--- a/src/content/blog/en/astro-rocket-configuration-guide.mdx
+++ b/src/content/blog/en/astro-rocket-configuration-guide.mdx
@@ -74,19 +74,19 @@ When `true`, a translucent brand-colour tint is applied over blog cover images. 
 Astro Rocket uses a 3-state colour-mode system — **System / Light / Dark** — instead of a binary toggle. Defaults are declared on the `<html>` element in `src/layouts/BaseLayout.astro`:
 
 ```html
-<html lang="en" class="scroll-smooth dark" data-theme="purple" data-theme-mode="system">
+<html lang="en" class="scroll-smooth dark" data-theme="violet" data-theme-mode="system">
 ```
 
 Three pieces of state cooperate:
 
 - `class="dark"` is the SSR fallback for visitors with JavaScript disabled — Tailwind's dark variant keys off it.
 - `data-theme-mode="system"` mirrors the user's saved choice and drives the icon shown in the header pill.
-- `data-theme="purple"` is the default colour palette.
+- `data-theme="violet"` is the default colour palette.
 
 For visitors with JavaScript enabled, the inline bootstrap script in `<head>` runs before body paint and reconciles all three values from storage:
 
 - `localStorage.theme` ∈ `'system' | 'light' | 'dark'` — the user's saved colour mode (default `'system'`)
-- `sessionStorage['color-theme']` — the active colour palette (default `'purple'`, resets per tab session)
+- `sessionStorage['color-theme']` — the active colour palette (default `'violet'`, resets per tab session)
 
 Under `'system'`, the bootstrap also subscribes to `window.matchMedia('(prefers-color-scheme: dark)')` once and re-applies on every OS flip. The full design — including the no-flash bootstrap, view-transition handling, and the header pill — is written up in [System, Light, Dark — How Astro Rocket's Colour-Mode System Works](/blog/colour-mode-system).
 

--- a/src/content/projects/en/astro-rocket.mdx
+++ b/src/content/projects/en/astro-rocket.mdx
@@ -36,7 +36,7 @@ That score isn't something I bolt on at the end. It comes from Astro shipping **
 
 ## Twelve themes, one click
 
-Astro Rocket ships **twelve colour themes** — Orange, Amber, Lime, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, **Purple**, and Magenta. They sit as swatches in the header: click one and every brand colour on the page — buttons, links, the auto-generated logo badge, the blog-cover gradients — updates live, no rebuild. **Purple is the default.** Once you've settled on a colour, you can pull the selector out of the header and keep everything else.
+Astro Rocket ships **twelve colour themes** — Orange, Amber, Lime, Emerald, Teal, Cyan, Sky, Blue, Indigo, **Violet**, Purple, and Magenta. They sit as swatches in the header: click one and every brand colour on the page — buttons, links, the auto-generated logo badge, the blog-cover gradients — updates live, no rebuild. **Violet is the default.** Once you've settled on a colour, you can pull the selector out of the header and keep everything else.
 
 Underneath it's just CSS custom properties scoped to a `data-theme` attribute, so the browser does all the work and the server never has to think about it.
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -87,7 +87,7 @@ if (commentsConfig?.enabled) {
 ---
 
 <!doctype html>
-<html lang={locale} class="scroll-smooth dark" data-theme="purple" data-theme-mode="system">
+<html lang={locale} class="scroll-smooth dark" data-theme="violet" data-theme-mode="system">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
The default moves from purple to violet: the html data-theme seed, the DEFAULT_THEME fallback in both theme selectors, the browser theme-color meta, the README (theme list, code sample, and hero image colours), and the demo content that documents the default. Purple stays available as one of the twelve swatches.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
