### PR TITLE
Match the Umami post image to the blog cover pattern

### DIFF
--- a/src/assets/blog/umami-analytics.svg
+++ b/src/assets/blog/umami-analytics.svg
@@ -10,18 +10,13 @@
   </style>
   <rect width="1200" height="630" class="bg"/>
   <!-- Lucide ChartColumnIncreasing — axis with rising bars, the analytics motif -->
-  <g transform="translate(540, 195) scale(5)" class="ico" opacity="0.9">
+  <g transform="translate(540, 205) scale(5)" class="ico" opacity="0.9">
     <path d="M13 17V9"/>
     <path d="M18 17V5"/>
     <path d="M8 17v-3"/>
     <path d="M3 3v16a2 2 0 0 0 2 2h16"/>
   </g>
   <text x="600" y="435" font-size="96" text-anchor="middle" letter-spacing="-2" class="txt">analytics</text>
-  <!-- "cookieless" tag pill, centred under the word -->
-  <g>
-    <rect x="505" y="470" width="190" height="46" rx="23" class="pil"/>
-    <text x="600" y="501" font-size="24" text-anchor="middle" letter-spacing="0.5" class="ptx">cookieless</text>
-  </g>
   <path d="M 36 60 L 36 36 L 60 36" class="cor"/>
   <path d="M 1140 36 L 1164 36 L 1164 60" class="cor"/>
   <path d="M 36 570 L 36 594 L 60 594" class="cor"/>

--- a/src/content/blog/en/umami-analytics.mdx
+++ b/src/content/blog/en/umami-analytics.mdx
@@ -8,7 +8,7 @@ featured: false
 locale: en
 image: "../../../assets/blog/umami-analytics.svg"
 svgSlug: "umami-analytics"
-imageAlt: "A rising bar chart above the word 'analytics' with a 'cookieless' tag, on a brand-coloured background"
+imageAlt: "A rising bar chart above the word 'analytics', on a brand-coloured background"
 ---
 
 [Astro Rocket](https://astrorocket.dev) has always shipped with built-in support for Google Analytics 4 and Google Tag Manager — set an environment variable and the tracking script loads itself. Now there's a third option that a lot of people have been asking for: **[Umami](https://umami.is)**. It works exactly the same way — one environment variable and you're done — but it's privacy-friendly and cookieless by design.


### PR DESCRIPTION
The cover carried a tag pill under the wordmark, which no other post cover uses — the .pil style is unused boilerplate, not part of the pattern. Removes the pill and restores the standard icon position, so the cover is background, icon, wordmark, corner brackets like the rest.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
