### PR TITLE
A collapsible TOC card brings the table of contents to every device

### DIFF
--- a/src/components/blog/TableOfContents.astro
+++ b/src/components/blog/TableOfContents.astro
@@ -23,6 +23,13 @@ interface Props {
   title?: string;
   /** When true, the TOC card sticks to the top of its scrolling container */
   sticky?: boolean;
+  /**
+   * Collapsed-card variant for small screens: a closed card with a
+   * localized Show/Hide hint and a chevron that unfolds on tap (native
+   * details/summary — the same pattern as accordion FAQs). Links
+   * auto-close the panel.
+   */
+  collapsible?: boolean;
 }
 
 const {
@@ -31,12 +38,16 @@ const {
   minHeadings = 3,
   title,
   sticky = false,
+  collapsible = false,
 } = Astro.props;
 
 const locale = getLocaleFromPath(Astro.url.pathname);
-// Default the heading to the localized "On this page"; an explicit `title`
-// prop still overrides it.
-const tocTitle = title ?? t('blog.onThisPage', locale);
+// A closed card must name its contents; an always-visible list only needs
+// a label. An explicit `title` prop still overrides either default.
+const tocTitle =
+  title ?? t(collapsible ? 'blog.tableOfContents' : 'blog.onThisPage', locale);
+const showLabel = t('blog.tocShow', locale);
+const hideLabel = t('blog.tocHide', locale);
 
 const items = headings.filter((h) => h.depth >= 2 && h.depth <= maxDepth);
 const shouldRender = items.length >= minHeadings;
@@ -47,44 +58,73 @@ const shouldRender = items.length >= minHeadings;
 const headingId = `toc-heading-${Math.random().toString(36).slice(2, 9)}`;
 ---
 
-{shouldRender && (
-  <nav
-    class:list={[
-      // The theme's card frame (rounded-xl + brand border + card surface),
-      // deliberately without shadow or hover: the TOC is a reading aid —
-      // its links are interactive, the box itself is not.
-      'toc not-prose rounded-xl border border-brand-500/40 bg-card p-5',
-      sticky && 'toc-sticky',
-    ]}
-    aria-labelledby={headingId}
-    data-toc
-  >
-    <p
-      id={headingId}
-      class="mb-3 flex items-center gap-2 text-sm font-semibold text-foreground"
+{shouldRender && (() => {
+  // The theme's card frame (rounded-xl + brand border + card surface),
+  // deliberately without shadow or hover: the TOC is a reading aid —
+  // its links are interactive, the box itself is not.
+  const Wrapper = collapsible ? 'details' : 'nav';
+  return (
+    <Wrapper
+      class:list={[
+        'toc not-prose rounded-xl border border-brand-500/40 bg-card',
+        !collapsible && 'p-5',
+        sticky && 'toc-sticky',
+      ]}
+      aria-labelledby={collapsible ? undefined : headingId}
+      data-toc
     >
-      <Icon name="list" size="sm" class="text-brand-500" />
-      {tocTitle}
-    </p>
-    <ul class="space-y-1.5 text-sm border-l border-border">
-      {items.map((h) => (
-        <li
-          class="toc-item"
-          data-depth={h.depth}
-          style={`padding-left: ${(h.depth - 2) * 0.875}rem`}
+      {collapsible ? (
+        <summary class="flex cursor-pointer list-none items-center gap-2 p-5 text-sm font-semibold text-foreground [&::-webkit-details-marker]:hidden">
+          <Icon name="list" size="sm" class="text-brand-500" />
+          {tocTitle}
+          <span class="toc-hint ml-auto flex shrink-0 items-center gap-1 text-xs font-medium text-foreground-muted">
+            <span class="toc-hint-show">{showLabel}</span>
+            <span class="toc-hint-hide">{hideLabel}</span>
+            <Icon
+              name="chevron-down"
+              size="sm"
+              class="toc-chevron transition-transform duration-200"
+            />
+          </span>
+        </summary>
+      ) : (
+        <p
+          id={headingId}
+          class="mb-3 flex items-center gap-2 text-sm font-semibold text-foreground"
         >
-          <a
-            href={`#${h.slug}`}
-            data-toc-link={h.slug}
-            class="toc-link block py-1 pl-3 -ml-px border-l border-transparent text-foreground-muted hover:text-foreground hover:border-brand-500 transition-colors"
+          <Icon name="list" size="sm" class="text-brand-500" />
+          {tocTitle}
+        </p>
+      )}
+      <ul
+        class:list={[
+          'space-y-1.5 text-sm border-l border-border',
+          collapsible && 'mx-5 mb-5',
+        ]}
+      >
+        {items.map((h) => (
+          <li
+            class="toc-item"
+            data-depth={h.depth}
+            style={`padding-left: ${(h.depth - 2) * 0.875}rem`}
           >
-            {h.text}
-          </a>
-        </li>
-      ))}
-    </ul>
-  </nav>
-)}
+            <a
+              href={`#${h.slug}`}
+              data-toc-link={h.slug}
+              class:list={[
+                'toc-link block pl-3 -ml-px border-l border-transparent text-foreground-muted hover:text-foreground hover:border-brand-500 transition-colors',
+                // Roomier tap targets on the touch-first collapsed variant.
+                collapsible ? 'py-1.5' : 'py-1',
+              ]}
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </Wrapper>
+  );
+})()}
 
 <style>
   /* Sticky positioning is opt-in (sidebar layout). The 6rem offset clears
@@ -101,6 +141,25 @@ const headingId = `toc-heading-${Math.random().toString(36).slice(2, 9)}`;
     color: var(--color-foreground);
     border-left-color: var(--color-brand-500);
     font-weight: 500;
+  }
+
+  /* Collapsed-card variant: the chevron flips when the panel unfolds —
+     the same motion accordion FAQs use — and the action hint swaps
+     between the localized Show and Hide labels to match. */
+  details[data-toc][open] .toc-chevron {
+    transform: rotate(180deg);
+  }
+
+  .toc-hint-hide {
+    display: none;
+  }
+
+  details[data-toc][open] .toc-hint-show {
+    display: none;
+  }
+
+  details[data-toc][open] .toc-hint-hide {
+    display: inline;
   }
 </style>
 
@@ -121,6 +180,58 @@ const headingId = `toc-heading-${Math.random().toString(36).slice(2, 9)}`;
     const headings = slugs
       .map((s) => document.getElementById(s))
       .filter((el): el is HTMLElement => el !== null);
+
+    // Jumping into a section whose scroll-reveal hasn't played yet lands
+    // short: the block still carries its entrance translate when the
+    // browser computes the scroll target, then rises out from under it.
+    // Settle the target's reveal state first (skipping its entrance
+    // animation — the reader is jumping straight to it anyway).
+    const settleTarget = (slug: string): HTMLElement | null => {
+      const el = document.getElementById(slug);
+      if (!el) return null;
+      const container = el.closest('[data-reveal-content]');
+      if (container) {
+        let child: HTMLElement = el;
+        while (child.parentElement && child.parentElement !== container) {
+          child = child.parentElement;
+        }
+        if (child.parentElement === container && !child.classList.contains('is-visible')) {
+          child.style.transition = 'none';
+          child.classList.add('is-visible');
+        }
+      }
+      const reveal = el.closest<HTMLElement>('[data-reveal]');
+      if (reveal && !reveal.classList.contains('is-visible')) {
+        reveal.style.transition = 'none';
+        reveal.classList.add('is-visible');
+      }
+      return el;
+    };
+
+    for (const a of links) {
+      const slug = a.getAttribute('data-toc-link')!;
+      if (toc.tagName === 'DETAILS') {
+        // Collapsed-card variant: fold the panel before navigating (an
+        // open panel above the target would make the scroll land short),
+        // then jump against the fully settled layout. The hash is written
+        // via pushState so the URL updates without a competing native
+        // scroll; scrollIntoView honours the html scroll-padding offset.
+        a.addEventListener('click', (e) => {
+          e.preventDefault();
+          toc.removeAttribute('open');
+          requestAnimationFrame(() => {
+            const target = settleTarget(slug);
+            if (!target) return;
+            history.pushState(null, '', `#${slug}`);
+            target.scrollIntoView();
+          });
+        });
+      } else {
+        // Sidebar/inline variant: native navigation proceeds — settling
+        // the target first is enough for an exact landing.
+        a.addEventListener('click', () => settleTarget(slug));
+      }
+    }
 
     if (headings.length === 0) continue;
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -67,6 +67,8 @@
     "tagEmpty": "No posts found for this tag.",
     "tagBackToAll": "Back to all posts",
     "onThisPage": "On this page",
+    "tocShow": "Show",
+    "tocHide": "Hide",
     "backToBlog": "Back to Blog",
     "updated": "Updated",
     "followAlong": "Follow along",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -67,6 +67,8 @@
     "tagEmpty": "Geen berichten gevonden voor deze tag.",
     "tagBackToAll": "Terug naar alle berichten",
     "onThisPage": "Op deze pagina",
+    "tocShow": "Toon",
+    "tocHide": "Verberg",
     "backToBlog": "Terug naar blog",
     "updated": "Bijgewerkt",
     "followAlong": "Blijf op de hoogte",

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -192,6 +192,17 @@ const languageAlternates = Object.fromEntries(
       <!-- Breadcrumbs -->
       <Breadcrumbs items={breadcrumbs} class="mb-8" />
 
+      {sidebarActive && (
+        <div class="xl:hidden mb-10">
+          <TableOfContents
+            headings={headings}
+            maxDepth={tocConfig?.maxDepth ?? 3}
+            minHeadings={tocConfig?.minHeadings ?? 3}
+            collapsible
+          />
+        </div>
+      )}
+
       {inlineActive && (
         <div class="mb-10 rounded-xl border border-border bg-background-secondary p-5">
           <TableOfContents

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -151,6 +151,17 @@ const languageAlternates = Object.fromEntries(
         <div class:list={['min-w-0 max-w-4xl w-full mx-auto', sidebarActive && 'xl:mx-0']}>
           <Breadcrumbs items={breadcrumbs} class="mb-8" />
 
+          {sidebarActive && (
+            <div class="xl:hidden mb-10">
+              <TableOfContents
+                headings={headings}
+                maxDepth={tocConfig?.maxDepth ?? 3}
+                minHeadings={tocConfig?.minHeadings ?? 3}
+                collapsible
+              />
+            </div>
+          )}
+
           {inlineActive && (
             <div class="mb-10 rounded-xl border border-border bg-background-secondary p-5">
               <TableOfContents


### PR DESCRIPTION
Below the desktop breakpoint, blog posts and project pages now open with a closed card — list icon, localized "Table of contents" title, and a Show/Hide hint beside a flipping chevron — built on native details/summary in the theme's card frame. Tapping unfolds the familiar list with roomier touch targets; choosing a link folds the panel and jumps. New i18n keys blog.tocShow / blog.tocHide ship in English and Dutch.

Landing precision is engineered, not assumed: the panel closes before the scroll target is computed, and the target section's scroll-reveal translate is settled first — otherwise the block rises out from under the computed position and the heading slides beneath the fixed header. The settle step also sharpens first-visit jumps from the desktop sidebar. Verified by measurement at phone width: headings land exactly at the scroll-padding offset, clear of the header, and the panel auto-closes after every jump.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
