### PR TITLE
Give the components page its accessible names back

### DIFF
--- a/public/demo/avatars/1.svg
+++ b/public/demo/avatars/1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150" width="150" height="150" role="img" aria-label="Abstract placeholder avatar">
+  <defs>
+    <radialGradient id="g1" cx="55%" cy="57%" r="78%">
+      <stop offset="0%" stop-color="hsl(240 82% 78%)"/>
+      <stop offset="62%" stop-color="hsl(212 62% 53%)"/>
+      <stop offset="100%" stop-color="hsl(182 55% 33%)"/>
+    </radialGradient>
+  </defs>
+  <rect width="150" height="150" fill="url(#g1)"/>
+  <circle cx="67" cy="103" r="46" fill="hsl(240 82% 78%)" opacity="0.20"/>
+  <circle cx="109" cy="101" r="30" fill="hsl(182 55% 33%)" opacity="0.22"/>
+</svg>

--- a/public/demo/avatars/2.svg
+++ b/public/demo/avatars/2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150" width="150" height="150" role="img" aria-label="Abstract placeholder avatar">
+  <defs>
+    <radialGradient id="g2" cx="38%" cy="50%" r="78%">
+      <stop offset="0%" stop-color="hsl(295 82% 72%)"/>
+      <stop offset="62%" stop-color="hsl(267 62% 60%)"/>
+      <stop offset="100%" stop-color="hsl(237 55% 38%)"/>
+    </radialGradient>
+  </defs>
+  <rect width="150" height="150" fill="url(#g2)"/>
+  <circle cx="50" cy="96" r="46" fill="hsl(295 82% 72%)" opacity="0.20"/>
+  <circle cx="100" cy="90" r="30" fill="hsl(237 55% 38%)" opacity="0.22"/>
+</svg>

--- a/public/demo/avatars/3.svg
+++ b/public/demo/avatars/3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150" width="150" height="150" role="img" aria-label="Abstract placeholder avatar">
+  <defs>
+    <radialGradient id="g3" cx="55%" cy="43%" r="78%">
+      <stop offset="0%" stop-color="hsl(8 82% 78%)"/>
+      <stop offset="62%" stop-color="hsl(340 62% 46%)"/>
+      <stop offset="100%" stop-color="hsl(310 55% 28%)"/>
+    </radialGradient>
+  </defs>
+  <rect width="150" height="150" fill="url(#g3)"/>
+  <circle cx="67" cy="89" r="46" fill="hsl(8 82% 78%)" opacity="0.20"/>
+  <circle cx="91" cy="112" r="30" fill="hsl(310 55% 28%)" opacity="0.22"/>
+</svg>

--- a/public/demo/avatars/4.svg
+++ b/public/demo/avatars/4.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150" width="150" height="150" role="img" aria-label="Abstract placeholder avatar">
+  <defs>
+    <radialGradient id="g4" cx="38%" cy="36%" r="78%">
+      <stop offset="0%" stop-color="hsl(52 82% 72%)"/>
+      <stop offset="62%" stop-color="hsl(24 62% 53%)"/>
+      <stop offset="100%" stop-color="hsl(354 55% 33%)"/>
+    </radialGradient>
+  </defs>
+  <rect width="150" height="150" fill="url(#g4)"/>
+  <circle cx="50" cy="82" r="46" fill="hsl(52 82% 72%)" opacity="0.20"/>
+  <circle cx="118" cy="101" r="30" fill="hsl(354 55% 33%)" opacity="0.22"/>
+</svg>

--- a/public/demo/avatars/5.svg
+++ b/public/demo/avatars/5.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150" width="150" height="150" role="img" aria-label="Abstract placeholder avatar">
+  <defs>
+    <radialGradient id="g5" cx="55%" cy="59%" r="78%">
+      <stop offset="0%" stop-color="hsl(186 82% 78%)"/>
+      <stop offset="62%" stop-color="hsl(158 62% 60%)"/>
+      <stop offset="100%" stop-color="hsl(128 55% 38%)"/>
+    </radialGradient>
+  </defs>
+  <rect width="150" height="150" fill="url(#g5)"/>
+  <circle cx="67" cy="105" r="46" fill="hsl(186 82% 78%)" opacity="0.20"/>
+  <circle cx="109" cy="90" r="30" fill="hsl(128 55% 38%)" opacity="0.22"/>
+</svg>

--- a/public/demo/avatars/6.svg
+++ b/public/demo/avatars/6.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150" width="150" height="150" role="img" aria-label="Abstract placeholder avatar">
+  <defs>
+    <radialGradient id="g6" cx="38%" cy="52%" r="78%">
+      <stop offset="0%" stop-color="hsl(218 82% 72%)"/>
+      <stop offset="62%" stop-color="hsl(190 62% 46%)"/>
+      <stop offset="100%" stop-color="hsl(160 55% 28%)"/>
+    </radialGradient>
+  </defs>
+  <rect width="150" height="150" fill="url(#g6)"/>
+  <circle cx="50" cy="98" r="46" fill="hsl(218 82% 72%)" opacity="0.20"/>
+  <circle cx="100" cy="112" r="30" fill="hsl(160 55% 28%)" opacity="0.22"/>
+</svg>

--- a/public/demo/avatars/7.svg
+++ b/public/demo/avatars/7.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150" width="150" height="150" role="img" aria-label="Abstract placeholder avatar">
+  <defs>
+    <radialGradient id="g7" cx="55%" cy="45%" r="78%">
+      <stop offset="0%" stop-color="hsl(73 82% 78%)"/>
+      <stop offset="62%" stop-color="hsl(45 62% 53%)"/>
+      <stop offset="100%" stop-color="hsl(15 55% 33%)"/>
+    </radialGradient>
+  </defs>
+  <rect width="150" height="150" fill="url(#g7)"/>
+  <circle cx="67" cy="91" r="46" fill="hsl(73 82% 78%)" opacity="0.20"/>
+  <circle cx="91" cy="101" r="30" fill="hsl(15 55% 33%)" opacity="0.22"/>
+</svg>

--- a/public/demo/banner-dark.svg
+++ b/public/demo/banner-dark.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 200" width="1200" height="200" role="img" aria-label="Abstract placeholder banner">
+  <defs>
+    <linearGradient id="sky-d" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#16233d"/>
+      <stop offset="100%" stop-color="#3b5573"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="200" fill="url(#sky-d)"/>
+  <circle cx="965" cy="58" r="34" fill="#7dd3fc" opacity="0.55"/>
+  <path d="M0 126 C 220 92, 430 152, 660 114 S 1010 82, 1200 120 L1200 200 L0 200 Z" fill="#4a6e94" opacity="0.85"/>
+  <path d="M0 158 C 220 124, 430 184, 660 146 S 1010 114, 1200 152 L1200 200 L0 200 Z" fill="#1b2b40" opacity="0.95"/>
+</svg>

--- a/public/demo/banner-light.svg
+++ b/public/demo/banner-light.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 200" width="1200" height="200" role="img" aria-label="Abstract placeholder banner">
+  <defs>
+    <linearGradient id="sky-l" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#6f86bd"/>
+      <stop offset="100%" stop-color="#9db0d6"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="200" fill="url(#sky-l)"/>
+  <circle cx="965" cy="58" r="34" fill="#f0dfa8" opacity="0.55"/>
+  <path d="M0 126 C 220 92, 430 152, 660 114 S 1010 82, 1200 120 L1200 200 L0 200 Z" fill="#59709f" opacity="0.85"/>
+  <path d="M0 158 C 220 124, 430 184, 660 146 S 1010 114, 1200 152 L1200 200 L0 200 Z" fill="#43567c" opacity="0.95"/>
+</svg>

--- a/scripts/demo-assets.mjs
+++ b/scripts/demo-assets.mjs
@@ -1,0 +1,96 @@
+/**
+ * Generates the placeholder imagery used by the /components showcase.
+ *
+ * The showcase used to hotlink avatars from i.pravatar.cc and banners from
+ * images.unsplash.com. That sent every visitor's IP to two third parties on a
+ * site that otherwise ships cookieless analytics, and left the demo dependent
+ * on services that can rate-limit or disappear. These are drawn locally
+ * instead: abstract, deterministic, and no faces, so nothing here implies a
+ * real person.
+ *
+ * Run with `node scripts/demo-assets.mjs`. Output is committed, so this only
+ * needs re-running when the artwork itself should change.
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const OUT = join(process.cwd(), 'public', 'demo');
+
+/** Distinct hues, kept clear of each other so an AvatarGroup reads as separate people. */
+const AVATAR_HUES = [212, 267, 340, 24, 158, 190, 45];
+
+/**
+ * An abstract avatar: a tinted field with a soft off-centre bloom and two
+ * overlapping arcs. Deliberately not a face and not initials — the showcase
+ * demonstrates the initials fallback separately, so these have to read as
+ * photographic fills rather than repeat it.
+ */
+function avatar(hue, i) {
+  const bg = `hsl(${hue} 62% ${46 + (i % 3) * 7}%)`;
+  const light = `hsl(${(hue + 28) % 360} 82% ${72 + (i % 2) * 6}%)`;
+  const dark = `hsl(${(hue + 330) % 360} 55% ${28 + (i % 3) * 5}%)`;
+  const cx = 38 + ((i * 17) % 34);
+  const cy = 34 + ((i * 23) % 30);
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150" width="150" height="150" role="img" aria-label="Abstract placeholder avatar">
+  <defs>
+    <radialGradient id="g${i}" cx="${cx}%" cy="${cy}%" r="78%">
+      <stop offset="0%" stop-color="${light}"/>
+      <stop offset="62%" stop-color="${bg}"/>
+      <stop offset="100%" stop-color="${dark}"/>
+    </radialGradient>
+  </defs>
+  <rect width="150" height="150" fill="url(#g${i})"/>
+  <circle cx="${cx + 12}" cy="${cy + 46}" r="46" fill="${light}" opacity="0.20"/>
+  <circle cx="${118 - (i % 4) * 9}" cy="${112 - (i % 3) * 11}" r="30" fill="${dark}" opacity="0.22"/>
+</svg>
+`;
+}
+
+/**
+ * A 1200x200 banner standing in for a wide photograph. Layered bands give the
+ * transparent-header demos something with real tonal variation to sit on —
+ * a flat fill would not show whether the header blends or fights with it.
+ */
+function banner({ id, sky, mid, near, haze }) {
+  const band = (y, fill, opacity) =>
+    `<path d="M0 ${y} C 220 ${y - 34}, 430 ${y + 26}, 660 ${y - 12} S 1010 ${y - 44}, 1200 ${y - 6} L1200 200 L0 200 Z" fill="${fill}" opacity="${opacity}"/>`;
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 200" width="1200" height="200" role="img" aria-label="Abstract placeholder banner">
+  <defs>
+    <linearGradient id="sky-${id}" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="${sky[0]}"/>
+      <stop offset="100%" stop-color="${sky[1]}"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="200" fill="url(#sky-${id})"/>
+  <circle cx="965" cy="58" r="34" fill="${haze}" opacity="0.55"/>
+  ${band(126, mid, '0.85')}
+  ${band(158, near, '0.95')}
+</svg>
+`;
+}
+
+await mkdir(join(OUT, 'avatars'), { recursive: true });
+
+for (const [i, hue] of AVATAR_HUES.entries()) {
+  await writeFile(join(OUT, 'avatars', `${i + 1}.svg`), avatar(hue, i + 1), 'utf8');
+}
+
+// Light banner: the demo over it applies grayscale + brightness-150 +
+// opacity-60, which is close to three stops of lift. Pastels disappear
+// completely under that, so this starts at mid tone and lands light.
+await writeFile(
+  join(OUT, 'banner-light.svg'),
+  banner({ id: 'l', sky: ['#6f86bd', '#9db0d6'], mid: '#59709f', near: '#43567c', haze: '#f0dfa8' }),
+  'utf8',
+);
+
+// Dark banner: sits under a black/40 overlay with white text on top. It has to
+// stay dark enough for the text, but the bands need real separation from the
+// sky or the overlay flattens the whole thing to one black rectangle.
+await writeFile(
+  join(OUT, 'banner-dark.svg'),
+  banner({ id: 'd', sky: ['#16233d', '#3b5573'], mid: '#4a6e94', near: '#1b2b40', haze: '#7dd3fc' }),
+  'utf8',
+);
+
+console.warn(`demo assets written to ${OUT}`);

--- a/src/components/ui/data-display/Progress/Progress.astro
+++ b/src/components/ui/data-display/Progress/Progress.astro
@@ -16,6 +16,11 @@ interface Props extends HTMLAttributes<'div'> {
   size?: 'sm' | 'md' | 'lg';
   /** Show percentage label */
   showLabel?: boolean;
+  /**
+   * Accessible name for the bar. Only needed when there is no visible label:
+   * with `showLabel` the slotted text names the bar already.
+   */
+  label?: string;
 }
 
 const {
@@ -24,24 +29,36 @@ const {
   variant = 'default',
   size = 'md',
   showLabel = false,
+  label,
   class: className,
   ...attrs
 } = Astro.props;
 
 const isIndeterminate = value === undefined;
 const percentage = isIndeterminate || max <= 0 ? 0 : Math.min(100, Math.max(0, (value / max) * 100));
+
+// A `progressbar` needs an accessible name of its own: with only `aria-valuenow`
+// a screen reader announces a bare number and nothing about what is loading.
+// Point at the visible label when there is one, so what is announced matches
+// what is on screen, and fall back to a generic name when there is neither.
+const hasVisibleLabel = showLabel && !isIndeterminate && Astro.slots.has('default');
+const labelId = hasVisibleLabel ? `progress-label-${Math.random().toString(36).slice(2, 9)}` : undefined;
+const ariaLabel = label ?? (hasVisibleLabel ? undefined : 'Progress');
+const ariaLabelledBy = !label && hasVisibleLabel ? labelId : undefined;
 ---
 
 <div class={cn('w-full', className)} {...attrs}>
   {showLabel && !isIndeterminate && (
     <div class="flex justify-between mb-1.5">
-      <slot />
+      <span id={labelId}><slot /></span>
       <span class="text-xs font-medium text-foreground-muted">{Math.round(percentage)}%</span>
     </div>
   )}
   <div
     class={cn(progressTrackVariants({ size }))}
     role="progressbar"
+    aria-label={ariaLabel}
+    aria-labelledby={ariaLabelledBy}
     aria-valuenow={isIndeterminate ? undefined : Math.round(percentage)}
     aria-valuemin={0}
     aria-valuemax={max}

--- a/src/components/ui/data-display/Progress/Progress.tsx
+++ b/src/components/ui/data-display/Progress/Progress.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes, type Ref, type ReactNode } from 'react';
+import { useId, type HTMLAttributes, type Ref, type ReactNode } from 'react';
 import { cn } from '@/lib/cn';
 import { progressTrackVariants, progressBarVariants, type ProgressVariants } from './progress.variants';
 
@@ -9,24 +9,38 @@ interface ProgressProps extends Omit<HTMLAttributes<HTMLDivElement>, 'ref'> {
   variant?: ProgressVariants['variant'];
   size?: ProgressVariants['size'];
   showLabel?: boolean;
+  /**
+   * Accessible name for the bar. Only needed when there is no visible label:
+   * with `showLabel` the children name the bar already.
+   */
+  label?: string;
   children?: ReactNode;
 }
 
-export function Progress({ ref, value, max = 100, variant = 'default', size = 'md', showLabel = false, className, children, ...rest }: ProgressProps) {
+export function Progress({ ref, value, max = 100, variant = 'default', size = 'md', showLabel = false, label, className, children, ...rest }: ProgressProps) {
   const isIndeterminate = value === undefined;
   const percentage = isIndeterminate || max <= 0 ? 0 : Math.min(100, Math.max(0, (value / max) * 100));
+
+  // See the note in Progress.astro: `aria-valuenow` alone is announced as a
+  // bare number, so the bar needs a name from the visible label or a fallback.
+  const labelId = useId();
+  const hasVisibleLabel = showLabel && !isIndeterminate && children != null;
+  const ariaLabel = label ?? (hasVisibleLabel ? undefined : 'Progress');
+  const ariaLabelledBy = !label && hasVisibleLabel ? labelId : undefined;
 
   return (
     <div ref={ref} className={cn('w-full', className)} {...rest}>
       {showLabel && !isIndeterminate && (
         <div className="flex justify-between mb-1.5">
-          {children}
+          <span id={labelId}>{children}</span>
           <span className="text-xs font-medium text-foreground-muted">{Math.round(percentage)}%</span>
         </div>
       )}
       <div
         className={cn(progressTrackVariants({ size }))}
         role="progressbar"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
         aria-valuenow={isIndeterminate ? undefined : Math.round(percentage)}
         aria-valuemin={0}
         aria-valuemax={max}

--- a/src/components/ui/feedback/Alert/Alert.astro
+++ b/src/components/ui/feedback/Alert/Alert.astro
@@ -40,10 +40,17 @@ const icons: Record<string, 'info' | 'check-circle' | 'alert-triangle' | 'x-circ
 
   {/* Content */}
   <div class="flex-1 min-w-0 pl-1">
+    {/*
+      The title labels this alert; it is not a section of the document, and
+      `role="alert"` above already has a screen reader announce the whole
+      banner as one thing. As an h5 it also inserted an arbitrary heading level
+      wherever an Alert happened to sit, breaking heading order on any page
+      using one. A div carries the same styling and stays out of the outline.
+    */}
     {title && (
-      <h5 class="font-semibold text-sm mb-1 text-foreground">
+      <div class="font-semibold text-sm mb-1 text-foreground">
         {title}
-      </h5>
+      </div>
     )}
     <div class="text-sm leading-relaxed text-foreground-muted">
       <slot />

--- a/src/components/ui/feedback/Alert/Alert.tsx
+++ b/src/components/ui/feedback/Alert/Alert.tsx
@@ -56,7 +56,7 @@ export function Alert({ ref, variant = 'info', title, dismissible = false, onDis
 
       <div className="flex-1 min-w-0 pl-1">
         {title && (
-          <h5 className="font-semibold text-sm mb-1 text-foreground">{title}</h5>
+          <div className="font-semibold text-sm mb-1 text-foreground">{title}</div>
         )}
         <div className="text-sm leading-relaxed text-foreground-muted">{children}</div>
       </div>

--- a/src/components/ui/feedback/Toast/Toast.tsx
+++ b/src/components/ui/feedback/Toast/Toast.tsx
@@ -111,9 +111,18 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={{ toast, dismiss }}>
       {children}
-      {/* Toast container */}
+      {/*
+        Toast container.
+
+        ARIA prohibits `aria-label` on a plain div: with no role there is
+        nothing for the name to belong to, so the label was being dropped.
+        `role="region"` gives the live area an identity, which makes the label
+        legal and turns the container into a landmark that screen-reader users
+        can jump to.
+      */}
       <div
         className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 max-w-[420px] w-full pointer-events-none"
+        role="region"
         aria-live="polite"
         aria-label="Notifications"
       >

--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -131,9 +131,9 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 class="mt-[var(--space-stack-lg)]"
                 text="Trusted by developers"
                 avatars={[
-                  'https://i.pravatar.cc/150?img=12',
-                  'https://i.pravatar.cc/150?img=33',
-                  'https://i.pravatar.cc/150?img=47',
+                  '/demo/avatars/1.svg',
+                  '/demo/avatars/2.svg',
+                  '/demo/avatars/3.svg',
                 ]}
               />
             </Hero>
@@ -235,9 +235,9 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 class="mt-[var(--space-stack-lg)]"
                 text="Join thousands of users"
                 avatars={[
-                  'https://i.pravatar.cc/150?img=5',
-                  'https://i.pravatar.cc/150?img=8',
-                  'https://i.pravatar.cc/150?img=11',
+                  '/demo/avatars/4.svg',
+                  '/demo/avatars/5.svg',
+                  '/demo/avatars/6.svg',
                 ]}
               />
             </Hero>
@@ -280,7 +280,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
           <div class="showcase-content">
             <div class="grid gap-4 sm:grid-cols-2 text-sm">
               <div>
-                <h4 class="font-semibold text-foreground mb-2">Props</h4>
+                <h3 class="font-semibold text-foreground mb-2">Props</h3>
                 <ul class="space-y-1 text-foreground-muted">
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">layout</code> centered | split</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">size</code> sm | md | lg | xl</li>
@@ -288,7 +288,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 </ul>
               </div>
               <div>
-                <h4 class="font-semibold text-foreground mb-2">Slots</h4>
+                <h3 class="font-semibold text-foreground mb-2">Slots</h3>
                 <ul class="space-y-1 text-foreground-muted">
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">badge</code> Use Badge component</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">title</code> Use h1/h2 directly</li>
@@ -434,7 +434,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
               <div class="relative overflow-hidden">
                 <div
                   class="absolute inset-0 bg-cover bg-center grayscale brightness-150 opacity-60"
-                  style="background-image: url('https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=1200&h=200&fit=crop&q=80');"
+                  style="background-image: url('/demo/banner-light.svg');"
                 ></div>
                 <div class="absolute inset-0 bg-white/20"></div>
                 <div class="relative">
@@ -456,7 +456,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
               <!-- Transparent on dark (inverted colors) -->
               <div
                 class="relative bg-cover bg-center"
-                style="background-image: url('https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=1200&h=200&fit=crop&q=80');"
+                style="background-image: url('/demo/banner-dark.svg');"
               >
                 <div class="absolute inset-0 bg-black/40"></div>
                 <div class="relative">
@@ -490,7 +490,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
           <div class="showcase-content">
             <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 text-sm">
               <div>
-                <h4 class="font-semibold text-foreground mb-2">Layout & Position</h4>
+                <h3 class="font-semibold text-foreground mb-2">Layout & Position</h3>
                 <ul class="space-y-1 text-foreground-muted">
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">layout</code> default | centered | minimal</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">position</code> fixed | sticky | static</li>
@@ -500,7 +500,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 </ul>
               </div>
               <div>
-                <h4 class="font-semibold text-foreground mb-2">Navigation</h4>
+                <h3 class="font-semibold text-foreground mb-2">Navigation</h3>
                 <ul class="space-y-1 text-foreground-muted">
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">nav</code> NavItem[] (overrides routes)</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">extraNav</code> NavItem[] (adds to routes)</li>
@@ -509,7 +509,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 </ul>
               </div>
               <div>
-                <h4 class="font-semibold text-foreground mb-2">Actions</h4>
+                <h3 class="font-semibold text-foreground mb-2">Actions</h3>
                 <ul class="space-y-1 text-foreground-muted">
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">showCta</code> boolean</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">cta</code> {'{ label, href }'}</li>
@@ -633,7 +633,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
           <div class="showcase-content">
             <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 text-sm">
               <div>
-                <h4 class="font-semibold text-foreground mb-2">Layout</h4>
+                <h3 class="font-semibold text-foreground mb-2">Layout</h3>
                 <ul class="space-y-1 text-foreground-muted">
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">layout</code> simple | columns | minimal | stacked</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">columns</code> 2 | 3 | 4</li>
@@ -641,7 +641,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 </ul>
               </div>
               <div>
-                <h4 class="font-semibold text-foreground mb-2">Content</h4>
+                <h3 class="font-semibold text-foreground mb-2">Content</h3>
                 <ul class="space-y-1 text-foreground-muted">
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">nav</code> NavItem[]</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">linkGroups</code> FooterLinkGroup[]</li>
@@ -650,7 +650,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 </ul>
               </div>
               <div>
-                <h4 class="font-semibold text-foreground mb-2">Copyright & Legal</h4>
+                <h3 class="font-semibold text-foreground mb-2">Copyright & Legal</h3>
                 <ul class="space-y-1 text-foreground-muted">
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">showCopyright</code> boolean</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">copyright</code> string (supports {'{year}'}, {'{siteName}'})</li>
@@ -803,7 +803,9 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 <Button>Default</Button>
                 <Button loading>Loading</Button>
                 <Button disabled>Disabled</Button>
-                <Button icon><Icon name="plus" /></Button>
+                <!-- An icon-only button has no text to name it, so it needs an
+                     aria-label of its own — copy this pattern, not just the icon. -->
+                <Button icon aria-label="Add item"><Icon name="plus" /></Button>
               </div>
             </div>
           </div>
@@ -1281,7 +1283,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
           <div class="showcase-content">
             <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 text-sm">
               <div>
-                <h4 class="font-semibold text-foreground mb-2">Core Props</h4>
+                <h3 class="font-semibold text-foreground mb-2">Core Props</h3>
                 <ul class="space-y-1 text-foreground-muted">
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">tabs</code> Tab[] (required)</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">defaultValue</code> string</li>
@@ -1290,7 +1292,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 </ul>
               </div>
               <div>
-                <h4 class="font-semibold text-foreground mb-2">Tab Interface</h4>
+                <h3 class="font-semibold text-foreground mb-2">Tab Interface</h3>
                 <ul class="space-y-1 text-foreground-muted">
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">id</code> string (required)</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">label</code> string (required)</li>
@@ -1299,7 +1301,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 </ul>
               </div>
               <div>
-                <h4 class="font-semibold text-foreground mb-2">Content Panels</h4>
+                <h3 class="font-semibold text-foreground mb-2">Content Panels</h3>
                 <ul class="space-y-1 text-foreground-muted">
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">data-tab-content</code></li>
                   <li class="text-xs">Match tab id for each panel</li>
@@ -1565,7 +1567,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
               <!-- User Profile Card -->
               <Card>
                 <div class="flex items-center gap-4">
-                  <Avatar size="lg" src="https://i.pravatar.cc/150?img=32" alt="Sarah Chen" />
+                  <Avatar size="lg" src="/demo/avatars/7.svg" alt="Sarah Chen" />
                   <div class="flex-1 min-w-0">
                     <h3 class="text-sm font-semibold text-foreground">Sarah Chen</h3>
                     <p class="text-xs text-foreground-muted">Product Designer</p>
@@ -1631,9 +1633,9 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
               </div>
               <div class="pl-4 border-l border-border">
                 <div class="flex -space-x-3">
-                  <Avatar size="md" src="https://i.pravatar.cc/150?img=12" alt="User 1" class="ring-2 ring-background" />
-                  <Avatar size="md" src="https://i.pravatar.cc/150?img=33" alt="User 2" class="ring-2 ring-background" />
-                  <Avatar size="md" src="https://i.pravatar.cc/150?img=47" alt="User 3" class="ring-2 ring-background" />
+                  <Avatar size="md" src="/demo/avatars/1.svg" alt="User 1" class="ring-2 ring-background" />
+                  <Avatar size="md" src="/demo/avatars/2.svg" alt="User 2" class="ring-2 ring-background" />
+                  <Avatar size="md" src="/demo/avatars/3.svg" alt="User 3" class="ring-2 ring-background" />
                   <div class="w-10 h-10 rounded-full bg-secondary flex items-center justify-center text-xs font-medium ring-2 ring-background">+5</div>
                 </div>
                 <span class="text-xs text-foreground-muted mt-2 block">Stacked</span>
@@ -1753,12 +1755,12 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
               <AvatarGroup
                 max={4}
                 avatars={[
-                  { src: 'https://i.pravatar.cc/150?img=12', alt: 'User 1' },
-                  { src: 'https://i.pravatar.cc/150?img=33', alt: 'User 2' },
-                  { src: 'https://i.pravatar.cc/150?img=47', alt: 'User 3' },
-                  { src: 'https://i.pravatar.cc/150?img=5', alt: 'User 4' },
-                  { src: 'https://i.pravatar.cc/150?img=8', alt: 'User 5' },
-                  { src: 'https://i.pravatar.cc/150?img=11', alt: 'User 6' },
+                  { src: '/demo/avatars/1.svg', alt: 'User 1' },
+                  { src: '/demo/avatars/2.svg', alt: 'User 2' },
+                  { src: '/demo/avatars/3.svg', alt: 'User 3' },
+                  { src: '/demo/avatars/4.svg', alt: 'User 4' },
+                  { src: '/demo/avatars/5.svg', alt: 'User 5' },
+                  { src: '/demo/avatars/6.svg', alt: 'User 6' },
                 ]}
               />
             </div>
@@ -1770,10 +1772,10 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                     size={size}
                     max={3}
                     avatars={[
-                      { src: 'https://i.pravatar.cc/150?img=12', alt: 'User 1' },
-                      { src: 'https://i.pravatar.cc/150?img=33', alt: 'User 2' },
-                      { src: 'https://i.pravatar.cc/150?img=47', alt: 'User 3' },
-                      { src: 'https://i.pravatar.cc/150?img=5', alt: 'User 4' },
+                      { src: '/demo/avatars/1.svg', alt: 'User 1' },
+                      { src: '/demo/avatars/2.svg', alt: 'User 2' },
+                      { src: '/demo/avatars/3.svg', alt: 'User 3' },
+                      { src: '/demo/avatars/4.svg', alt: 'User 4' },
                     ]}
                   />
                 </div>


### PR DESCRIPTION
Lighthouse scored /components 86 on accessibility and 96 on best practices. Four of the five failures are fixed here; three of them were in components rather than on the page, so every site built on the theme carried them.

Progress set role="progressbar" with aria-valuenow and no name at all, so a screen reader announced a bare number with nothing to attach it to — 12 of the 16 violations on the page, and a bug on any site using it. It now takes its name from the visible label when `showLabel` is used, from a new `label` prop otherwise, and falls back to "Progress".

Toast put aria-label on a plain div. ARIA prohibits that: with no role there is nothing for the name to belong to, so the label was discarded. role="region" makes it legal and turns the live area into a landmark.

Alert titled itself with an h5. The alert already carries role="alert", so the title was never needed as a heading, and it inserted a stray level into the outline of any page holding one. It is a div now, same styling, out of the document outline.

On the page itself: 11 h4s that sat directly under an h2 with no h3 between them are h3s now, and the icon-only Button demo has an aria-label, since that demo is what people copy.

Accessibility 86 -> 97. What remains is 7 contrast failures, which need decisions about the colour tokens rather than markup, so they are left alone.

Best practices 96 -> 100, because the page no longer makes third-party requests. It hotlinked six avatars from i.pravatar.cc and two banners from images.unsplash.com, sending every visitor's IP to two other companies on a site that otherwise ships cookieless analytics, and leaving the showcase at the mercy of services that can rate-limit or disappear. scripts/demo-assets.mjs draws local replacements instead: abstract, no faces, no implied real people. The banners went through two rounds — the first pair vanished under the transparent-header demo's own grayscale and brightness filters.

SEO stays at 69 and should: the page sets noindex, and Lighthouse counts that as a failure whatever the intent.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
