### PR TITLE
Separate status colours meant for fills from ones meant for text

### DIFF
--- a/src/components/patterns/ContactForm.astro
+++ b/src/components/patterns/ContactForm.astro
@@ -106,7 +106,7 @@ const {
 
         if (data.success) {
           message.textContent = successMessage;
-          message.className = 'text-sm text-success';
+          message.className = 'text-sm text-success-strong';
           form.reset();
         } else {
           const errors = data.errors

--- a/src/components/patterns/NewsletterForm.astro
+++ b/src/components/patterns/NewsletterForm.astro
@@ -142,8 +142,8 @@ const stacked = layout === 'stacked';
       // className, so the layout classes on the element survive a submit.
       const setMessage = (text: string, ok: boolean) => {
         message.textContent = text;
-        message.classList.remove('text-success', 'text-destructive');
-        message.classList.add(ok ? 'text-success' : 'text-destructive');
+        message.classList.remove('text-success-strong', 'text-destructive');
+        message.classList.add(ok ? 'text-success-strong' : 'text-destructive');
       };
 
       form.addEventListener('submit', async (e) => {

--- a/src/components/patterns/StatCard.astro
+++ b/src/components/patterns/StatCard.astro
@@ -30,8 +30,8 @@ const {
 } = Astro.props;
 
 const trendColors = {
-  up: 'text-[var(--success)]',
-  down: 'text-[var(--error)]',
+  up: 'text-[var(--success-strong)]',
+  down: 'text-[var(--error-strong)]',
   neutral: 'text-foreground-muted',
 };
 

--- a/src/components/ui/content/CodeBlock/CodeBlock.astro
+++ b/src/components/ui/content/CodeBlock/CodeBlock.astro
@@ -45,7 +45,7 @@ const codeId = `code-${Math.random().toString(36).slice(2, 9)}`;
         <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
         <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
       </svg>
-      <svg class="check-icon hidden h-3 w-3 text-success" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg class="check-icon hidden h-3 w-3 text-success-strong" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="20 6 9 17 4 12"></polyline>
       </svg>
       <span class="copy-text">Copy</span>

--- a/src/components/ui/feedback/Alert/alert.variants.ts
+++ b/src/components/ui/feedback/Alert/alert.variants.ts
@@ -19,9 +19,9 @@ export const alertVariants = cva(
 
 export const alertIconColors = {
   info: 'text-foreground-muted',
-  success: 'text-[var(--success)]',
-  warning: 'text-[var(--warning)]',
-  error: 'text-[var(--error)]',
+  success: 'text-[var(--success-strong)]',
+  warning: 'text-[var(--warning-strong)]',
+  error: 'text-[var(--error-strong)]',
 } as const;
 
 export const alertAccentColors = {

--- a/src/components/ui/feedback/Toast/ToastDemo.tsx
+++ b/src/components/ui/feedback/Toast/ToastDemo.tsx
@@ -19,7 +19,7 @@ function ToastButtons() {
       </button>
       <button
         type="button"
-        className="inline-flex items-center justify-center gap-2 rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700"
+        className="inline-flex items-center justify-center gap-2 rounded-md bg-green-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-800"
         onClick={() =>
           toast({
             variant: 'success',
@@ -45,7 +45,7 @@ function ToastButtons() {
       </button>
       <button
         type="button"
-        className="inline-flex items-center justify-center gap-2 rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-600"
+        className="inline-flex items-center justify-center gap-2 rounded-md bg-amber-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-amber-800"
         onClick={() =>
           toast({
             variant: 'warning',

--- a/src/components/ui/feedback/Toast/toast.variants.ts
+++ b/src/components/ui/feedback/Toast/toast.variants.ts
@@ -23,10 +23,10 @@ export const toastVariants = cva(
 
 export const toastIconColors = {
   default: 'text-foreground-muted',
-  success: 'text-[var(--success)]',
-  error: 'text-[var(--error)]',
-  warning: 'text-[var(--warning)]',
-  info: 'text-[var(--info)]',
+  success: 'text-[var(--success-strong)]',
+  error: 'text-[var(--error-strong)]',
+  warning: 'text-[var(--warning-strong)]',
+  info: 'text-[var(--info-strong)]',
 } as const;
 
 export type ToastVariants = VariantProps<typeof toastVariants>;

--- a/src/components/ui/marketing/NpmCopyButton/NpmCopyButton.astro
+++ b/src/components/ui/marketing/NpmCopyButton/NpmCopyButton.astro
@@ -46,7 +46,7 @@ const sizes = {
   <span data-copy-icon class="ml-1 text-secondary">
     <Icon name="copy" size="sm" />
   </span>
-  <span data-check-icon class="ml-1 hidden text-success">
+  <span data-check-icon class="ml-1 hidden text-success-strong">
     <Icon name="check" size="sm" />
   </span>
 </button>

--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -1557,7 +1557,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
                 <div class="text-center">
                   <p class="text-xs font-medium text-foreground-subtle uppercase tracking-wider">Total Revenue</p>
                   <p class="text-3xl font-bold text-foreground mt-1">$45,231</p>
-                  <p class="text-xs text-success mt-2 flex items-center justify-center gap-1">
+                  <p class="text-xs text-success-strong mt-2 flex items-center justify-center gap-1">
                     <Icon name="arrow-right" size="xs" class="rotate-[-45deg]" />
                     +12.5% from last month
                   </p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -86,6 +86,13 @@
   --color-warning: var(--warning);
   --color-error: var(--error);
 
+  /* Higher-contrast variants for status colour used as text or as an icon on
+     the page background. See the note in tokens/primitives.css. */
+  --color-success-strong: var(--success-strong);
+  --color-warning-strong: var(--warning-strong);
+  --color-error-strong: var(--error-strong);
+  --color-info-strong: var(--info-strong);
+
   /* Inverted/Contrast Sections */
   --color-surface-invert: var(--surface-invert);
   --color-surface-invert-secondary: var(--surface-invert-secondary);
@@ -1308,6 +1315,20 @@
 .cta-btn-brand:hover {
   background-color: var(--color-brand-800) !important;
   background-image: none !important;
+}
+
+/* Primary button inside an inverted section.
+   The primary variant is `bg-foreground text-background`, but the Button's own
+   light-mode style wins the cascade for background-color and fills with
+   brand-700 (see the note on .hero-dark-gradient .btn-primary above). The
+   label kept following `text-background`, which .invert-section redefines all
+   the way down to the near-black inverted surface — so the button rendered as
+   near-black on brand blue, 3.9:1. White is what a brand-700 fill was built
+   for: 5.3:1 on the blue theme, and AA on every other, exactly as for
+   .hero-btn-brand and .cta-btn-brand above. !important to match them, since
+   the utility it overrides is applied by the same variant. */
+.invert-section .btn-primary {
+  color: white !important;
 }
 
 /* Header CTA — brand colour in light mode (brand-700 for AA white text) */

--- a/src/styles/tokens/primitives.css
+++ b/src/styles/tokens/primitives.css
@@ -55,4 +55,48 @@
   --info: oklch(59.5% 0.19 260);
   --info-light: oklch(94% 0.05 260);
   --info-foreground: oklch(40% 0.15 260); /* WCAG AA compliant on info-light */
+
+  /* -------------------------------------------------------------------------
+     Status text/icon colors, for status colour placed directly on the page
+     background rather than on its own tint.
+
+     The four base tokens above are fills. On a white background none of them
+     is legible as text (success 2.3:1, warning 1.9:1, error 3.9:1, info
+     4.1:1 — AA wants 4.5:1), and success and warning miss even the 3:1 that
+     WCAG asks of icons and other non-text.
+
+     The `-foreground` tokens are not the answer either: they are built for
+     the pale `-light` tints and drop to about 2:1 on a dark surface. So these
+     carry a light-mode and a dark-mode value, and land near 6:1 in both.
+
+     Fills, badges, borders and progress bars keep using the base tokens and
+     are unaffected.
+     ------------------------------------------------------------------------- */
+  --success-strong: oklch(48% 0.15 145); /* 6.1:1 on white */
+  --warning-strong: oklch(47% 0.12 85);  /* 6.9:1 on white */
+  --error-strong: oklch(50% 0.20 25);    /* 6.7:1 on white */
+  --info-strong: oklch(48% 0.17 260);    /* 6.7:1 on white */
+}
+
+html.dark {
+  /* Same roles, inverted: light enough to read on a dark surface. */
+  --success-strong: oklch(80% 0.16 145); /* 11.1:1 on the dark card */
+  --warning-strong: oklch(85% 0.15 85);  /* 12.3:1 */
+  --error-strong: oklch(74% 0.16 25);    /*  7.9:1 */
+  --info-strong: oklch(78% 0.13 260);    /*  9.6:1 */
+
+  /* The `-light` tints flip to near-black in dark mode (18% lightness), but
+     the `-foreground` text meant to sit on them did not, so a Badge rendered
+     dark-on-dark: success came out at 1.8:1, the others near 2:1. In dark mode
+     the `-strong` colour is already the readable version of each hue, so it
+     serves here too — 7.7:1 to 11.8:1 on the matching tint. */
+  --success-foreground: var(--success-strong);
+  --warning-foreground: var(--warning-strong);
+  --error-foreground: var(--error-strong);
+
+  /* --info-foreground deliberately stays as it is. The themes give
+     --success-light, --warning-light and --error-light a dark variant but
+     never --info-light, so the info tint is still near-white here and its
+     text has to stay dark. Flipping it put light text on a light chip at
+     1.7:1. The odd one out is --info-light, not this. */
 }


### PR DESCRIPTION
primitives.css documents --success/--warning/--error/--info as "base colors for icons, borders, indicators", and global.css then hands them to Tailwind's text-* utilities. On a white background none of them is legible: success 2.3:1, warning 1.9:1, error 3.9:1, info 4.1:1 against the 4.5:1 AA needs. Success and warning miss even the 3:1 WCAG asks of icons, so they failed in their documented role too.

The -foreground tokens could not stand in: they are built for the pale -light tints and fall to about 2:1 on a dark surface. So this adds --success-strong and friends, carrying a light-mode and a dark-mode value and landing near 6:1 in light and 8-12:1 in dark.

The four fill tokens are untouched, so badges, borders, accent bars and progress fills look exactly as before. Repointed at the readable variants: Alert and Toast icons (both sit on bg-card, not on the tint), StatCard trend figures, the contact and newsletter confirmation messages, and the two copy-to-clipboard check marks.

Two more contrast bugs turned up while checking the fix, both older than it:

Badges were dark-on-dark in dark mode, worst at 1.8:1. The themes give --success-light, --warning-light and --error-light a dark variant, but --success-foreground and the rest never got one, so the text stayed dark after its background went black. In dark mode they now follow -strong. --info-foreground is left alone on purpose: --info-light is the one tint with no dark variant, so its text has to stay dark. That asymmetry is still there to decide on.

The primary button inside .invert-section rendered near-black on brand blue, 3.9:1. The Button's own light-mode style wins the cascade and fills with brand-700, while the label followed text-background, which .invert-section redefines down to the inverted surface. White is what a brand-700 fill was built for, matching .hero-btn-brand.

Also darkened two demo buttons in ToastDemo that put white text on green-600 (3.2:1) and amber-500 (2.1:1).

Verified with axe-core over /, /contact and /components in both colour modes, since Lighthouse only ever tests one. /components accessibility
100. Nine dark-mode failures remain, all one token: --foreground-subtle at 4.21:1 on dark surfaces, which is helper text across the whole site rather than anything here.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
