### PR TITLE
Full-height hero covers the whole viewport on every device

### DIFF
--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -66,9 +66,11 @@ const sectionClasses = cn(
   heroSectionVariants({ size }),
   // Full-viewport hero: stretch to at least the viewport height. Uses svh (stable
   // small viewport) rather than dvh so the hero does NOT resize as the mobile
-  // browser's address bar shows/hides on scroll; capped so it never grows too tall
-  // on large monitors.
-  fullHeight && 'min-h-[min(100svh,60rem)]',
+  // browser's address bar shows/hides on scroll. No upper cap — a 60rem cap used
+  // to cut the hero short on viewports taller than 960px (portrait tablets), so
+  // the next section bled into the first screen; the floored bottom slot absorbs
+  // extra height by design.
+  fullHeight && 'min-h-[100svh]',
   // Floored bottom slot (e.g. the homepage tech-stack marquee): flex column so the
   // slot floats to the floor with a guaranteed minimum gap above it.
   isFlooredBottom && 'flex flex-col gap-[var(--hero-floor-gap,4rem)]',


### PR DESCRIPTION
The fullHeight hero capped its minimum height at 60rem, which cut it short on viewports taller than 960px: on a portrait tablet the next section bled into the first screen. The cap is gone — the hero now stretches to the full viewport everywhere, and the floored bottom slot absorbs the extra height as its layout was designed to do. Verified across phone, tablet portrait and landscape, desktop, and a portrait monitor.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
