### PR TITLE
Serve the stylesheet as a cached file instead of inlining it everywhere

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -115,7 +115,7 @@ export default defineConfig({
   compressHTML: true,
 
   build: {
-    inlineStylesheets: 'always',
+    inlineStylesheets: 'auto',
   },
 
   env: {


### PR DESCRIPTION
`inlineStylesheets: 'always'` put all 223 KB of CSS into the <head> of all 88 pages. It is the same stylesheet every time, so a reader who opens three pages downloaded it three times — 36 KB gzip each, none of it cacheable, because it was part of the HTML.

'auto' emits one hashed file that all 88 pages link, so it is fetched once and served from cache for the rest of the visit. HTML drops by 216 KB per page; the sample post goes 360 KB to 145 KB.

Measured with Lighthouse against a local gzip server, desktop and mobile presets, before and after:

                          always            auto
  /                  100/100/100/100  100/100/100/100   desktop
  /blog/table-of-c.  100/100/100/100  100/100/100/100   desktop
  /                  100 (FCP 1337)    99 (FCP 1258)    mobile
  /blog/table-of-c.   99 (FCP 1413)    98 (FCP 1652)    mobile
  /components         93 (LCP 2868)    95 (LCP 2635)    mobile

The 1-2 point mobile differences fall on both sides and are within run-to-run noise, so inlining was not buying the score it looks like it was buying — it was only moving the cost of the first paint onto every page after it. Lighthouse measures one cold page load and never sees the second visit, which is where this change pays.

Left as its own branch: it touches how the theme delivers CSS, and the 100/100/100/100 claim on the project page rests on it.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
