### PR TITLE
Move the table of contents to the right on desktop

### DIFF
--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -287,7 +287,7 @@ const siteConfig: SiteConfig = {
     toc: {
       enabled: true,
       layout: 'auto',
-      sidebarPosition: 'left',
+      sidebarPosition: 'right',
       minHeadings: 3,
       maxDepth: 3,
     },


### PR DESCRIPTION
The shipped config set the sidebar TOC to the left. It now sits on the right of the article, which is the usual placement for articles and the same side the layouts fall back to when the setting is omitted.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
