### PR TITLE
Add brand-outline Button variant

### DIFF
--- a/src/components/ui/form/Button/Button.astro
+++ b/src/components/ui/form/Button/Button.astro
@@ -6,7 +6,7 @@ import { buttonVariants } from './button.variants';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 
 interface Props extends HTMLAttributes<'button'> {
-  variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'link' | 'destructive';
+  variant?: 'primary' | 'secondary' | 'brand-outline' | 'outline' | 'ghost' | 'link' | 'destructive';
   size?: 'sm' | 'md' | 'lg';
   loading?: boolean;
   fullWidth?: boolean;

--- a/src/components/ui/form/Button/button.variants.ts
+++ b/src/components/ui/form/Button/button.variants.ts
@@ -19,6 +19,13 @@ export const buttonVariants = cva(
           'bg-secondary text-secondary-foreground border border-border hover:bg-secondary-hover hover:border-border-strong active:scale-[0.98]',
         outline:
           'border border-foreground/25 bg-transparent text-foreground hover:bg-secondary hover:border-foreground/40 active:scale-[0.98]',
+        // The outline button in brand colour: transparent fill, brand border
+        // and text, soft brand wash on hover. Text shades chosen for WCAG AA /
+        // Lighthouse contrast (verified on the default blue theme: 6.2:1+
+        // light, 6.1:1+ dark at rest, above 4.5:1 on the hover wash —
+        // brand-600 would dip under on tinted fills).
+        'brand-outline':
+          'bg-transparent text-brand-700 border border-brand-500/40 hover:bg-brand-500/10 hover:border-brand-500/80 active:scale-[0.98] dark:text-brand-400',
         ghost:
           'text-foreground-secondary hover:text-foreground hover:bg-secondary active:scale-[0.98]',
         link: 'text-foreground-secondary hover:text-foreground underline-offset-4 hover:underline',


### PR DESCRIPTION
The outline button in brand colour: transparent fill, brand-coloured border and text, and a soft brand wash on hover. Border strengths match the card border language (brand-500/40, hover /80). Text uses brand-700 in light mode and brand-400 in dark, keeping WCAG AA / Lighthouse contrast on every section background including the hover wash. The React Button picks the variant up automatically via ButtonVariants.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
