### PR TITLE
Brand primary button text in dark mode on hero and menu CTAs

### DIFF
--- a/src/components/projects/ProjectHero.astro
+++ b/src/components/projects/ProjectHero.astro
@@ -88,7 +88,7 @@ const locale = getLocaleFromPath(Astro.url.pathname);
         {(url || repo) && (
           <div class="flex flex-wrap gap-3 mb-[var(--space-stack-lg)]">
             {url && (
-              <Button href={url} target="_blank" rel="noopener noreferrer" size="md">
+              <Button href={url} target="_blank" rel="noopener noreferrer" size="md" class="project-live-btn">
                 <Icon name="external-link" size="sm" />
                 View live site
               </Button>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1465,3 +1465,16 @@ input[type='radio'],
 input[type='range'] {
   accent-color: var(--color-brand-500);
 }
+
+/* #551: in dark mode the project hero's live-site button and the mobile
+   menu's CTA keep their light primary fill, but the text and icon go brand
+   for consistency. brand-700 at rest and brand-800 on the darker hover fill
+   clear WCAG AA on every theme (worst case teal: 4.62:1 / 6.21:1). */
+html.dark .btn-primary.project-live-btn,
+html.dark .mobile-menu-cta-wrap .btn-primary {
+  color: var(--color-brand-700);
+}
+html.dark .btn-primary.project-live-btn:hover,
+html.dark .mobile-menu-cta-wrap .btn-primary:hover {
+  color: var(--color-brand-800);
+}


### PR DESCRIPTION
In dark mode the project hero's live-site button and the mobile menu's CTA keep their light primary fill, but the text and icon now read brand (#551): brand-700 at rest, brand-800 on the darker hover fill. Checked against all 12 themes — worst case (teal) still clears WCAG AA at 4.62:1 at rest and 6.21:1 on hover; a single brand-700 would dip below 4.5:1 on the emerald, sky, and teal hover fills. Light mode is untouched. Verified computed styles on rendered builds in the default and teal themes.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
