### PR TITLE
Add llms.txt, AGENTS.md and SECURITY.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# Working in this codebase
+
+Astro Rocket is a starter theme. You are almost certainly here to help someone
+build **their** website on top of it, not to develop the theme itself. This file
+tells you where everything lives and which conventions to follow, so you can
+make changes that fit rather than changes that merely work.
+
+## The shape of the project
+
+```
+src/config/          Site settings — start here for almost any request
+src/content/         The site's content (Markdown/MDX/JSON collections)
+src/i18n/            All user-facing interface text, per language
+src/components/      57 components, grouped by purpose
+src/pages/           Routes; a file here is a URL
+src/layouts/         Page shells the routes render into
+src/lib/             Helpers for blog, projects, tags, SEO, themes
+src/styles/          Design tokens and the twelve colour themes
+component-registry.json   Machine-readable catalogue of every component
+```
+
+**Read `component-registry.json` first.** It lists every component with its
+category, purpose and props. It is the fastest way to find out whether the
+thing you are about to build already exists — it usually does.
+
+## Where to make a change
+
+| The request | The file |
+|---|---|
+| Site name, logo, social links, contact details | `src/config/site.config.ts` |
+| Navigation menus | `src/config/nav.config.ts` |
+| Languages | `src/config/i18n.config.ts` |
+| Cookie-consent behaviour | `src/config/consent.config.ts` |
+| Any visible interface text | `src/i18n/en.json` (and other locales) |
+| A blog post | a new `.mdx` file in `src/content/blog/<locale>/` |
+| A project | a new `.mdx` file in `src/content/projects/<locale>/` |
+| Colours | `src/styles/themes/*.css` — twelve themes, tokens only |
+
+**Page copy is not in the page files.** Text lives in `src/i18n/en.json` and is
+read through `t()`. Editing a heading usually means editing JSON, not `.astro`.
+If a page appears to have hard-coded text, check the locale file first.
+
+## Conventions worth keeping
+
+- **Use existing components.** Check the registry before writing a new one.
+  Components share one design language; a bespoke element breaks it.
+- **Use the design tokens.** Colours come from CSS custom properties defined in
+  `src/styles/`. Never hard-code a hex value — it will not follow the colour
+  theme, and it will fail the contrast checks.
+- **Every locale file stays in step.** Adding a key to `en.json` means adding it
+  to every other locale, or that language falls back mid-page.
+- **Motion respects `prefers-reduced-motion`.** Anything animated must stop for
+  visitors who ask it to.
+- **Images go through `astro:assets`.** Use the `<Image>` component so sizes and
+  formats are generated at build time.
+- **Zero JavaScript unless it earns its place.** Astro ships none by default;
+  reach for a `<script>` only when the interaction genuinely needs one.
+
+## Commands
+
+```bash
+pnpm dev          # development server
+pnpm build        # production build — run before declaring work finished
+pnpm check        # astro check, TypeScript, ESLint and Prettier
+pnpm test         # Vitest unit tests
+pnpm fix          # apply ESLint and Prettier fixes
+```
+
+`pnpm build` is the real test. It runs `astro check`, the content-collection
+schemas and the link validation, and it fails on problems a dev server hides.
+
+## Things that are easy to get wrong
+
+- **Content collections are schema-checked.** Frontmatter that does not match
+  `src/content.config.ts` fails the build. Read the schema before adding fields.
+- **Drafts are filtered in production only.** `draft: true` still renders in
+  `pnpm dev`, so verify with a build.
+- **A draft is unreachable.** Linking to a drafted post or project produces a
+  404 in production. Check inbound links before drafting something.
+- **The theme supports multiple languages.** Locale-prefixed routes are
+  generated automatically; do not create `src/pages/<locale>/` files by hand.
+
+## Before you finish
+
+Run `pnpm build`. Then confirm what you changed is actually visible on the page
+you changed it on — not merely that the command exited without an error.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are released for the latest published version of Astro Rocket.
+The theme is distributed by cloning the repository, so the way to receive a fix
+is to update from upstream — see the update guide on the theme blog.
+
+| Version | Supported |
+|---------|-----------|
+| 2.x     | Yes       |
+| 1.x     | No        |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.** A public report
+tells everyone running the theme about the weakness before there is a fix.
+
+Report it privately in one of two ways:
+
+1. **GitHub Security Advisories** — preferred. Go to the repository's
+   **Security** tab and choose **Report a vulnerability**. This keeps the
+   report private and creates a place to discuss the fix.
+2. **Email** — `hello@hansmartens.dev`, if you would rather not use GitHub.
+
+Useful things to include, as far as you can:
+
+- what the problem is, and what an attacker could achieve with it
+- the affected file, route or component
+- steps to reproduce, or a proof of concept
+- the version or commit you found it on
+
+## What to expect
+
+- An acknowledgement that the report arrived, within a few days.
+- An assessment of whether it is reproducible and how serious it is.
+- A fix released as soon as it is ready, with the problem described in the
+  changelog once users have had the chance to update.
+- Credit for the report, unless you prefer not to be named.
+
+This is a free, MIT-licensed project maintained by one person, so there is no
+bug bounty and no guaranteed response time. Reports are taken seriously
+regardless.
+
+## Notes for people running a site on this theme
+
+A few things are your responsibility rather than the theme's:
+
+- **Keep secrets out of the repository.** API keys belong in environment
+  variables, not in committed files. `.env` is gitignored for that reason.
+- **Server-side keys stay server-side.** Anything named `PUBLIC_` is visible to
+  every visitor. Never put a private key behind that prefix.
+- **Update your dependencies.** Most vulnerabilities in a site built on this
+  theme will come from packages, not from the theme's own code.
+- **Check your own additions.** Forms, API routes and third-party embeds you add
+  are outside the theme's control and its testing.

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,89 @@
+import type { APIRoute } from 'astro';
+import siteConfig from '@/config/site.config';
+import { defaultLocale } from '@/i18n';
+import { getPublishedPosts, getPostUrl } from '@/lib/blog';
+import { getVisibleProjects, getProjectUrl } from '@/lib/projects';
+
+/**
+ * /llms.txt
+ *
+ * A plain-Markdown map of this site for large language models, following the
+ * proposal at https://llmstxt.org. Where robots.txt tells a crawler *whether*
+ * it may read the site, llms.txt tells a model *what the site is and which
+ * pages matter* — in one short, token-cheap file.
+ *
+ * Why it's worth having: when someone asks an assistant a question this site
+ * could answer, the model has a clean, citable summary instead of guessing
+ * from scattered marketing copy.
+ *
+ * Everything here is generated at build time from `site.config.ts` and the
+ * content collections, so it describes *your* site and never drifts out of
+ * sync with the real pages. There is nothing to keep updated by hand.
+ *
+ * Multi-language sites: the default locale is listed, since llms.txt is meant
+ * to stay short. Translated pages remain discoverable through the sitemap and
+ * the hreflang tags the theme already emits.
+ */
+
+export const GET: APIRoute = async ({ site }) => {
+  const base = (site?.toString() || siteConfig.url).replace(/\/$/, '');
+
+  const posts = await getPublishedPosts(defaultLocale);
+  const projects = await getVisibleProjects(defaultLocale);
+
+  const line = (title: string, url: string, description?: string) =>
+    description ? `- [${title}](${url}): ${description}` : `- [${title}](${url})`;
+
+  const postLines = [...posts]
+    .sort((a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf())
+    .map((post) => line(post.data.title, `${base}${getPostUrl(post.id, defaultLocale)}`, post.data.description))
+    .join('\n');
+
+  const projectLines = [...projects]
+    .sort((a, b) => a.data.order - b.data.order)
+    .map((project) =>
+      line(project.data.title, `${base}${getProjectUrl(project.id, defaultLocale)}`, project.data.description)
+    )
+    .join('\n');
+
+  const sections = [
+    `# ${siteConfig.name}`,
+    ``,
+    `> ${siteConfig.description}`,
+    ``,
+    `## Pages`,
+    ``,
+    line('Home', `${base}/`),
+    line('About', `${base}/about`),
+    line('Projects', `${base}/projects`),
+    line('Blog', `${base}/blog`),
+    line('Contact', `${base}/contact`),
+  ];
+
+  if (projectLines) {
+    sections.push(``, `## Projects`, ``, projectLines);
+  }
+
+  if (postLines) {
+    sections.push(``, `## Blog posts`, ``, postLines);
+  }
+
+  sections.push(
+    ``,
+    `## More`,
+    ``,
+    line('Sitemap', `${base}/sitemap-index.xml`),
+    line('RSS feed', `${base}/rss.xml`),
+    ``,
+    `---`,
+    ``,
+    `Contact: ${siteConfig.email}`,
+    ``
+  );
+
+  return new Response(sections.join('\n'), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+};

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -10,6 +10,9 @@ Allow: /
 # Block API routes
 Disallow: /api/
 
+# Plain-Markdown map of this site for language models — see https://llmstxt.org
+# LLM map: ${siteUrl}llms.txt
+
 Sitemap: ${siteUrl}sitemap-index.xml
 `.trim();
 


### PR DESCRIPTION
/llms.txt gives language models a short, plain-Markdown map of the site, following the llmstxt.org proposal. It is generated at build time from site.config.ts and the content collections, so it describes the site that was built with the theme and never drifts from the real pages. robots.txt points at it.

AGENTS.md documents the codebase for an agent helping someone build a site on the theme: where settings, content and interface text live, that page copy sits in the locale files rather than the page files, the conventions worth keeping, and the mistakes that are easy to make.

SECURITY.md sets out supported versions and asks for vulnerabilities to be reported privately through GitHub Security Advisories or email rather than a public issue.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
