### PR TITLE
Turn tertiary cards white on secondary sections in light mode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1374,3 +1374,11 @@
     transform: none;
   }
 }
+
+/* Light mode: tile cards use the tertiary surface, which sits very close to
+   the secondary section background behind them. Cards on secondary sections
+   switch to the page-white surface instead; dark mode keeps the tertiary
+   surface everywhere. */
+html:not(.dark) .bg-background-secondary .bg-background-tertiary {
+  background-color: var(--color-background);
+}


### PR DESCRIPTION
One scoped rule: cards with the tertiary surface that sit inside a secondary section render on the page-white surface in light mode, for contrast against the tinted section behind them. Cards on default sections and everything in dark mode are unchanged.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
