### PR TITLE
Say how to stop counting your own visits

### DIFF
--- a/src/content/blog/en/umami-analytics.mdx
+++ b/src/content/blog/en/umami-analytics.mdx
@@ -111,6 +111,24 @@ Check that request, not just the `script.js` one. The script loads successfully 
 
 With a 200, open the **Realtime** view in Umami and you should see yourself within a few seconds.
 
+### Step 6 — Stop counting yourself
+
+On a site with modest traffic your own visits will outnumber everyone else's, and the numbers stop meaning anything. Umami's tracker checks localStorage for a flag and skips sending when it finds one. On your live site, open the developer tools **Console** and run:
+
+```js
+localStorage.setItem('umami.disabled', 1)
+```
+
+Reload and check the Network tab again: there should now be no request to `/api/send` at all. To start counting yourself again:
+
+```js
+localStorage.removeItem('umami.disabled')
+```
+
+This is stored per browser profile, per device and per site, so repeat it on your phone and in any other browser you use, and expect to redo it if you clear the site's data. It also means the flag you set on one of your sites does nothing on another.
+
+Blocking the script host in an ad blocker works too and follows you between profiles — but then you can never check that tracking still works, which is how a broken setup goes unnoticed for months.
+
 ## Troubleshooting
 
 | Problem | Likely cause |
@@ -121,7 +139,7 @@ With a 200, open the **Realtime** view in Umami and you should see yourself with
 | Still nothing after a redeploy | Double-check the Website ID is exactly the UUID from your dashboard, with no extra spaces. |
 | Works locally but not in production | The variable was added to `.env` but not to Vercel's environment variables (or only to Preview, not Production). |
 | Self-hosted instance shows no hits | `PUBLIC_UMAMI_SRC` is missing or points at the wrong URL — it must be your instance's `script.js`. |
-| Your own visits inflate the numbers | Umami Cloud can exclude your own traffic; you can also use its built-in filters. This is expected, not a bug. |
+| Your own visits inflate the numbers | Expected on a new site, and worth switching off — see below. |
 
 ## That's the whole setup
 


### PR DESCRIPTION
The troubleshooting table said Umami Cloud "can exclude your own traffic" without saying how, which is no help to the person reading it — and I am not certain the Cloud dashboard offers it at all.

Replaced with the method that does work everywhere: the `umami.disabled` flag in localStorage, as a step of its own after verification, with the line to undo it and the caveats that matter — per browser, per device, per site, and lost when site data is cleared.

Also notes why blocking the script in an ad blocker is a worse answer: it follows you between profiles, but it removes any way to check the tracking still works, which is how a broken setup survives months unnoticed.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
