### PR TITLE
Restore the original about hero with the typing headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Built on Astro 7 and Tailwind CSS v4.
 | **57 Components** | 33 UI, 7 patterns, 1 hero, 4 layout, 4 blog, 7 landing, 3 SEO — all accessible with TypeScript |
 | **Auto Logo & Favicon** | First letter of your site name on brand color — generated automatically from `site.config.ts`, no design tools needed. Prefer your own logo? Set `branding.logo.image` to a file in `public/`. |
 | **Icon System** | Unified `Icon` component (Astro + React) — 350+ [Lucide](https://lucide.dev) UI icons and 3000+ [Simple Icons](https://simpleicons.org) brand icons via Iconify |
-| **Typing Effect** | Animated typing headline component, ready to drop into any hero |
+| **Typing Effect** | Animated typing effect in the hero section |
 | **Page Animations** | Smooth page transitions via Astro View Transitions, scroll-triggered counter and score animations, scroll-reactive header, card hover effects, and a full suite of UI micro-animations — all with reduced-motion support |
 | **SEO Toolkit** | Meta tags, JSON-LD structured data, sitemap, and robots.txt |
 | **Static OG Image** | A polished default Open Graph image serves as social preview for all pages — no build-time generation required |
@@ -558,7 +558,7 @@ Astro Rocket includes 57 components across 7 categories. All UI components use [
 
 | Category | Count | Components |
 |----------|-------|------------|
-| Hero | 1 | Hero section with centered/split layouts and grid pattern |
+| Hero | 1 | Hero section with centered/split layouts, grid pattern, and typing effect |
 | Layout | 6 | Header (with scroll progress bar), Footer, ThemeModeDropdown, ThemeSelector, ThemeSelectorDropdown, Analytics |
 | Blog | 4 | ArticleHero, BlogCard, ShareButtons, RelatedPosts |
 | Landing | 5 | Credibility, LighthouseScores, TechStack, FeatureTabs, and more |

--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -18,9 +18,10 @@ import Card from '@/components/ui/data-display/Card/Card.astro';
 import ProofTile from '@/components/ui/data-display/ProofTile/ProofTile.astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import { Hero } from '@/components/hero';
+import TypingEffect from '@/components/ui/TypingEffect.astro';
 import TechStack from '@/components/landing/TechStack.astro';
 import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
-import { t, tData, defaultLocale, localizedPath } from '@/i18n';
+import { t, tData, defaultLocale } from '@/i18n';
 
 interface Props {
   /** Locale whose copy this page renders. Defaults to the site default. */
@@ -53,10 +54,10 @@ const GITHUB_URL = 'https://github.com/hansmartensdev/astro-rocket';
 const hero = tData<{
   badge: string;
   titleLead: string;
-  titleHighlight: string;
+  typingWords: string[];
+  /** Shorter set for phones (below sm), dropping the one word wide enough to clip at the hero size. */
+  typingWordsMobile: string[];
   description: string;
-  ctaDemo: string;
-  ctaGithub: string;
 }>('pages.about.hero', locale)!;
 const whatYouGet = tData<{ badge: string; heading: string; lead: string; items: IconText[] }>(
   'pages.about.whatYouGet',
@@ -82,31 +83,24 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
   description={t('pages.about.meta.description', locale)}
   footerBackground="secondary"
 >
-  {/* Bottom padding steps up to section-md so the buttons get the same
-      96px of air below as above — the sm token alone leaves the hero
-      bottom-tight (64px). */}
-  <Hero layout="centered" size="sm" class="isolate !pb-[var(--space-section-md)]" showHeroHalo>
+  <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>
       <Icon name="rocket" size="sm" />
       {hero.badge}
     </Badge>
     <h1 slot="title">
       <span class="text-foreground [-webkit-text-fill-color:currentColor]">{hero.titleLead}</span><br />
-      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)]">{hero.titleHighlight}</span>
+      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)] sm:hidden">
+        <TypingEffect words={hero.typingWordsMobile} />
+      </span>
+      <span class="text-brand-500 [-webkit-text-fill-color:var(--color-brand-500)] hidden sm:inline">
+        <TypingEffect words={hero.typingWords} />
+      </span>
     </h1>
+
     <p slot="description" class="!text-balance">
       {hero.description}
     </p>
-    <Fragment slot="actions">
-      <Button href={localizedPath('/', locale)} class="cta-btn-brand">
-        {hero.ctaDemo}
-        <Icon name="arrow-right" size="sm" />
-      </Button>
-      <Button variant="brand-outline" href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
-        <Icon name="github" size="sm" />
-        {hero.ctaGithub}
-      </Button>
-    </Fragment>
   </Hero>
 
   <!-- What you get -->

--- a/src/content/blog/en/animations-in-astro-rocket.mdx
+++ b/src/content/blog/en/animations-in-astro-rocket.mdx
@@ -281,7 +281,7 @@ Both use `var(--color-brand-500)`, so they re-colour instantly whenever the visi
 
 ## The typing effect
 
-The [hero typing effect](/blog/hero-typing-effect) component cycles through words one character at a time. It is a `setTimeout` loop with three non-obvious fixes: the element width is locked to the widest word up front (via an off-screen measuring span) so nothing reflows as words of different lengths cycle; it restarts on `astro:page-load` so it survives client navigation; and `overflow: hidden` was removed because it clipped descenders at large heading sizes.
+The [hero typing effect](/blog/hero-typing-effect) on the About page cycles through words one character at a time. It is a `setTimeout` loop with three non-obvious fixes: the element width is locked to the widest word up front (via an off-screen measuring span) so nothing reflows as words of different lengths cycle; it restarts on `astro:page-load` so it survives client navigation; and `overflow: hidden` was removed because it clipped descenders at large heading sizes.
 
 ## Why no view transitions
 

--- a/src/content/blog/en/hero-typing-effect.mdx
+++ b/src/content/blog/en/hero-typing-effect.mdx
@@ -11,7 +11,7 @@ svgSlug: "hero-typing-effect"
 imageAlt: "Rocket icon above the words 'typing effect' on a dark background"
 ---
 
-Astro Rocket ships a typing headline component: drop it into a heading and the text does not sit still. It types one word, pauses, deletes it, and types the next — looping forever. This post explains exactly how the effect is built, what each value controls, and how to make it faster, slower, or gone entirely.
+Open the Astro Rocket About page and the headline does not sit still. It types one word, pauses, deletes it, and types the next — looping forever. This post explains exactly how that effect is built, what each value controls, and how to make it faster, slower, or gone entirely.
 
 ## Where the component lives
 
@@ -23,9 +23,9 @@ src/components/ui/TypingEffect.astro
 
 It is a standard Astro component with a scoped `<style>` block for the cursor blink and a `<script>` block for the typing logic. No third-party library, no external dependency.
 
-## How to use it
+## Where it is used
 
-Drop the component into a hero title, inside a brand-coloured `<span>`:
+The component currently lives in the About page hero, inside a brand-coloured `<span>`:
 
 ```astro
 <h1 slot="title">
@@ -36,7 +36,7 @@ Drop the component into a hero title, inside a brand-coloured `<span>`:
 </h1>
 ```
 
-The demo's own heroes use static text — a deliberate choice for product pages, where the headline is a tagline that should hold still. The component is made for the other case: a personal "who am I" cycling statement, like the word list above.
+The homepage hero uses static text. The typing effect was kept on the About page where it acts as a personal "who am I" cycling statement rather than a product tagline.
 
 You can place `<TypingEffect>` inside any heading or inline context. The `words` prop is the only required value.
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -196,12 +196,11 @@
         "description": "What Astro Rocket is and how it's built: a free, lightning-fast Astro 7 starter theme with 57 designed components, 12 colour themes, built-in i18n, and dark mode."
       },
       "hero": {
-        "badge": "Free & open source · MIT",
+        "badge": "About",
         "titleLead": "Astro Rocket —",
-        "titleHighlight": "The free Astro starter theme",
-        "description": "A lightning-fast Astro\u00a07 starter\u00a0theme to build anything\u00a0on. The site you're reading right now is built on it too.",
-        "ctaDemo": "View the demo",
-        "ctaGithub": "View on GitHub"
+        "typingWords": ["Lightning-fast", "Starter theme", "57 Components", "12 Themes", "Dark Mode", "Built-in i18n"],
+        "typingWordsMobile": ["Lightning-fast", "Starter theme", "12 Themes", "Dark Mode", "Built-in i18n"],
+        "description": "A free, open-source Astro 7 starter\u00a0theme to build anything on."
       },
       "whatYouGet": {
         "badge": "What you get",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -196,12 +196,11 @@
         "description": "Wat Astro Rocket is en hoe het gebouwd is: een gratis, razendsnel Astro 7 starter-thema met 57 ontworpen componenten, 12 kleurthema's, ingebouwde i18n en donkere modus."
       },
       "hero": {
-        "badge": "Gratis & open source · MIT",
+        "badge": "Over",
         "titleLead": "Astro Rocket —",
-        "titleHighlight": "Het gratis Astro starter-thema",
-        "description": "Een razendsnel Astro\u00a07 starter-thema om alles op te bouwen. De site die je nu leest, is er zelf op gebouwd.",
-        "ctaDemo": "Bekijk de demo",
-        "ctaGithub": "Bekijk op GitHub"
+        "typingWords": ["Razendsnel", "Starter-thema", "57 Componenten", "12 Thema's", "Donkere modus", "Ingebouwde i18n"],
+        "typingWordsMobile": ["Razendsnel", "Starter-thema", "12 Thema's", "Donkere modus", "Ingebouwde i18n"],
+        "description": "Een gratis, open-source Astro 7 starter-thema om alles op te bouwen."
       },
       "whatYouGet": {
         "badge": "Wat je krijgt",


### PR DESCRIPTION
The about hero returns to its pre-redesign form: the typewriter effect cycling through the theme's highlights, no buttons, no mockup. The typing-effect blog post, the animations post, and the README follow, since the effect lives on the About page again.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
