### PR TITLE
Polish the about page's centered text

### DIFF
--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -105,7 +105,7 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
             <Icon name="list-checks" size="sm" />
             {whatYouGet.badge}
           </Badge>
-          <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground">
+          <h2 class="font-display text-3xl md:text-4xl font-bold text-foreground text-balance">
             {whatYouGet.heading}
           </h2>
         </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -252,7 +252,7 @@
       "principles": {
         "badge": "Design Principles",
         "heading": "Built with intention",
-        "lead": "Every decision in Astro Rocket — from component structure to default config — is driven by the same three principles.",
+        "lead": "Every decision in Astro Rocket, from component structure to default config, is driven by the same three principles.",
         "items": [
           { "icon": "zap", "title": "Performance First", "description": "Zero JavaScript by default. Every component is optimised for speed, Core Web Vitals, and lean output." },
           { "icon": "award", "title": "Developer Experience", "description": "TypeScript throughout, sensible defaults, and a component library you can drop straight into any page." },
@@ -262,7 +262,7 @@
       "stack": {
         "badge": "Tools & Tech",
         "title": "The Stack",
-        "description": "The technologies powering Astro Rocket — chosen for performance, great developer experience, and long-term reliability."
+        "description": "The technologies powering Astro Rocket, chosen for performance, great developer experience, and long-term reliability."
       },
       "faq": {
         "badge": "Good to know",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -252,7 +252,7 @@
       "principles": {
         "badge": "Ontwerpprincipes",
         "heading": "Met intentie gebouwd",
-        "lead": "Elke keuze in Astro Rocket — van componentstructuur tot standaardconfiguratie — komt voort uit dezelfde drie principes.",
+        "lead": "Elke keuze in Astro Rocket, van componentstructuur tot standaardconfiguratie, komt voort uit dezelfde drie principes.",
         "items": [
           { "icon": "zap", "title": "Prestaties eerst", "description": "Standaard nul JavaScript. Elk component is geoptimaliseerd voor snelheid, Core Web Vitals en compacte output." },
           { "icon": "award", "title": "Ontwikkelaarservaring", "description": "Overal TypeScript, verstandige standaardinstellingen en een componentbibliotheek die je zo in elke pagina laat vallen." },
@@ -262,7 +262,7 @@
       "stack": {
         "badge": "Tools & techniek",
         "title": "De stack",
-        "description": "De technologieën achter Astro Rocket — gekozen voor prestaties, een uitstekende ontwikkelaarservaring en betrouwbaarheid op de lange termijn."
+        "description": "De technologieën achter Astro Rocket, gekozen voor prestaties, een uitstekende ontwikkelaarservaring en betrouwbaarheid op de lange termijn."
       },
       "faq": {
         "badge": "Goed om te weten",


### PR DESCRIPTION
The What-you-get heading gets text-balance so its last line keeps two words on phones instead of an orphan. The principles lead and the stack description drop their em dashes for comma constructions — centered text breaks poorly around dashes — in both the English and Dutch dictionaries. Dashes in left-aligned prose (FAQ answers, the open source card) stay.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
