### PR TITLE
Shorten the post titles to what search results actually show

### DIFF
--- a/src/content/blog/en/animations-in-astro-rocket.mdx
+++ b/src/content/blog/en/animations-in-astro-rocket.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Animations in Astro Rocket — How the Premium Motion Design Works"
+title: "Animations: How the Motion Design Works"
 description: "Every animation layer in Astro Rocket: the ease-out hero entrance, the staggered scroll-reveal cascade, and how it stays smooth with no JS animation library."
 publishedAt: 2026-04-17
 author: "Hans Martens"

--- a/src/content/blog/en/astro-rocket-configuration-guide.mdx
+++ b/src/content/blog/en/astro-rocket-configuration-guide.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Astro Rocket Configuration — Every Toggle, Theme, and Layout Option Explained"
+title: "Every Configuration Toggle, Theme and Layout"
 description: "A walkthrough of every configuration option: 12 colour themes, OKLCH colours, typography, radius and shadow tokens, header styles, and dark mode."
 publishedAt: 2026-04-18
 author: "Hans Martens"

--- a/src/content/blog/en/astro-rocket-getting-started.mdx
+++ b/src/content/blog/en/astro-rocket-getting-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started with Astro Rocket — From Install to Live in Minutes"
+title: "Getting Started: From Install to Live"
 description: "How to install, configure, and deploy Astro Rocket — covering site.config.ts, brand colours, navigation, writing posts, and deploying to Vercel."
 publishedAt: 2026-04-19
 author: "Hans Martens"

--- a/src/content/blog/en/colour-mode-system.mdx
+++ b/src/content/blog/en/colour-mode-system.mdx
@@ -1,5 +1,5 @@
 ---
-title: "System, Light, Dark — How Astro Rocket's Colour-Mode System Works"
+title: "System, Light, Dark: How Colour Mode Works"
 description: "A 3-state colour mode with no flash, live OS-preference tracking, and a pill dropdown that respects what the user picked. Here is how it is built."
 publishedAt: 2026-05-06
 author: "Hans Martens"

--- a/src/content/blog/en/component-library.mdx
+++ b/src/content/blog/en/component-library.mdx
@@ -1,5 +1,5 @@
 ---
-title: "57 Components Ready to Use — Astro Rocket's Full UI Library"
+title: "57 Components Ready to Use"
 description: "A 57-component UI library: buttons, cards, dialogs, forms, data display, and full page-structure components. All accessible, all themed."
 publishedAt: 2026-04-17
 author: "Hans Martens"

--- a/src/content/blog/en/contact-form-resend-setup.mdx
+++ b/src/content/blog/en/contact-form-resend-setup.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Contact Form Setup: Resend, Vercel, and GoDaddy Step by Step"
+title: "Contact Form Setup: Resend, Vercel, GoDaddy"
 description: "The contact form is wired up but needs three things to deliver email: a Resend account, a verified domain, and one environment variable on Vercel."
 publishedAt: 2026-03-31
 author: "Hans Martens"

--- a/src/content/blog/en/custom-logo-and-site-name.mdx
+++ b/src/content/blog/en/custom-logo-and-site-name.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Make It Yours: Set a Custom Logo and Site Name"
+title: "Set a Custom Logo and Site Name"
 description: "Swap the auto-generated monogram for your own logo, rename your site, and choose a logo-with-wordmark or logo-only header — mostly from one config file."
 publishedAt: 2026-06-09
 author: "Hans Martens"

--- a/src/content/blog/en/design-system-color-tokens.mdx
+++ b/src/content/blog/en/design-system-color-tokens.mdx
@@ -1,5 +1,5 @@
 ---
-title: "How Astro Rocket's Design System Works — Tokens, Colors, and Dark Mode"
+title: "The Design System: Tokens, Colours, Dark Mode"
 description: "Astro Rocket uses a three-tier token architecture with OKLCH colors. Change one value and the entire site updates. Here's how it works and how to make it yours."
 publishedAt: 2026-03-16
 author: "Hans Martens"

--- a/src/content/blog/en/giscus-comments.mdx
+++ b/src/content/blog/en/giscus-comments.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Comments on Blog Posts — Giscus, Cusdis, or Artalk, Lazy-Loaded"
+title: "Blog Comments: Giscus, Cusdis or Artalk"
 description: "Astro Rocket's blog comments are pluggable: pick Giscus, Cusdis, or the fully self-hosted Artalk. All three lazy-load on scroll — skip them and you pay nothing."
 publishedAt: 2026-05-09
 updatedAt: 2026-07-01

--- a/src/content/blog/en/hero-scroll-indicator.mdx
+++ b/src/content/blog/en/hero-scroll-indicator.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Hero Scroll Indicator — Desktop-Only, Hides on Scroll"
+title: "Hero Scroll Indicator: Hides on Scroll"
 description: "Two bouncing chevrons that fade in after the hero animation and disappear the moment you start scrolling. How every part of the indicator works."
 publishedAt: 2026-04-16
 author: "Hans Martens"

--- a/src/content/blog/en/hero-typing-effect.mdx
+++ b/src/content/blog/en/hero-typing-effect.mdx
@@ -1,5 +1,5 @@
 ---
-title: "The Hero Typing Effect in Astro Rocket — How It Works and How to Tune It"
+title: "The Hero Typing Effect: How to Tune It"
 description: "The hero headline cycles through words with a typing animation. How it works, how to tune every speed and pause, and how to turn it off."
 publishedAt: 2026-03-16
 author: "Hans Martens"

--- a/src/content/blog/en/i18n-in-astro-rocket.mdx
+++ b/src/content/blog/en/i18n-in-astro-rocket.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Going Multilingual: Native i18n in Astro Rocket"
+title: "Going Multilingual with Native i18n"
 description: "How the opt-in i18n works: locale routing, the t()/tData() dictionary, an auto-localized blog, projects and pages, and how to ship a multilingual site."
 publishedAt: 2026-05-11
 updatedAt: 2026-07-01

--- a/src/content/blog/en/independent-footer-menu.mdx
+++ b/src/content/blog/en/independent-footer-menu.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Independent Footer Menu — Different Links in Header and Footer"
+title: "A Footer Menu Separate From the Header"
 description: "Configure the footer menu independently of the header navigation: add a Privacy link, an Imprint, or a Cookie Policy without cluttering your main nav."
 publishedAt: 2026-05-09
 author: "Hans Martens"

--- a/src/content/blog/en/letter-glitch-astro-7.mdx
+++ b/src/content/blog/en/letter-glitch-astro-7.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Add a LetterGlitch Effect to Your Astro 7 Site"
+title: "Add a LetterGlitch Effect to Astro 7"
 description: "How to drop a brand-tinted LetterGlitch canvas effect into an Astro 7 project: the full component, an Astro wrapper, and the production-ready details."
 publishedAt: 2026-05-04
 author: "Hans Martens"

--- a/src/content/blog/en/newsletter-signup.mdx
+++ b/src/content/blog/en/newsletter-signup.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Newsletter Signup: Collect Subscribers Straight From Your Blog"
+title: "Newsletter Signup: Collect Subscribers"
 description: "A newsletter signup that posts to a Resend audience. Set two environment variables, flip one switch, and the form appears on your blog index and every post."
 publishedAt: 2026-07-28
 author: "Hans Martens"

--- a/src/content/blog/en/project-gallery-video-slides.mdx
+++ b/src/content/blog/en/project-gallery-video-slides.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Video Slides in Project Galleries — Zero Bytes Until Play"
+title: "Video Slides in Project Galleries"
 description: "Project carousels now accept self-hosted video slides next to images. Here's how to use them, how they work, and why they don't cost a single Lighthouse point."
 publishedAt: 2026-06-12
 author: "Hans Martens"

--- a/src/content/blog/en/scroll-progress-bar.mdx
+++ b/src/content/blog/en/scroll-progress-bar.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Scroll Progress Bar — Reading Progress at a Glance"
+title: "The Scroll Progress Bar"
 description: "A thin brand-coloured line that fills as you scroll. How the progress bar works, where it lives, and how to enable it on any page."
 publishedAt: 2026-03-25
 author: "Hans Martens"

--- a/src/content/blog/en/scroll-progress-ring.mdx
+++ b/src/content/blog/en/scroll-progress-ring.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Scroll Progress Ring — A Circular Indicator on the Back-to-Top Button"
+title: "A Progress Ring on the Back-to-Top Button"
 description: "The back-to-top button has a circular SVG ring that fills as you scroll: brand-coloured, theme-aware, and built from CSS and a small inline script."
 publishedAt: 2026-04-15
 author: "Hans Martens"

--- a/src/content/blog/en/seo-in-astro-rocket.mdx
+++ b/src/content/blog/en/seo-in-astro-rocket.mdx
@@ -1,5 +1,5 @@
 ---
-title: "SEO in Astro Rocket: What's Built In and How to Configure It"
+title: "SEO: What's Built In and How to Configure It"
 description: "Astro Rocket handles structured data, Open Graph, canonical URLs, sitemaps, and more out of the box. Here's exactly what ships and where to configure it."
 publishedAt: 2026-04-17
 author: "Hans Martens"

--- a/src/content/blog/en/stack-marquee.mdx
+++ b/src/content/blog/en/stack-marquee.mdx
@@ -1,5 +1,5 @@
 ---
-title: "The Stack Marquee — A Pure-CSS Infinite Tech Strip"
+title: "The Stack Marquee: A Pure-CSS Tech Strip"
 description: "Two rows of tech-stack cards scrolling opposite ways with no JavaScript. How the homepage marquee loop works, and why it is hidden on phones."
 publishedAt: 2026-06-07
 author: "Hans Martens"

--- a/src/content/blog/en/table-of-contents.mdx
+++ b/src/content/blog/en/table-of-contents.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Table of Contents — Reading Anchors for Long Posts"
+title: "Table of Contents for Long Posts"
 description: "An optional TOC on blog posts in three layouts — inline card, sticky sidebar, or both — with the sidebar on the left or right. Pick what fits your audience."
 publishedAt: 2026-05-09
 author: "Hans Martens"

--- a/src/content/blog/en/umami-analytics.mdx
+++ b/src/content/blog/en/umami-analytics.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Umami Analytics, Built In: Privacy-Friendly, Cookieless Stats"
+title: "Umami Analytics: Cookieless, Built In"
 description: "Umami works out of the box: private, cookieless web analytics. Set one environment variable and you get visitor numbers with no cookie banner."
 publishedAt: 2026-07-25
 author: "Hans Martens"

--- a/src/content/blog/en/updating-astro-rocket.mdx
+++ b/src/content/blog/en/updating-astro-rocket.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Updating Astro Rocket Without Losing Your Content"
+title: "Updating Without Losing Your Content"
 description: "Astro Rocket is installed with git clone, so updating is a git merge rather than an npm install. Here's the safe, reversible way to do it."
 publishedAt: 2026-07-25
 author: "Hans Martens"

--- a/src/content/blog/en/youtube-embeds.mdx
+++ b/src/content/blog/en/youtube-embeds.mdx
@@ -1,5 +1,5 @@
 ---
-title: "YouTube in Your Posts — the Click-to-Play Embed"
+title: "The Click-to-Play YouTube Embed"
 description: "Embed a YouTube video with one component. The page ships only a thumbnail; the player loads from youtube-nocookie.com on play, so Lighthouse stays at 100."
 publishedAt: 2026-07-07
 author: "Hans Martens"


### PR DESCRIPTION
The 24 titles here ran up to 77 characters, and with the site-name suffix the <title> tag reached 92, so Google truncated the end of most of them. The lever in nearly every one was the same: the title repeated "Astro Rocket" on a site where every post is about Astro Rocket, while the <title> tag appends it and og:site_name carries it on social.

Social titles over 60 characters: 11 -> 0.
<title> tags over 60 characters:  25 -> 1.

The one left is /services at 64, which is page copy in the i18n dictionary rather than a post, and its og:title already fits.

Two changes are more than length. The design-system title said "Colors" while the rest of the site says "colour", so it now says Colours. The animations title loses "Premium", which was an empty intensifier and the most expensive word in it.

Slugs come from the filename, not the title, so no URL changes and no redirects. Titles do drive the H1, the card title in listings and the text drawn on the generated share cards, all of which were rebuilt and checked. No two titles collide.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
