### PR TITLE
Refine the about hero typewriter words

### DIFF
--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -51,10 +51,14 @@ const { locale = defaultLocale } = Astro.props;
 
 const GITHUB_URL = 'https://github.com/hansmartensdev/astro-rocket';
 
-const hero = tData<{ badge: string; titleLead: string; typingWords: string[]; description: string }>(
-  'pages.about.hero',
-  locale
-)!;
+const hero = tData<{
+  badge: string;
+  titleLead: string;
+  typingWords: string[];
+  /** Shorter set for phones (below sm), dropping the one word wide enough to clip at the hero size. */
+  typingWordsMobile: string[];
+  description: string;
+}>('pages.about.hero', locale)!;
 const whatYouGet = tData<{ badge: string; heading: string; lead: string; items: IconText[] }>(
   'pages.about.whatYouGet',
   locale
@@ -86,7 +90,10 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
     </Badge>
     <h1 slot="title">
       <span class="text-foreground [-webkit-text-fill-color:currentColor]">{hero.titleLead}</span><br />
-      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)]">
+      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)] sm:hidden">
+        <TypingEffect words={hero.typingWordsMobile} />
+      </span>
+      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)] hidden sm:inline">
         <TypingEffect words={hero.typingWords} />
       </span>
     </h1>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -195,7 +195,8 @@
       "hero": {
         "badge": "About",
         "titleLead": "Astro Rocket —",
-        "typingWords": ["Lightning-fast", "57+ Components", "12 Themes", "Dark Mode", "Built-in i18n"],
+        "typingWords": ["Lightning-fast", "Starter theme", "57 Components", "12 Themes", "Dark Mode", "Built-in i18n"],
+        "typingWordsMobile": ["Lightning-fast", "Starter theme", "12 Themes", "Dark Mode", "Built-in i18n"],
         "description": "A free, open-source Astro 7 starter\u00a0theme to build anything on."
       },
       "whatYouGet": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -195,7 +195,8 @@
       "hero": {
         "badge": "Over",
         "titleLead": "Astro Rocket —",
-        "typingWords": ["Razendsnel", "57+ Componenten", "12 Thema's", "Donkere modus", "Ingebouwde i18n"],
+        "typingWords": ["Razendsnel", "Starter-thema", "57 Componenten", "12 Thema's", "Donkere modus", "Ingebouwde i18n"],
+        "typingWordsMobile": ["Razendsnel", "Starter-thema", "12 Thema's", "Donkere modus", "Ingebouwde i18n"],
         "description": "Een gratis, open-source Astro 7 starter-thema om alles op te bouwen."
       },
       "whatYouGet": {


### PR DESCRIPTION
The typewriter now reads Lightning-fast, Starter theme, 57 Components, 12 Themes, Dark Mode, and Built-in i18n. Phones use a shorter set (a new typingWordsMobile key) that skips "57 Components" — the only word wide enough to clip at the hero size — while the sm breakpoint and up show the full set, so no word is ever cut off. Both locales updated.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
