### PR TITLE
Give the about facts tiles the standard title size

### DIFF
--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -119,7 +119,7 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
           <Card variant="elevated" padding="lg" class="flex-1 flex flex-col justify-center">
             <div class="grid grid-cols-2 sm:grid-cols-3 glitch:grid-cols-2 gap-3 auto-rows-fr">
               {intro.facts.map((fact) => (
-                <ProofTile size="sm" icon={fact.icon} title={fact.title}>
+                <ProofTile icon={fact.icon} title={fact.title}>
                   {fact.description}
                 </ProofTile>
               ))}


### PR DESCRIPTION
The six fact tiles in the Free & Open Source section used the compact ProofTile variant, whose smaller bold titles sat oddly under the icons next to the principles tiles further down the page. They now use the standard tile size, so every tile title on the about page matches.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
