### PR TITLE
The typing-effect docs stop pointing at the about hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Built on Astro 7 and Tailwind CSS v4.
 | **57 Components** | 33 UI, 7 patterns, 1 hero, 4 layout, 4 blog, 7 landing, 3 SEO — all accessible with TypeScript |
 | **Auto Logo & Favicon** | First letter of your site name on brand color — generated automatically from `site.config.ts`, no design tools needed. Prefer your own logo? Set `branding.logo.image` to a file in `public/`. |
 | **Icon System** | Unified `Icon` component (Astro + React) — 350+ [Lucide](https://lucide.dev) UI icons and 3000+ [Simple Icons](https://simpleicons.org) brand icons via Iconify |
-| **Typing Effect** | Animated typing effect in the hero section |
+| **Typing Effect** | Animated typing headline component, ready to drop into any hero |
 | **Page Animations** | Smooth page transitions via Astro View Transitions, scroll-triggered counter and score animations, scroll-reactive header, card hover effects, and a full suite of UI micro-animations — all with reduced-motion support |
 | **SEO Toolkit** | Meta tags, JSON-LD structured data, sitemap, and robots.txt |
 | **Static OG Image** | A polished default Open Graph image serves as social preview for all pages — no build-time generation required |
@@ -558,7 +558,7 @@ Astro Rocket includes 57 components across 7 categories. All UI components use [
 
 | Category | Count | Components |
 |----------|-------|------------|
-| Hero | 1 | Hero section with centered/split layouts, grid pattern, and typing effect |
+| Hero | 1 | Hero section with centered/split layouts and grid pattern |
 | Layout | 6 | Header (with scroll progress bar), Footer, ThemeModeDropdown, ThemeSelector, ThemeSelectorDropdown, Analytics |
 | Blog | 4 | ArticleHero, BlogCard, ShareButtons, RelatedPosts |
 | Landing | 5 | Credibility, LighthouseScores, TechStack, FeatureTabs, and more |

--- a/src/content/blog/en/animations-in-astro-rocket.mdx
+++ b/src/content/blog/en/animations-in-astro-rocket.mdx
@@ -281,7 +281,7 @@ Both use `var(--color-brand-500)`, so they re-colour instantly whenever the visi
 
 ## The typing effect
 
-The [hero typing effect](/blog/hero-typing-effect) on the About page cycles through words one character at a time. It is a `setTimeout` loop with three non-obvious fixes: the element width is locked to the widest word up front (via an off-screen measuring span) so nothing reflows as words of different lengths cycle; it restarts on `astro:page-load` so it survives client navigation; and `overflow: hidden` was removed because it clipped descenders at large heading sizes.
+The [hero typing effect](/blog/hero-typing-effect) component cycles through words one character at a time. It is a `setTimeout` loop with three non-obvious fixes: the element width is locked to the widest word up front (via an off-screen measuring span) so nothing reflows as words of different lengths cycle; it restarts on `astro:page-load` so it survives client navigation; and `overflow: hidden` was removed because it clipped descenders at large heading sizes.
 
 ## Why no view transitions
 

--- a/src/content/blog/en/hero-typing-effect.mdx
+++ b/src/content/blog/en/hero-typing-effect.mdx
@@ -11,7 +11,7 @@ svgSlug: "hero-typing-effect"
 imageAlt: "Rocket icon above the words 'typing effect' on a dark background"
 ---
 
-Open the Astro Rocket About page and the headline does not sit still. It types one word, pauses, deletes it, and types the next — looping forever. This post explains exactly how that effect is built, what each value controls, and how to make it faster, slower, or gone entirely.
+Astro Rocket ships a typing headline component: drop it into a heading and the text does not sit still. It types one word, pauses, deletes it, and types the next — looping forever. This post explains exactly how the effect is built, what each value controls, and how to make it faster, slower, or gone entirely.
 
 ## Where the component lives
 
@@ -23,9 +23,9 @@ src/components/ui/TypingEffect.astro
 
 It is a standard Astro component with a scoped `<style>` block for the cursor blink and a `<script>` block for the typing logic. No third-party library, no external dependency.
 
-## Where it is used
+## How to use it
 
-The component currently lives in the About page hero, inside a brand-coloured `<span>`:
+Drop the component into a hero title, inside a brand-coloured `<span>`:
 
 ```astro
 <h1 slot="title">
@@ -36,7 +36,7 @@ The component currently lives in the About page hero, inside a brand-coloured `<
 </h1>
 ```
 
-The homepage hero uses static text. The typing effect was kept on the About page where it acts as a personal "who am I" cycling statement rather than a product tagline.
+The demo's own heroes use static text — a deliberate choice for product pages, where the headline is a tagline that should hold still. The component is made for the other case: a personal "who am I" cycling statement, like the word list above.
 
 You can place `<TypingEffect>` inside any heading or inline context. The `words` prop is the only required value.
 


### PR DESCRIPTION
The about page's headline is static now, so the blog posts and README describe the component as it is: shipped and ready to drop into any hero, with the usage example intact.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
