### PR TITLE
Rework the about hero words and description

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -195,8 +195,8 @@
       "hero": {
         "badge": "About",
         "titleLead": "Astro Rocket —",
-        "typingWords": ["Astro 7 Theme", "12 Themes", "57+ Components", "Dark Mode", "Built-in i18n", "Zero Config SEO"],
-        "description": "A free, open-source Astro 7 starter theme to build anything on, with a complete component library so you never start from zero."
+        "typingWords": ["Lightning-fast", "57+ Components", "12 Themes", "Dark Mode", "Built-in i18n"],
+        "description": "A free, open-source Astro 7 starter\u00a0theme to build anything on."
       },
       "whatYouGet": {
         "badge": "What you get",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -195,8 +195,8 @@
       "hero": {
         "badge": "Over",
         "titleLead": "Astro Rocket —",
-        "typingWords": ["Astro 7 Thema", "12 Thema's", "57+ Componenten", "Donkere modus", "Ingebouwde i18n", "Zero-config SEO"],
-        "description": "Een gratis, open-source Astro 7 starter-thema om alles op te bouwen, met een complete componentbibliotheek zodat je nooit vanaf nul begint."
+        "typingWords": ["Razendsnel", "57+ Componenten", "12 Thema's", "Donkere modus", "Ingebouwde i18n"],
+        "description": "Een gratis, open-source Astro 7 starter-thema om alles op te bouwen."
       },
       "whatYouGet": {
         "badge": "Wat je krijgt",


### PR DESCRIPTION
The typewriter now cycles the theme's qualities and contents — Lightning-fast, 57+ Components, 12 Themes, Dark Mode, Built-in i18n — and the description underneath states plainly what the theme is. Zero Config SEO is retired from the rotation, and a non-breaking space keeps "starter theme" from splitting across lines on phones.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
