### PR TITLE
Free the about fact tiles from their wrapping card

### DIFF
--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -118,8 +118,8 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
              read like every other tile grid and keep their full width on
              phones. justify-center keeps the grid vertically centred against
              the text column on desktop. -->
-        <div class="flex flex-col h-full justify-center" data-reveal data-reveal-eager data-reveal-ease="smooth">
-          <div class="grid grid-cols-1 sm:grid-cols-3 glitch:grid-cols-2 gap-3 auto-rows-fr">
+        <div class="flex flex-col h-full justify-center">
+          <div class="grid grid-cols-1 sm:grid-cols-3 glitch:grid-cols-2 gap-3 auto-rows-fr" data-reveal-children>
             {intro.facts.map((fact) => (
               <ProofTile icon={fact.icon} title={fact.title}>
                 {fact.description}


### PR DESCRIPTION
The six fact tiles in the Free & Open Source section sat inside an elevated card — a border around six more borders that stole ~50px of width on phones and squeezed the tiles into narrow towers. The card is gone: the tiles now stand alone like every other tile grid, vertically centred against the text column on desktop, and phones get a single column of full-width tiles instead of two cramped ones.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
