### PR TITLE
Add native Umami analytics support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,12 @@ SITE_URL=https://example.com
 # Google Tag Manager Container ID
 # PUBLIC_GTM_ID=GTM-XXXXXXX
 
+# Umami — privacy-friendly, cookieless analytics.
+# Set your website ID (a UUID from the Umami dashboard) to enable it.
+# PUBLIC_UMAMI_WEBSITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# Optional — defaults to Umami Cloud. Point this at your own instance to self-host.
+# PUBLIC_UMAMI_SRC=https://cloud.umami.is/script.js
+
 # -----------------------------------------------------------------------------
 # Form Handling (optional)
 # -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -325,10 +325,16 @@ SITE_URL=https://yoursite.com
 PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 PUBLIC_GTM_ID=GTM-XXXXXXX
 
+# Optional - Umami (privacy-friendly, cookieless analytics)
+PUBLIC_UMAMI_WEBSITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# PUBLIC_UMAMI_SRC=https://cloud.umami.is/script.js   # override to self-host
+
 # Optional - Verification
 GOOGLE_SITE_VERIFICATION=your-code
 BING_SITE_VERIFICATION=your-code
 ```
+
+Astro Rocket ships with built-in support for **Google Analytics 4**, **Google Tag Manager**, and **Umami**. For Umami, set `PUBLIC_UMAMI_WEBSITE_ID` (the UUID from your Umami dashboard) and the tracking script loads automatically — it defaults to Umami Cloud, so override `PUBLIC_UMAMI_SRC` only when you self-host. Umami is cookieless and stores no personal data, so it loads without the cookie-consent banner.
 
 ---
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -97,6 +97,15 @@ export default defineConfig({
       SITE_URL: envField.string({ context: 'server', access: 'public', optional: true }),
       PUBLIC_GA_MEASUREMENT_ID: envField.string({ context: 'client', access: 'public', optional: true }),
       PUBLIC_GTM_ID: envField.string({ context: 'client', access: 'public', optional: true }),
+      // Umami — privacy-friendly, cookieless analytics. Set the website ID to
+      // enable it; the src defaults to Umami Cloud, override it when self-hosting.
+      PUBLIC_UMAMI_WEBSITE_ID: envField.string({ context: 'client', access: 'public', optional: true }),
+      PUBLIC_UMAMI_SRC: envField.string({
+        context: 'client',
+        access: 'public',
+        optional: true,
+        default: 'https://cloud.umami.is/script.js',
+      }),
       RESEND_API_KEY: envField.string({ context: 'server', access: 'secret', optional: true }),
       RESEND_FROM_EMAIL: envField.string({ context: 'server', access: 'secret', optional: true }),
       NEWSLETTER_API_KEY: envField.string({ context: 'server', access: 'secret', optional: true }),

--- a/src/components/layout/Analytics.astro
+++ b/src/components/layout/Analytics.astro
@@ -3,15 +3,20 @@
  * Analytics Component
  *
  * Conditionally loads analytics scripts based on environment variables.
- * Supports Google Analytics (GA4) and Google Tag Manager.
+ * Supports Google Analytics (GA4), Google Tag Manager, and Umami.
  *
  * When PUBLIC_CONSENT_ENABLED is true, integrates with Google Consent Mode v2:
  * - consent_mode_v2: Scripts load normally but with denied defaults (cookieless pings)
  * - strict: Scripts only load after explicit user consent
  *
+ * Umami is privacy-friendly and cookieless by design, so it loads directly and
+ * is not gated by the cookie-consent flow (there are no cookies to consent to).
+ *
  * Environment variables:
  * - PUBLIC_GA_MEASUREMENT_ID: Google Analytics 4 Measurement ID (e.g., G-XXXXXXXXXX)
  * - PUBLIC_GTM_ID: Google Tag Manager Container ID (e.g., GTM-XXXXXXX)
+ * - PUBLIC_UMAMI_WEBSITE_ID: Umami website ID (a UUID from your Umami dashboard)
+ * - PUBLIC_UMAMI_SRC: Umami script URL (defaults to Umami Cloud; override when self-hosting)
  * - PUBLIC_CONSENT_ENABLED: Enable cookie consent integration (boolean)
  *
  * CSP: All is:inline scripts here are STATIC (no define:vars). Dynamic values are
@@ -35,11 +40,20 @@
  * www.google-analytics.com will silently drop all tracking requests with
  * no console errors. The wildcard *.google-analytics.com is required.
  */
-import { PUBLIC_GA_MEASUREMENT_ID, PUBLIC_GTM_ID, PUBLIC_CONSENT_ENABLED } from 'astro:env/client';
+import {
+  PUBLIC_GA_MEASUREMENT_ID,
+  PUBLIC_GTM_ID,
+  PUBLIC_CONSENT_ENABLED,
+  PUBLIC_UMAMI_WEBSITE_ID,
+  PUBLIC_UMAMI_SRC,
+} from 'astro:env/client';
 import consentConfig from '@/config/consent.config';
 
 const gaId = PUBLIC_GA_MEASUREMENT_ID;
 const gtmId = PUBLIC_GTM_ID;
+const umamiId = PUBLIC_UMAMI_WEBSITE_ID;
+const umamiSrc = PUBLIC_UMAMI_SRC;
+const hasUmami = !!umamiId;
 const consentEnabled = PUBLIC_CONSENT_ENABLED;
 const consentMode = consentConfig.mode;
 const storageKey = consentConfig.storageKey;
@@ -94,6 +108,14 @@ const analyticsDataJson = JSON.stringify({
   analyticsCategoryKey,
 });
 ---
+
+{/* ── Umami — privacy-friendly, cookieless analytics ──
+    Loads directly (no consent gating): Umami sets no cookies and stores no
+    personal data, so it needs no cookie banner. Self-host by overriding
+    PUBLIC_UMAMI_SRC. */}
+{hasUmami && (
+  <script is:inline async src={umamiSrc} data-website-id={umamiId}></script>
+)}
 
 {/* Analytics data element — read by all inline scripts below */}
 {hasAnalytics && (


### PR DESCRIPTION
Umami joins Google Analytics 4 and Google Tag Manager as a built-in analytics option. Set PUBLIC_UMAMI_WEBSITE_ID to enable it; the script src defaults to Umami Cloud and can be overridden with PUBLIC_UMAMI_SRC for self-hosted instances. Umami is cookieless, so it loads directly without the cookie-consent flow.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
