### PR TITLE
Make live-site and menu CTA buttons solid brand in dark mode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1466,15 +1466,40 @@ input[type='range'] {
   accent-color: var(--color-brand-500);
 }
 
-/* #551: in dark mode the project hero's live-site button and the mobile
-   menu's CTA keep their light primary fill, but the text and icon go brand
-   for consistency. brand-700 at rest and brand-800 on the darker hover fill
-   clear WCAG AA on every theme (worst case teal: 4.62:1 / 6.21:1). */
+/* The project hero's live-site button and the mobile menu's CTA are solid
+   brand in dark mode too, mirroring the light-mode primary: brand-600 fill,
+   brand-700 hover, white label. The same four cooler hues as light mode
+   (cyan/emerald/sky/teal) sit on brand-700/800 so the white text keeps
+   WCAG AA — worst case across all 12 themes is 4.54:1 (green, at rest). */
 html.dark .btn-primary.project-live-btn,
 html.dark .mobile-menu-cta-wrap .btn-primary {
-  color: var(--color-brand-700);
+  background-color: var(--color-brand-600);
+  background-image: none;
+  border-color: transparent;
+  color: white;
 }
 html.dark .btn-primary.project-live-btn:hover,
 html.dark .mobile-menu-cta-wrap .btn-primary:hover {
-  color: var(--color-brand-800);
+  background-color: var(--color-brand-700);
+  background-image: none;
+}
+html.dark[data-theme="cyan"] .btn-primary.project-live-btn,
+html.dark[data-theme="emerald"] .btn-primary.project-live-btn,
+html.dark[data-theme="sky"] .btn-primary.project-live-btn,
+html.dark[data-theme="teal"] .btn-primary.project-live-btn,
+html.dark[data-theme="cyan"] .mobile-menu-cta-wrap .btn-primary,
+html.dark[data-theme="emerald"] .mobile-menu-cta-wrap .btn-primary,
+html.dark[data-theme="sky"] .mobile-menu-cta-wrap .btn-primary,
+html.dark[data-theme="teal"] .mobile-menu-cta-wrap .btn-primary {
+  background-color: var(--color-brand-700);
+}
+html.dark[data-theme="cyan"] .btn-primary.project-live-btn:hover,
+html.dark[data-theme="emerald"] .btn-primary.project-live-btn:hover,
+html.dark[data-theme="sky"] .btn-primary.project-live-btn:hover,
+html.dark[data-theme="teal"] .btn-primary.project-live-btn:hover,
+html.dark[data-theme="cyan"] .mobile-menu-cta-wrap .btn-primary:hover,
+html.dark[data-theme="emerald"] .mobile-menu-cta-wrap .btn-primary:hover,
+html.dark[data-theme="sky"] .mobile-menu-cta-wrap .btn-primary:hover,
+html.dark[data-theme="teal"] .mobile-menu-cta-wrap .btn-primary:hover {
+  background-color: var(--color-brand-800);
 }


### PR DESCRIPTION
Design correction: instead of brand text on the light pill, the project hero's live-site button and the mobile menu's CTA are now solid brand in dark mode too, mirroring the light-mode primary — brand-600 fill, brand-700 hover, white label and icon. The same four cooler hues as light mode (cyan, emerald, sky, teal) sit on brand-700/800 so the white text keeps WCAG AA; worst case across all 12 themes is 4.54:1 (green, at rest). Verified computed styles on rendered builds in the default and teal themes, both modes.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
