### PR TITLE
Deepen the stack marquee cards to the elevated shadow

### DIFF
--- a/src/components/landing/StackMarquee.astro
+++ b/src/components/landing/StackMarquee.astro
@@ -151,7 +151,7 @@ const rowConfigs = Array.from({ length: rowCount }, (_, r) => {
                 style={logoColor === 'tool' && item.colorOklch ? `--tech-color: oklch(${item.colorOklch});` : undefined}
               >
                 <Card
-                  variant="default"
+                  variant="elevated"
                   padding="md"
                   href={linked ? item.url : undefined}
                   target={linked && item.url ? '_blank' : undefined}


### PR DESCRIPTION
Switch the StackMarquee cards from the default Card variant (shadow-md) to elevated (shadow-lg) so the scrolling stack cards match the static stack grid and the rest of the theme's cards. The marquee container already lets shadows breathe vertically.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
