### PR TITLE
The about hero mirrors the theme's product-page look

### DIFF
--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -19,10 +19,9 @@ import Card from '@/components/ui/data-display/Card/Card.astro';
 import ProofTile from '@/components/ui/data-display/ProofTile/ProofTile.astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import { Hero } from '@/components/hero';
-import TypingEffect from '@/components/ui/TypingEffect.astro';
 import TechStack from '@/components/landing/TechStack.astro';
 import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
-import { t, tData, defaultLocale } from '@/i18n';
+import { t, tData, defaultLocale, localizedPath } from '@/i18n';
 // The theme on a monitor, a tablet, and a phone — light and dark stage.
 import trioLight from '@/assets/projects/astrorocket-trio-light.jpg';
 import trioDark from '@/assets/projects/astrorocket-trio-dark.jpg';
@@ -58,10 +57,12 @@ const GITHUB_URL = 'https://github.com/hansmartensdev/astro-rocket';
 const hero = tData<{
   badge: string;
   titleLead: string;
-  typingWords: string[];
-  /** Shorter set for phones (below sm), dropping the one word wide enough to clip at the hero size. */
-  typingWordsMobile: string[];
+  titleHighlight: string;
   description: string;
+  ctaDemo: string;
+  ctaGithub: string;
+  mockupAlt: string;
+  mockupAltDark: string;
 }>('pages.about.hero', locale)!;
 const whatYouGet = tData<{ badge: string; heading: string; lead: string; items: IconText[] }>(
   'pages.about.whatYouGet',
@@ -87,37 +88,41 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
   description={t('pages.about.meta.description', locale)}
   footerBackground="secondary"
 >
-  {/* The mockup at the hero's bottom edge needs the same breathing room the
-      sections below keep between each other, so the sm-hero's tighter bottom
-      padding steps up to the page-wide section-md rhythm. */}
-  <Hero layout="centered" size="sm" class="isolate !pb-[var(--space-section-md)]" showHeroHalo>
+  <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>
       <Icon name="rocket" size="sm" />
       {hero.badge}
     </Badge>
     <h1 slot="title">
       <span class="text-foreground [-webkit-text-fill-color:currentColor]">{hero.titleLead}</span><br />
-      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)] sm:hidden">
-        <TypingEffect words={hero.typingWordsMobile} />
-      </span>
-      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)] hidden sm:inline">
-        <TypingEffect words={hero.typingWords} />
-      </span>
+      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)]">{hero.titleHighlight}</span>
     </h1>
-
     <p slot="description" class="!text-balance">
       {hero.description}
     </p>
+    <Fragment slot="actions">
+      <Button href={localizedPath('/', locale)} class="cta-btn-brand">
+        {hero.ctaDemo}
+        <Icon name="arrow-right" size="sm" />
+      </Button>
+      <Button variant="brand-outline" href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+        <Icon name="github" size="sm" />
+        {hero.ctaGithub}
+      </Button>
+    </Fragment>
+  </Hero>
 
-    {/* Last hero item: the theme on every device — the pair swaps with the
-        visitor's colour mode. */}
-    <div class="mt-4 w-full max-w-4xl">
-      <div class="rounded-xl overflow-hidden">
+  <!-- ─── The theme on every screen ────────────────────────────────────────── -->
+  <section class="pb-[var(--space-section-md)] bg-background">
+    <div class="mx-auto max-w-5xl px-6" data-reveal>
+      {/* The pair swaps with the visitor's colour mode — the image itself
+          demonstrates the theme's dark mode while they read about it. */}
+      <div class="rounded-xl overflow-hidden media-shadow">
         <Image src={trioLight} alt={hero.mockupAlt} class="w-full dark:hidden" />
         <Image src={trioDark} alt={hero.mockupAltDark} class="w-full hidden dark:block" />
       </div>
     </div>
-  </Hero>
+  </section>
 
   <!-- What you get -->
   <section class="py-[var(--space-section-md)] bg-background-secondary border-t border-border">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -196,11 +196,12 @@
         "description": "What Astro Rocket is and how it's built: a free, lightning-fast Astro 7 starter theme with 57 designed components, 12 colour themes, built-in i18n, and dark mode."
       },
       "hero": {
-        "badge": "About",
+        "badge": "Free & open source · MIT",
         "titleLead": "Astro Rocket —",
-        "typingWords": ["Lightning-fast", "Starter theme", "57 Components", "12 Themes", "Dark Mode", "Built-in i18n"],
-        "typingWordsMobile": ["Lightning-fast", "Starter theme", "12 Themes", "Dark Mode", "Built-in i18n"],
-        "description": "A free, open-source Astro 7 starter\u00a0theme to build anything on.",
+        "titleHighlight": "The free Astro starter theme",
+        "description": "A lightning-fast Astro\u00a07 starter\u00a0theme to build anything\u00a0on. The site you're reading right now is built on it too.",
+        "ctaDemo": "View the demo",
+        "ctaGithub": "View on GitHub",
         "mockupAlt": "The Astro Rocket demo shown on a desktop monitor, a tablet, and a smartphone, on a light studio background",
         "mockupAltDark": "The Astro Rocket demo in dark mode, shown on a desktop monitor, a tablet, and a smartphone, on a dark studio background"
       },

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -196,11 +196,12 @@
         "description": "Wat Astro Rocket is en hoe het gebouwd is: een gratis, razendsnel Astro 7 starter-thema met 57 ontworpen componenten, 12 kleurthema's, ingebouwde i18n en donkere modus."
       },
       "hero": {
-        "badge": "Over",
+        "badge": "Gratis & open source · MIT",
         "titleLead": "Astro Rocket —",
-        "typingWords": ["Razendsnel", "Starter-thema", "57 Componenten", "12 Thema's", "Donkere modus", "Ingebouwde i18n"],
-        "typingWordsMobile": ["Razendsnel", "Starter-thema", "12 Thema's", "Donkere modus", "Ingebouwde i18n"],
-        "description": "Een gratis, open-source Astro 7 starter-thema om alles op te bouwen.",
+        "titleHighlight": "Het gratis Astro starter-thema",
+        "description": "Een razendsnel Astro\u00a07 starter-thema om alles op te bouwen. De site die je nu leest, is er zelf op gebouwd.",
+        "ctaDemo": "Bekijk de demo",
+        "ctaGithub": "Bekijk op GitHub",
         "mockupAlt": "De Astro Rocket-demo op een monitor, een tablet en een smartphone, op een lichte studioachtergrond",
         "mockupAltDark": "De Astro Rocket-demo in donkere modus, op een monitor, een tablet en een smartphone, op een donkere studioachtergrond"
       },


### PR DESCRIPTION
Static two-line title with the brand-coloured highlight, the MIT badge, demo and GitHub buttons, and the device mockup right below the hero in its own section — the construction whose spacing matches the page rhythm by design. Replaces the typing-effect headline; all strings localized in both shipped locales.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
