### PR TITLE
Say "theme with a component library" in the about hero

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -195,7 +195,7 @@
         "badge": "About",
         "titleLead": "Astro Rocket —",
         "typingWords": ["Astro 7 Theme", "12 Themes", "57+ Components", "Dark Mode", "Built-in i18n", "Zero Config SEO"],
-        "description": "A free, open-source Astro 7 theme — a complete component library for building beautiful websites, without starting from zero."
+        "description": "A free, open-source Astro 7 theme with a complete component library for building beautiful websites, without starting from zero."
       },
       "whatYouGet": {
         "badge": "What you get",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -195,7 +195,7 @@
         "badge": "Over",
         "titleLead": "Astro Rocket —",
         "typingWords": ["Astro 7 Thema", "12 Thema's", "57+ Componenten", "Donkere modus", "Ingebouwde i18n", "Zero-config SEO"],
-        "description": "Een gratis, open-source Astro 7 thema — een complete componentbibliotheek om mooie websites mee te bouwen, zonder vanaf nul te beginnen."
+        "description": "Een gratis, open-source Astro 7 thema met een complete componentbibliotheek om mooie websites mee te bouwen, zonder vanaf nul te beginnen."
       },
       "whatYouGet": {
         "badge": "Wat je krijgt",


### PR DESCRIPTION
The em dash equated the theme with the component library; "with" says the theme contains it, which is the truth — the theme is also the pages, blog, search, and everything else. It also removes an em dash from centered text, where the dash breaks poorly. Same change in the Dutch dictionary.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
