### PR TITLE
Give the project hero image a defined edge in light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **The table of contents now sits on the right** — `articleFeatures.toc.sidebarPosition` ships as `'right'`, the usual side for an article and the side the layouts already fell back to when the setting was omitted. Set it back to `'left'` in `site.config.ts` to keep the previous placement.
 - **Blog posts and project pages have a framed reading surface** — the article sits in a card with a neutral border, matching the TOC card beside it. The border stays neutral rather than brand-tinted: an accent suits a small card, while the same tint around a full-length article reads as decoration. The frame starts at the `sm` breakpoint, so a phone held upright keeps the full screen width for the text.
 
+### Fixed
+
+- **Light screenshots in a project hero had no visible edge** — the hero frame's light-mode ring was 5% black, which against a white page is close to invisible. A screenshot of a light interface therefore ended where its shadow began, and the shadow read as the outline rather than as depth. The ring now uses the standard border colour. Dark screenshots and dark mode are unchanged, and the shadow itself was not touched.
+
 ## [2.2.0] — 2026-07-27
 
 ### Added

--- a/src/components/projects/ProjectCarousel.astro
+++ b/src/components/projects/ProjectCarousel.astro
@@ -45,7 +45,14 @@ const posters = await Promise.all(
   aria-roledescription="carousel"
   aria-label={label}
 >
-  <div class="relative overflow-hidden rounded-xl media-shadow ring-1 ring-black/5 dark:ring-white/10">
+  <!--
+    The ring uses the standard border colour in light mode. A screenshot of a
+    light interface has no edge of its own against the page, which leaves the
+    shadow marking where the image stops; a defined edge puts the shadow back
+    to suggesting depth. Dark screenshots are unaffected — they already read
+    as a distinct shape — and dark mode keeps its own ring.
+  -->
+  <div class="relative overflow-hidden rounded-xl media-shadow ring-1 ring-border dark:ring-white/10">
     <div
       class="carousel-track flex snap-x snap-mandatory overflow-x-auto scroll-smooth"
       data-carousel-track


### PR DESCRIPTION
The hero frame's light-mode ring was 5% black, which against a white page is close to invisible. A screenshot of a light interface then ended where its shadow began, leaving the shadow to mark the edge instead of suggesting depth. The ring now uses the standard border colour.

The shadow is unchanged, so dark screenshots look as they did, and dark mode keeps its own ring.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
