### PR TITLE
Stagger the services Design section left-to-right on desktop

### DIFF
--- a/src/components/pages/views/ServicesView.astro
+++ b/src/components/pages/views/ServicesView.astro
@@ -128,7 +128,7 @@ const aboutUrl = localizedPath('/about', locale);
           ))}
         </div>
         <!-- Card -->
-        <div class="sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal data-reveal-ease="smooth">
+        <div class="sm:max-w-xl sm:mx-auto glitch:max-w-none glitch:mx-0" data-reveal data-reveal-delay="1" data-reveal-ease="smooth">
           <Card variant="elevated" padding="lg" class="h-full flex flex-col justify-center">
             <div class="flex items-center gap-3 pb-4 mb-4 border-b border-border sm:justify-center glitch:justify-start">
               <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">


### PR DESCRIPTION
The Design section's two blocks revealed together, unlike the Development and Performance sections where the right block trails the left. Add data-reveal-delay="1" to the Design card (the right block) so the text reveals first and the card follows — left-then-right, matching the rest.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
