### PR TITLE
Keep the site's own URL in one place

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ That single field swaps the monogram for your image in the header, footer, and a
 
 Create a `.env` file from `.env.example`:
 
+`SITE_URL` is the one that matters everywhere: canonical tags, `og:url`, `og:image`, RSS links and the sitemap are all built from it, and your host needs it set as an environment variable too, not only in your local `.env`. Leave it unset and the build says so and falls back to `https://example.com`.
+
 ```bash
 # Required
 SITE_URL=https://yoursite.com

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ import vercel from '@astrojs/vercel';
 import netlify from '@astrojs/netlify';
 import cloudflare from '@astrojs/cloudflare';
 import i18nConfig from './src/config/i18n.config.ts';
+import { SITE_URL_FALLBACK } from './src/config/site-url.ts';
 
 /**
  * Deploy-target adapter selection. Vercel is the default; set
@@ -29,6 +30,31 @@ function resolveAdapter() {
     default:
       return vercel();
   }
+}
+
+/**
+ * Build-time check that the site knows its own address.
+ *
+ * With `SITE_URL` unset the build still succeeds, and every canonical tag,
+ * `og:url`, `og:image`, RSS link and sitemap entry is written against the
+ * placeholder above — pointing search engines and social crawlers at a domain
+ * that isn't yours. Nothing in the output looks broken, so it survives to
+ * production easily. Warn where it will be read: the build log.
+ */
+function siteUrlCheck() {
+  return {
+    name: 'site-url-check',
+    hooks: {
+      'astro:build:start': ({ logger }) => {
+        if (process.env.SITE_URL) return;
+        logger.warn(
+          `SITE_URL is not set, so canonical URLs, og:image, RSS and the sitemap ` +
+            `will all be written against ${SITE_URL_FALLBACK}. Set SITE_URL in ` +
+            `your host's environment variables to your own domain.`
+        );
+      },
+    },
+  };
 }
 
 /**
@@ -80,7 +106,7 @@ const astroI18nOptions = i18nEnabled
 export default defineConfig({
   output: 'static',
   adapter: resolveAdapter(),
-  site: process.env.SITE_URL || 'https://example.com',
+  site: process.env.SITE_URL || SITE_URL_FALLBACK,
   ...(astroI18nOptions ? { i18n: astroI18nOptions } : {}),
 
   // Astro 7 changed the default to 'jsx', which strips whitespace between
@@ -127,6 +153,7 @@ export default defineConfig({
     mdx(),
     sitemap(),
     icon(),
+    siteUrlCheck(),
     pagefind(),
   ],
 

--- a/src/config/site-url.ts
+++ b/src/config/site-url.ts
@@ -1,0 +1,16 @@
+/**
+ * The URL used when the `SITE_URL` environment variable is not set.
+ *
+ * Two places need the site's own address and they must agree: `astro.config.mjs`
+ * sets `site`, which produces every canonical tag, `og:url`, `og:image`, RSS
+ * link and sitemap entry — and `site.config.ts` sets `url`, which the JSON-LD,
+ * the share cards and the footer read. `astro.config.mjs` runs before
+ * `astro:env` exists, so it cannot import `site.config.ts`; without a shared
+ * constant the two drift, and a site ends up serving canonical URLs for one
+ * domain while telling crawlers it lives at another.
+ *
+ * Set `SITE_URL` in your host's environment and this is never used. It stays a
+ * placeholder on purpose: a site that ships without `SITE_URL` should be
+ * obviously unconfigured rather than quietly claim someone else's domain.
+ */
+export const SITE_URL_FALLBACK = 'https://example.com';

--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -1,5 +1,6 @@
 import { SITE_URL, GOOGLE_SITE_VERIFICATION, BING_SITE_VERIFICATION } from 'astro:env/server';
 import i18nConfig, { type I18nConfig } from './i18n.config';
+import { SITE_URL_FALLBACK } from './site-url';
 
 export { i18nConfig };
 export type { I18nConfig };
@@ -263,7 +264,7 @@ const siteConfig: SiteConfig = {
     'Astro Rocket is a free, lightning-fast Astro 7 starter theme to build anything on — with 57+ designed components, 12 colour themes, dark mode, and built-in i18n on board.',
   tagline: 'Astro 7 starter theme to build anything on',
   footerNote: 'Free & open source · MIT licensed',
-  url: SITE_URL || 'https://astrorocket.dev',
+  url: SITE_URL || SITE_URL_FALLBACK,
   // Generated at build time from `name`, `tagline` and the brand colour below.
   // Point this at a file in `public/` to use your own — it has to be a raster
   // (PNG or JPEG): social platforms don't render SVG share images.

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,7 +1,8 @@
 import type { APIRoute } from 'astro';
+import { SITE_URL_FALLBACK } from '@/config/site-url';
 
 export const GET: APIRoute = ({ site }) => {
-  const siteUrl = site?.toString() || 'https://example.com';
+  const siteUrl = site?.toString() || SITE_URL_FALLBACK;
 
   const robotsTxt = `
 User-agent: *


### PR DESCRIPTION
`astro.config.mjs` sets `site` — the source of every canonical tag, `og:url`, `og:image`, RSS link and sitemap entry — and `site.config.ts` sets `url`, which the JSON-LD, the share cards and the footer read. With `SITE_URL` unset the first fell back to `https://example.com` and the second to `https://astrorocket.dev`, so a build without the environment variable told crawlers the site lived at one domain while every canonical URL named another. The share card printed one and its `og:image` URL the other.

`astro.config.mjs` runs before `astro:env` exists, so it cannot import `site.config.ts` to read the value. A small shared module can be imported by both, and now is — along with robots.txt, which had a third copy. It keeps `https://example.com`: a site that ships without `SITE_URL` should be obviously unconfigured rather than quietly claim someone else's domain.

The build also warns when `SITE_URL` is unset, naming what will be used. Nothing in the output looks wrong when it is, which is how a deployment ends up serving canonical URLs for example.com without anyone noticing. The README says to set it on the host, not only in a local `.env`.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
