### PR TITLE
Finish the repositioning on the theme's own project page

### DIFF
--- a/src/content/projects/en/astro-rocket.mdx
+++ b/src/content/projects/en/astro-rocket.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Astro Rocket Theme"
 locale: en
-description: "Astro Rocket — my free, open-source Astro 7 theme. A finished website you launch by changing the text: 12 colour themes, 57 components, a 3-state colour mode, and a 100/100/100/100 Lighthouse score out of the box."
+description: "Astro Rocket — my free, open-source Astro 7 starter theme to build anything on: 57 designed components, 12 colour themes, a 3-state colour mode, and a 100/100/100/100 Lighthouse score out of the box."
 url: "https://astrorocket.dev"
 repo: "https://github.com/hansmartensdev/Astro-Rocket"
 tags: ["Astro", "TypeScript", "Tailwind CSS", "Open Source"]
@@ -20,9 +20,9 @@ import LighthouseScoresGrid from '@/components/landing/LighthouseScoresGrid.astr
 
 ## What it is
 
-**Astro Rocket** is my own free, open-source theme, built on **Astro 7** and **Tailwind CSS v4**. It isn't a boilerplate you spend a week wiring up — it's a finished website. Every page is already designed and built, so you change the text, pick a colour, and go live.
+**Astro Rocket** is my own free, open-source theme, built on **Astro 7** and **Tailwind CSS v4**. It isn't a boilerplate you spend a week wiring up — it's a complete foundation built around a component library: **57 designed, accessible components** that all speak one design language, so whatever you build with them looks right.
 
-I made it for the people I know best: designers, freelancers, and developers who want a site that already looks finished on day one. It's MIT-licensed, [up on GitHub](https://github.com/hansmartensdev/Astro-Rocket), and listed on the [official Astro themes directory](https://astro.build/themes/details/astro-rocket/). The full thing runs live at [astrorocket.dev](https://astrorocket.dev).
+I made it for the people I know best: designers, freelancers, and developers who want to build a beautiful website without starting from zero. It's MIT-licensed, [up on GitHub](https://github.com/hansmartensdev/Astro-Rocket), and listed on the [official Astro themes directory](https://astro.build/themes/details/astro-rocket/). The full thing runs live at [astrorocket.dev](https://astrorocket.dev).
 
 ## Lighthouse score result
 
@@ -67,7 +67,7 @@ The heart of the project is the **component library — 57 components** (33 UI, 
 
 Astro Rocket started as a fork of **[Velocity](https://github.com/southwellmedia/velocity)** by Southwell Media — a strong Astro boilerplate with a serious design system underneath it, and full credit to them for that foundation. On top of that fork I set out to build my own website, [hansmartens.dev](https://hansmartens.dev) — and before that site was even finished, I realised what I was building could be useful to more people than me. So I released a version of it, with demo content, as a theme of its own. From that point the website and the theme evolved side by side, each improvement in one flowing into the other.
 
-And since the release, the theme hasn't grown alone. Users open issues with enhancement ideas and bug reports, improvements ship within days with contributors credited in the commits — and the built-in i18n in particular has evolved through those conversations into one of the theme's most complete features. What started as a fork is now its own theme — a complete, ready-to-launch site where the only thing standing between a clone and a live website is your own text.
+And since the release, the theme hasn't grown alone. Users open issues with enhancement ideas and bug reports, improvements ship within days with contributors credited in the commits — and the built-in i18n in particular has evolved through those conversations into one of the theme's most complete features. What started as a fork is now its own theme — a complete foundation to build anything on. Use all of it or only the parts you need: the website you build on it is yours.
 
 ## Free, and on GitHub
 


### PR DESCRIPTION
This page was missed in the repositioning sweep: it still framed the theme as "a finished website you launch by changing the text". All four spots now carry the agreed positioning — a starter theme to build anything on, a complete foundation built around 57 designed components, for people who want to build a beautiful website without starting from zero. Use all of it or only the parts you need; the website you build on it is yours.

Verified in the built page: zero occurrences of the old framing remain.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
