### PR TITLE
Stop the hero primary button flashing dark on hover and tap

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -374,19 +374,23 @@
 
   /* Primary CTA — near-white gradient pill. Targets .btn-primary, which is
      the homepage primary CTA marker (added by the primary button variant). */
+  /* !important throughout: the Button component's own light-mode styles
+     (brand-700 fill, brand-800 hover) otherwise win the cascade for
+     background-color, so hovering or tapping the near-white hero pill
+     flashed it dark blue. */
   html:not(.dark) .hero-dark-gradient .btn-primary {
-    background-color: var(--color-foreground);
+    background-color: var(--color-foreground) !important;
     background-image: linear-gradient(
       180deg,
       var(--color-foreground) 0%,
       color-mix(in oklch, var(--color-foreground) 55%, var(--color-foreground-secondary)) 100%
-    );
-    border: 1px solid var(--color-foreground-secondary);
-    color: var(--color-background);
+    ) !important;
+    border: 1px solid var(--color-foreground-secondary) !important;
+    color: var(--color-background) !important;
   }
   html:not(.dark) .hero-dark-gradient .btn-primary:hover {
-    background-image: none;
-    background-color: color-mix(in oklch, var(--color-foreground) 90%, transparent);
+    background-image: none !important;
+    background-color: color-mix(in oklch, var(--color-foreground) 90%, transparent) !important;
   }
 
   html:not(.dark) .hero-dark-gradient .border-foreground\/25 {


### PR DESCRIPTION
The light-mode hero repaints the primary button as a near-white pill, but without !important its background-color lost the cascade to the Button component's own light-mode styles (brand-700 fill, brand-800 hover). Hovering — or tapping on a touch device, which applies the hover state until navigation — removed the near-white gradient image and revealed the dark brand colour underneath: a white button flashing dark blue.

The override now carries !important on every declaration, so rest and hover both stay near-white and the tap state is visually calm.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
