### PR TITLE
Return the footer menu and legal links to muted grey

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -203,11 +203,11 @@ function getSocialIcon(platform: string): string {
             </div>
           )}
 
-          <nav class="flex flex-wrap justify-center gap-x-[var(--space-inline-lg)] gap-y-3 text-sm font-medium text-brand-700 dark:text-brand-400">
+          <nav class="flex flex-wrap justify-center gap-x-[var(--space-inline-lg)] gap-y-3 text-sm font-medium text-foreground-muted">
             {allNavItems.map((item) => (
               <a
                 href={item.href}
-                class="transition-colors hover:text-brand-800 dark:hover:text-brand-300"
+                class="transition-colors hover:text-foreground"
                 target={item.external || item.href.startsWith('http') ? '_blank' : undefined}
                 rel={item.external || item.href.startsWith('http') ? 'noopener noreferrer' : undefined}
               >
@@ -226,9 +226,9 @@ function getSocialIcon(platform: string): string {
               <p class="text-sm text-foreground-muted text-balance" set:html={legalLine} />
             )}
             {resolvedLegalLinks.length > 0 && (
-              <nav class="flex flex-wrap justify-center gap-x-[var(--space-inline-lg)] gap-y-2 text-xs text-brand-700 dark:text-brand-400">
+              <nav class="flex flex-wrap justify-center gap-x-[var(--space-inline-lg)] gap-y-2 text-xs text-foreground-muted">
                 {resolvedLegalLinks.map((link) => (
-                  <a href={link.href} class="transition-colors hover:text-brand-800 dark:hover:text-brand-300">
+                  <a href={link.href} class="transition-colors hover:text-foreground">
                     {link.label}
                   </a>
                 ))}


### PR DESCRIPTION
The centered footer's menu items and legal links go back to their original styling from before the brand-colour pass: foreground-muted at rest, foreground on hover, in both modes. Verified computed colours in a rendered build.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
