### PR TITLE
Match the Services hero bottom spacing to the other heroes

### DIFF
--- a/src/components/pages/views/ServicesView.astro
+++ b/src/components/pages/views/ServicesView.astro
@@ -76,7 +76,7 @@ const aboutUrl = localizedPath('/about', locale);
   description={t('pages.services.meta.description', locale)}
   footerBackground="secondary"
 >
-  <Hero layout="centered" size="sm" class="isolate services-hero" showHeroHalo>
+  <Hero layout="centered" size="sm" class="isolate services-hero pb-[calc(var(--space-section-sm)_+_var(--space-stack-lg))]" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>
       <Icon name="sparkles" size="sm" />
       {hero.badge}


### PR DESCRIPTION
The Services hero ends with the three jump buttons, which carry no trailing margin, so its bottom padding sat ~32px tighter than the heroes that end with the description (which has a --space-stack-lg bottom margin). Add that same amount to the Services hero's bottom padding so it lines up with the contact, blog, projects, and about heroes at every width.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
