### PR TITLE
Darken the brand badge one step so it holds AA on its own tint

### DIFF
--- a/src/components/ui/data-display/Badge/badge.variants.ts
+++ b/src/components/ui/data-display/Badge/badge.variants.ts
@@ -18,7 +18,7 @@ export const badgeVariants = cva(
           'bg-[var(--error-light)] text-[var(--error-foreground)] border-[var(--error)]/20',
         info: 'bg-[var(--info-light)] text-[var(--info-foreground)] border-[var(--info)]/20',
         brand:
-          'bg-brand-500/10 text-brand-600 border-brand-500/20 dark:text-brand-400',
+          'bg-brand-500/10 text-brand-700 border-brand-500/20 dark:text-brand-400',
       },
       size: {
         sm: 'text-[10px] px-2 py-0.5 gap-1',


### PR DESCRIPTION
The brand Badge is text-brand-600 on bg-brand-500/10, which comes out at 4.31:1 — blue on pale blue, just under the 4.5:1 AA asks. brand-700 on the same tint gives 6.10:1. Dark mode already used brand-400 and does not change.

Found on hansmartens.dev's /about page, which uses this component; it applies anywhere a brand badge sits on a light background.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
