### PR TITLE
Make the blog hero description match the blog's content

### DIFF
--- a/src/components/blog/views/BlogIndexView.astro
+++ b/src/components/blog/views/BlogIndexView.astro
@@ -61,7 +61,7 @@ const topTags = collectTopTags(posts, BLOG_TAG_CLOUD_LIMIT);
 
     <h1 slot="title">{t('blog.title', locale)}</h1>
 
-    <p slot="description">{t('blog.heroDescription', locale)}</p>
+    <p slot="description" class="!text-balance">{t('blog.heroDescription', locale)}</p>
   </Hero>
 
   <!-- Featured Posts Section -->

--- a/src/components/blog/views/BlogPageView.astro
+++ b/src/components/blog/views/BlogPageView.astro
@@ -66,7 +66,7 @@ const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
 
     <h1 slot="title">{t('blog.title', locale)}</h1>
 
-    <p slot="description">{t('blog.heroDescription', locale)}</p>
+    <p slot="description" class="!text-balance">{t('blog.heroDescription', locale)}</p>
   </Hero>
 
   <section class="bg-background-secondary py-[var(--space-section-md)] border-t border-border">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -52,7 +52,7 @@
     "metaTitle": "Blog",
     "metaDescription": "Articles on web design, development, and the web by Astro Rocket.",
     "heroBadge": "All posts",
-    "heroDescription": "Articles on Astro, web performance, design systems, and building with Astro Rocket.",
+    "heroDescription": "Everything you need to know about Astro\u00a0Rocket, explained in practical guides.",
     "allPosts": "All posts",
     "noPosts": "No posts found",
     "pageMetaTitle": "Blog — Page {page}",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -52,7 +52,7 @@
     "metaTitle": "Blog",
     "metaDescription": "Artikelen over webdesign, ontwikkeling en het web door Astro Rocket.",
     "heroBadge": "Alle berichten",
-    "heroDescription": "Artikelen over Astro, webprestaties, designsystemen en bouwen met Astro Rocket.",
+    "heroDescription": "Alles wat je over Astro\u00a0Rocket moet weten, uitgelegd in praktische gidsen.",
     "allPosts": "Alle berichten",
     "noPosts": "Geen berichten gevonden",
     "pageMetaTitle": "Blog — Pagina {page}",


### PR DESCRIPTION
The demo blog's posts are all practical guides to the theme itself, so the hero now says exactly that instead of promising general articles on web performance and design systems. The description is line-balanced, and a non-breaking space keeps the theme name from splitting across lines.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
