### PR TITLE
Brand the footer credit link

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -182,7 +182,7 @@
   },
   "footer": {
     "copyright": "© {year} {siteName}",
-    "credit": "Theme by <a href=\"https://hansmartens.dev\" class=\"transition-colors hover:text-foreground\" target=\"_blank\" rel=\"noopener noreferrer\">Hans Martens Dev</a>",
+    "credit": "Theme by <a href=\"https://hansmartens.dev\" class=\"text-brand-700 dark:text-brand-400 transition-colors hover:text-brand-800 dark:hover:text-brand-300\" target=\"_blank\" rel=\"noopener noreferrer\">Hans Martens Dev</a>",
     "builtWith": "Built with Astro Rocket",
     "followOn": "Follow us on {platform}"
   },

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -182,7 +182,7 @@
   },
   "footer": {
     "copyright": "© {year} {siteName}",
-    "credit": "Thema door <a href=\"https://hansmartens.dev\" class=\"transition-colors hover:text-foreground\" target=\"_blank\" rel=\"noopener noreferrer\">Hans Martens Dev</a>",
+    "credit": "Thema door <a href=\"https://hansmartens.dev\" class=\"text-brand-700 dark:text-brand-400 transition-colors hover:text-brand-800 dark:hover:text-brand-300\" target=\"_blank\" rel=\"noopener noreferrer\">Hans Martens Dev</a>",
     "builtWith": "Gebouwd met Astro Rocket",
     "followOn": "Volg ons op {platform}"
   },


### PR DESCRIPTION
The "Theme by Hans Martens Dev" credit is a link, so it joins the clickable-is-brand language (#551): brand-700/brand-400 text, darkening on hover, in both locales.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
