### PR TITLE
Fix the two dark-mode contrast gaps left over from the token work

### DIFF
--- a/src/styles/themes/amber.css
+++ b/src/styles/themes/amber.css
@@ -145,7 +145,7 @@ html.dark[data-theme="amber"] {
   --foreground: oklch(94% 0.010 75);           /* warm near-white */
   --foreground-secondary: oklch(82% 0.012 75);
   --foreground-muted: oklch(68% 0.010 75);
-  --foreground-subtle: oklch(58% 0.008 75);    /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.008 75);    /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.012 75);
   --border-strong: oklch(27% 0.010 75);

--- a/src/styles/themes/blue.css
+++ b/src/styles/themes/blue.css
@@ -144,7 +144,7 @@ html.dark[data-theme="blue"] {
   --foreground: oklch(91% 0.008 255);          /* cool near-white — 15:1 on dark bg, WCAG AAA */
   --foreground-secondary: oklch(82% 0.012 255);
   --foreground-muted: oklch(68% 0.01 255);
-  --foreground-subtle: oklch(58% 0.008 255);   /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.008 255);   /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.012 255);
   --border-strong: oklch(28% 0.01 255);

--- a/src/styles/themes/cyan.css
+++ b/src/styles/themes/cyan.css
@@ -136,7 +136,7 @@ html.dark[data-theme="cyan"] {
   --foreground: oklch(94% 0.008 200);
   --foreground-secondary: oklch(82% 0.010 200);
   --foreground-muted: oklch(68% 0.008 200);
-  --foreground-subtle: oklch(58% 0.006 200);   /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.006 200);   /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.010 200);
   --border-strong: oklch(27% 0.008 200);

--- a/src/styles/themes/emerald.css
+++ b/src/styles/themes/emerald.css
@@ -143,7 +143,7 @@ html.dark[data-theme="emerald"] {
   --foreground: oklch(91% 0.008 160);          /* emerald-tinted near-white — 15:1 on dark bg, WCAG AAA */
   --foreground-secondary: oklch(82% 0.01 160);
   --foreground-muted: oklch(68% 0.008 160);
-  --foreground-subtle: oklch(58% 0.006 160);   /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.006 160);   /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.01 160);
   --border-strong: oklch(27% 0.008 160);

--- a/src/styles/themes/green.css
+++ b/src/styles/themes/green.css
@@ -143,7 +143,7 @@ html.dark[data-theme="green"] {
   --foreground: oklch(94% 0.008 155);          /* cool near-white — WCAG AAA */
   --foreground-secondary: oklch(82% 0.01 155);
   --foreground-muted: oklch(68% 0.008 155);
-  --foreground-subtle: oklch(58% 0.006 155);   /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.006 155);   /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.01 155);
   --border-strong: oklch(27% 0.008 155);

--- a/src/styles/themes/indigo.css
+++ b/src/styles/themes/indigo.css
@@ -137,7 +137,7 @@ html.dark[data-theme="indigo"] {
   --foreground: oklch(94% 0.010 264);
   --foreground-secondary: oklch(82% 0.012 264);
   --foreground-muted: oklch(68% 0.010 264);
-  --foreground-subtle: oklch(58% 0.008 264);   /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.008 264);   /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.012 264);
   --border-strong: oklch(27% 0.010 264);

--- a/src/styles/themes/lime.css
+++ b/src/styles/themes/lime.css
@@ -145,7 +145,7 @@ html.dark[data-theme="lime"] {
   --foreground: oklch(91% 0.010 130);          /* lime-tinted near-white — 15:1 on dark bg, WCAG AAA */
   --foreground-secondary: oklch(82% 0.012 130);
   --foreground-muted: oklch(68% 0.010 130);
-  --foreground-subtle: oklch(58% 0.008 130);   /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.008 130);   /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.012 130);
   --border-strong: oklch(27% 0.010 130);

--- a/src/styles/themes/magenta.css
+++ b/src/styles/themes/magenta.css
@@ -144,7 +144,7 @@ html.dark[data-theme="magenta"] {
   --foreground: oklch(94% 0.008 330);          /* magenta-tinted near-white */
   --foreground-secondary: oklch(82% 0.01 330);
   --foreground-muted: oklch(68% 0.008 330);
-  --foreground-subtle: oklch(58% 0.006 330);   /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.006 330);   /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.01 330);
   --border-strong: oklch(27% 0.008 330);

--- a/src/styles/themes/orange.css
+++ b/src/styles/themes/orange.css
@@ -133,7 +133,7 @@ html.dark[data-theme="orange"] {
   --foreground: oklch(91% 0.008 38);           /* warm near-white — 15:1 on dark bg, WCAG AAA */
   --foreground-secondary: oklch(82% 0.008 38);
   --foreground-muted: oklch(68% 0.006 38);
-  --foreground-subtle: oklch(58% 0.005 38);    /*  ~4.6:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.005 38);    /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(22% 0.006 38);
   --border-strong: oklch(28% 0.005 38);

--- a/src/styles/themes/purple.css
+++ b/src/styles/themes/purple.css
@@ -143,7 +143,7 @@ html.dark[data-theme="purple"] {
   --foreground: oklch(91% 0.010 292);          /* purple-tinted near-white — 15:1 on dark bg, WCAG AAA */
   --foreground-secondary: oklch(83% 0.015 292);
   --foreground-muted: oklch(68% 0.012 292);
-  --foreground-subtle: oklch(58% 0.009 292);   /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.009 292);   /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.016 292);
   --border-strong: oklch(27% 0.013 292);

--- a/src/styles/themes/sky.css
+++ b/src/styles/themes/sky.css
@@ -137,7 +137,7 @@ html.dark[data-theme="sky"] {
   --foreground: oklch(91% 0.008 222);          /* sky-tinted near-white — 15:1 on dark bg, WCAG AAA */
   --foreground-secondary: oklch(82% 0.010 222);
   --foreground-muted: oklch(68% 0.008 222);
-  --foreground-subtle: oklch(58% 0.006 222);   /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.006 222);   /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.010 222);
   --border-strong: oklch(27% 0.008 222);

--- a/src/styles/themes/teal.css
+++ b/src/styles/themes/teal.css
@@ -144,7 +144,7 @@ html.dark[data-theme="teal"] {
   --foreground: oklch(91% 0.008 190);          /* teal-tinted near-white — 15:1 on dark bg, WCAG AAA */
   --foreground-secondary: oklch(82% 0.01 190);
   --foreground-muted: oklch(68% 0.008 190);
-  --foreground-subtle: oklch(58% 0.006 190);   /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.006 190);   /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.01 190);
   --border-strong: oklch(27% 0.008 190);

--- a/src/styles/themes/violet.css
+++ b/src/styles/themes/violet.css
@@ -137,7 +137,7 @@ html.dark[data-theme="violet"] {
   --foreground: oklch(95% 0.010 277);
   --foreground-secondary: oklch(83% 0.013 277);
   --foreground-muted: oklch(68% 0.010 277);
-  --foreground-subtle: oklch(58% 0.008 277);   /*  ~4.8:1 on bg — WCAG AA  */
+  --foreground-subtle: oklch(62% 0.008 277);   /*  4.9:1 on --secondary, the lightest dark surface — WCAG AA  */
 
   --border: oklch(20% 0.014 277);
   --border-strong: oklch(27% 0.011 277);

--- a/src/styles/tokens/primitives.css
+++ b/src/styles/tokens/primitives.css
@@ -89,14 +89,15 @@ html.dark {
      the `-foreground` text meant to sit on them did not, so a Badge rendered
      dark-on-dark: success came out at 1.8:1, the others near 2:1. In dark mode
      the `-strong` colour is already the readable version of each hue, so it
-     serves here too — 7.7:1 to 11.8:1 on the matching tint. */
+     serves here too — 7.7:1 to 11.8:1 on the matching tint.
+
+     --info-light gets its dark variant here rather than in the theme files,
+     because unlike the other three it is only ever defined in this file. It
+     was the reason an info Badge stayed a pale chip in dark mode while the
+     other three went dark. */
+  --info-light: oklch(18% 0.05 260);
   --success-foreground: var(--success-strong);
   --warning-foreground: var(--warning-strong);
   --error-foreground: var(--error-strong);
-
-  /* --info-foreground deliberately stays as it is. The themes give
-     --success-light, --warning-light and --error-light a dark variant but
-     never --info-light, so the info tint is still near-white here and its
-     text has to stay dark. Flipping it put light text on a light chip at
-     1.7:1. The odd one out is --info-light, not this. */
+  --info-foreground: var(--info-strong); /* 9.2:1 on the tint above */
 }


### PR DESCRIPTION
--foreground-subtle carries a comment saying it clears WCAG AA, and it does — on --background, which is what it was measured against. It is used on the raised surfaces too, and those are lighter: 4.56:1 on --card and 4.18:1 on --secondary/--muted, where it fails. 53 usages across 22 files, all of it helper text, field hints, descriptions and labels.

Raising the dark value from 58% to 62% gives 4.92:1 on --secondary, the lightest of the three, and more on the other two. A four-point lightness step on a grey is not visible, and it stays far below --foreground at 91%, so subtle text still reads as subtle. Same edit in all 13 themes.

--info-light never got the dark variant the other three status tints have, because unlike them it is only defined in primitives.css and the theme files never mention it. That is why an info Badge stayed a pale chip in dark mode while success, warning and error went dark. It gets one here, and --info-foreground can now follow -strong like the others: 9.2:1.

This clears the last nine dark-mode failures on /components. axe-core over /, /contact and /components is clean in both colour modes, and Lighthouse reports 100/100/100 on all three, with /components on 69 for SEO as it should be while the page is noindex.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
