### PR TITLE
Make the contact hero a warm invitation

### DIFF
--- a/src/components/pages/views/ContactView.astro
+++ b/src/components/pages/views/ContactView.astro
@@ -25,10 +25,14 @@ interface Props {
 
 const { locale = defaultLocale } = Astro.props;
 
-const hero = tData<{ badge: string; titleLead: string; titleHighlight: string; description: string }>(
-  'pages.contact.hero',
-  locale
-)!;
+const hero = tData<{
+  badge: string;
+  titleLead: string;
+  titleHighlight: string;
+  description: string;
+  /** Shorter variant shown below the `sm` breakpoint so the hero stays compact on phones. */
+  descriptionMobile: string;
+}>('pages.contact.hero', locale)!;
 
 const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
 
@@ -67,8 +71,9 @@ const channels = [
       {hero.titleLead} <span class="text-brand-500">{hero.titleHighlight}</span>
     </h1>
 
-    <p slot="description">
-      {hero.description}
+    <p slot="description" class="!text-balance">
+      <span class="sm:hidden">{hero.descriptionMobile}</span>
+      <span class="hidden sm:inline">{hero.description}</span>
     </p>
   </Hero>
 

--- a/src/components/pages/views/ContactView.astro
+++ b/src/components/pages/views/ContactView.astro
@@ -25,14 +25,10 @@ interface Props {
 
 const { locale = defaultLocale } = Astro.props;
 
-const hero = tData<{
-  badge: string;
-  titleLead: string;
-  titleHighlight: string;
-  description: string;
-  /** Shorter variant shown below the `sm` breakpoint so the hero stays compact on phones. */
-  descriptionMobile: string;
-}>('pages.contact.hero', locale)!;
+const hero = tData<{ badge: string; titleLead: string; titleHighlight: string; description: string }>(
+  'pages.contact.hero',
+  locale
+)!;
 
 const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
 
@@ -72,8 +68,7 @@ const channels = [
     </h1>
 
     <p slot="description" class="!text-balance">
-      <span class="sm:hidden">{hero.descriptionMobile}</span>
-      <span class="hidden sm:inline">{hero.description}</span>
+      {hero.description}
     </p>
   </Hero>
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -404,7 +404,8 @@
         "badge": "Start a project",
         "titleLead": "Tell me about your",
         "titleHighlight": "new project",
-        "description": "I design and build new websites from scratch — every project, start to finish, by me. Share a few details below and I'll get back to you within 1 business day."
+        "description": "I'd love to hear from you. Send a message with the\u00a0form, or reach out on one of the other channels below.",
+        "descriptionMobile": "I'd love to hear from you. Message\u00a0me on one of the channels below."
       },
       "formTitle": "Project details",
       "channelsTitle": "Other channels",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -404,8 +404,7 @@
         "badge": "Start a project",
         "titleLead": "Tell me about your",
         "titleHighlight": "new project",
-        "description": "I'd love to hear from you. Send a message with the\u00a0form, or reach out on one of the other channels below.",
-        "descriptionMobile": "I'd love to hear from you. Message\u00a0me on one of the channels below."
+        "description": "I'd love to hear from you. Send a message with the form below, or reach out on one of the other channels below."
       },
       "formTitle": "Project details",
       "channelsTitle": "Other channels",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -404,8 +404,7 @@
         "badge": "Start een project",
         "titleLead": "Vertel me over je",
         "titleHighlight": "nieuwe project",
-        "description": "Ik hoor graag van je. Stuur een bericht via het formulier, of gebruik een van de andere kanalen hieronder.",
-        "descriptionMobile": "Ik hoor graag van je. Stuur\u00a0me een bericht via een van de kanalen hieronder."
+        "description": "Ik hoor graag van je. Stuur een bericht via het formulier hieronder, of gebruik een van de andere kanalen hieronder."
       },
       "formTitle": "Projectdetails",
       "channelsTitle": "Andere kanalen",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -404,7 +404,8 @@
         "badge": "Start een project",
         "titleLead": "Vertel me over je",
         "titleHighlight": "nieuwe project",
-        "description": "Ik ontwerp en bouw nieuwe websites vanaf nul — elk project, van begin tot eind, door mij. Deel hieronder een paar details en ik reageer binnen 1 werkdag."
+        "description": "Ik hoor graag van je. Stuur een bericht via het formulier, of gebruik een van de andere kanalen hieronder.",
+        "descriptionMobile": "Ik hoor graag van je. Stuur\u00a0me een bericht via een van de kanalen hieronder."
       },
       "formTitle": "Projectdetails",
       "channelsTitle": "Andere kanalen",


### PR DESCRIPTION
## What does this PR do?

Replaces the contact page hero description with a warm invitation that points at the two ways to get in touch that the page actually offers: the contact form and the channel list below it.

- English: "I'd love to hear from you. Send a message with the form below, or reach out on one of the other channels below."
- Dutch: "Ik hoor graag van je. Stuur een bericht via het formulier hieronder, of gebruik een van de andere kanalen hieronder."

The same text renders at every viewport width (no mobile-only variant), and the paragraph is line-balanced so it wraps evenly on phones.

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [x] Refactor or code quality improvement
- [x] Other: copy change in the demo content

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm check` passes with 0 errors
- [x] `pnpm build` completes successfully
- [x] I have tested this change in the browser
- [x] No unnecessary files are included in this PR

## Screenshots (if relevant)

Verified at 360/390/430/1280px: the description renders as three balanced lines on phones and two on desktop, with no orphan words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST)_