### PR TITLE
Make project card tags pill-shaped

### DIFF
--- a/src/components/projects/ProjectCard.astro
+++ b/src/components/projects/ProjectCard.astro
@@ -54,7 +54,7 @@ const { data } = project;
     {data.tags && data.tags.length > 0 && (
       <div class="flex flex-wrap gap-1.5">
         {data.tags.map((tag) => (
-          <Badge variant="brand">#{tag}</Badge>
+          <Badge variant="brand" pill>#{tag}</Badge>
         ))}
       </div>
     )}


### PR DESCRIPTION
Project card tags rendered as the default rounded Badge; the blog card tags are pills. Add the `pill` prop so project card tags share the pill shape while keeping their brand colour. Blog and archive tags unchanged.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
