### PR TITLE
Float blog hero images and project screenshots with the media shadow

### DIFF
--- a/src/components/blog/ArticleHero.astro
+++ b/src/components/blog/ArticleHero.astro
@@ -114,13 +114,13 @@ const readingTime = getReadingTime(body ?? description);
     <div class="relative z-[1] mx-auto max-w-5xl px-6 mt-[var(--space-section)] animate-hero-slide-up [animation-delay:450ms]">
       {svgSlug ? (
         <div
-          class="relative overflow-hidden rounded-xl border border-border shadow-lg"
+          class="relative overflow-hidden rounded-xl media-shadow"
           style="color: var(--brand-500);"
         >
           <BlogImageSVG slug={svgSlug} title={imageAlt || title} />
         </div>
       ) : image ? (
-        <div class="relative overflow-hidden rounded-xl border border-border shadow-lg">
+        <div class="relative overflow-hidden rounded-xl media-shadow">
           <Image
             src={image}
             alt={imageAlt || title}

--- a/src/components/projects/ProjectCarousel.astro
+++ b/src/components/projects/ProjectCarousel.astro
@@ -41,7 +41,7 @@ const posters = await Promise.all(
   aria-roledescription="carousel"
   aria-label={label}
 >
-  <div class="relative overflow-hidden rounded-xl border border-border shadow-xl ring-1 ring-black/5 dark:ring-white/10">
+  <div class="relative overflow-hidden rounded-xl media-shadow ring-1 ring-black/5 dark:ring-white/10">
     <div
       class="carousel-track flex snap-x snap-mandatory overflow-x-auto scroll-smooth"
       data-carousel-track

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1382,3 +1382,19 @@
 html:not(.dark) .bg-background-secondary .bg-background-tertiary {
   background-color: var(--color-background);
 }
+
+/* Media frames (blog hero images, project screenshots): saturated or dark
+   artwork can't take the theme's grey-wash shadow tiers — the same physics
+   as the LetterGlitch band. Light mode gets a heavy drop shadow with a soft
+   halo; dark mode gets a brand glow, since a dark shadow can never show on
+   a dark page. */
+.media-shadow {
+  box-shadow:
+    0 24px 48px -12px rgb(0 0 0 / 0.45),
+    0 0 24px -4px rgb(0 0 0 / 0.2);
+}
+html.dark .media-shadow {
+  box-shadow:
+    0 0 40px -6px color-mix(in oklab, var(--color-brand-500) 30%, transparent),
+    0 20px 40px -12px rgb(0 0 0 / 0.6);
+}


### PR DESCRIPTION
Blog post hero images and the project carousel frame carried theme shadow tiers that cannot register on saturated SVG artwork and dark screenshots, plus a light border that the halo would unmask as a hairline. Add a .media-shadow utility (heavy drop + halo in light mode, brand glow in dark) and apply it to both, dropping the border-border frame. The carousel keeps its subtle black/5 and dark white/10 rings.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
