### PR TITLE
A softer shadow for the about-page mockup

### DIFF
--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -117,7 +117,7 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
     <div class="mx-auto max-w-5xl px-6" data-reveal>
       {/* The pair swaps with the visitor's colour mode — the image itself
           demonstrates the theme's dark mode while they read about it. */}
-      <div class="rounded-xl overflow-hidden media-shadow">
+      <div class="rounded-xl overflow-hidden media-shadow-soft">
         <Image src={trioLight} alt={hero.mockupAlt} class="w-full dark:hidden" />
         <Image src={trioDark} alt={hero.mockupAltDark} class="w-full hidden dark:block" />
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1399,6 +1399,20 @@ html.dark .media-shadow {
     0 20px 40px -12px rgb(0 0 0 / 0.6);
 }
 
+/* Softer lift for pale device mockups: media-shadow's tight ambient ring
+   wrapped the rounded corners in a dark rim against the light stage, so
+   this variant keeps only a low, offset drop shadow — clean corners. */
+.media-shadow-soft {
+  box-shadow:
+    0 16px 40px -16px rgb(0 0 0 / 0.25),
+    0 4px 12px -6px rgb(0 0 0 / 0.1);
+}
+html.dark .media-shadow-soft {
+  box-shadow:
+    0 0 32px -10px color-mix(in oklab, var(--color-brand-500) 15%, transparent),
+    0 16px 32px -16px rgb(0 0 0 / 0.45);
+}
+
 /* Clickable affordance (#551): every enabled control gets the hand cursor,
    including buttons that browsers default to an arrow cursor. */
 button:not(:disabled),


### PR DESCRIPTION
media-shadow's tight ambient ring wrapped the image's rounded corners in a dark rim against the pale stage. The new media-shadow-soft keeps only a low, offset drop shadow (and half the glow in dark mode) — clean corners, gentle lift.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
