### PR TITLE
Balance the about hero description

### DIFF
--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -91,7 +91,7 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
       </span>
     </h1>
 
-    <p slot="description">
+    <p slot="description" class="!text-balance">
       {hero.description}
     </p>
   </Hero>


### PR DESCRIPTION
The description's last word ("zero.") wrapped alone on both mobile and desktop. text-balance evens the line lengths so the last line keeps several words, at any width and in any locale. The other page heroes were measured for the same problem and are clean.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
