### PR TITLE
Add Home and GitHub links to the footer menu

### DIFF
--- a/src/config/nav.config.ts
+++ b/src/config/nav.config.ts
@@ -78,11 +78,13 @@ export const navItems: NavItem[] = [
 ];
 
 export const footerNavItems: NavItem[] = [
-  { label: 'Services', href: '/services', order: 0, labelKey: 'nav.items.services' },
-  { label: 'Projects', href: '/projects', order: 1, labelKey: 'nav.items.projects' },
-  { label: 'Blog', href: '/blog', order: 2, labelKey: 'nav.items.blog' },
-  { label: 'About', href: '/about', order: 3, labelKey: 'nav.items.about' },
-  { label: 'Contact', href: '/contact', order: 4, labelKey: 'nav.items.contact' },
+  { label: 'Home', href: '/', order: 0, labelKey: 'nav.items.home' },
+  { label: 'Services', href: '/services', order: 1, labelKey: 'nav.items.services' },
+  { label: 'Projects', href: '/projects', order: 2, labelKey: 'nav.items.projects' },
+  { label: 'Blog', href: '/blog', order: 3, labelKey: 'nav.items.blog' },
+  { label: 'About', href: '/about', order: 4, labelKey: 'nav.items.about' },
+  { label: 'Contact', href: '/contact', order: 5, labelKey: 'nav.items.contact' },
+  { label: 'GitHub', href: 'https://github.com/hansmartensdev/Astro-Rocket', order: 6, external: true },
 ];
 
 export const legalLinks: LegalLink[] = [];


### PR DESCRIPTION
Home returns as the first item and a GitHub link to the repository closes the list, opening in a new tab like every external nav item.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
