### PR TITLE
Drop the longest word from the about hero typing effect

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -194,7 +194,7 @@
       "hero": {
         "badge": "About",
         "titleLead": "Astro Rocket —",
-        "typingWords": ["Astro 7 Theme", "Component Library", "12 Themes", "57+ Components", "Dark Mode", "Built-in i18n", "Zero Config SEO"],
+        "typingWords": ["Astro 7 Theme", "12 Themes", "57+ Components", "Dark Mode", "Built-in i18n", "Zero Config SEO"],
         "description": "A free, open-source Astro 7 theme — a complete component library for building beautiful websites, without starting from zero."
       },
       "whatYouGet": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -194,7 +194,7 @@
       "hero": {
         "badge": "Over",
         "titleLead": "Astro Rocket —",
-        "typingWords": ["Astro 7 Thema", "Componentbibliotheek", "12 Thema's", "57+ Componenten", "Donkere modus", "Ingebouwde i18n", "Zero-config SEO"],
+        "typingWords": ["Astro 7 Thema", "12 Thema's", "57+ Componenten", "Donkere modus", "Ingebouwde i18n", "Zero-config SEO"],
         "description": "Een gratis, open-source Astro 7 thema — een complete componentbibliotheek om mooie websites mee te bouwen, zonder vanaf nul te beginnen."
       },
       "whatYouGet": {


### PR DESCRIPTION
"Component Library" (and the even longer Dutch "Componentbibliotheek") overflowed the hero line on phones. The remaining six words cover the same ground — the component library still leads the What-you-get section directly below.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
