### PR TITLE
Find the component counts the first sweep missed

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
 ## Overview
 
-Astro Rocket is a **free, lightning-fast Astro 7 starter theme to build anything on**. Its heart is a complete component library: 57 designed, accessible, TypeScript components that all speak one design language — so whatever you build with them looks right. Around that library it brings everything a real website needs: pages to start from, a full blog, search, SEO, i18n, dark mode, and 12 colour themes. It's made for web designers, developers, bloggers, and anyone who wants to build a beautiful website without starting from zero. Use all of it or only the parts you need — the website you build on it is yours.
+Astro Rocket is a **free, lightning-fast Astro 7 starter theme to build anything on**. Its heart is a complete component library: 44 designed, accessible, TypeScript components that all speak one design language — so whatever you build with them looks right. Around that library it brings everything a real website needs: pages to start from, a full blog, search, SEO, i18n, dark mode, and 12 colour themes. It's made for web designers, developers, bloggers, and anyone who wants to build a beautiful website without starting from zero. Use all of it or only the parts you need — the website you build on it is yours.
 
 Built on Astro 7 and Tailwind CSS v4.
 
@@ -254,7 +254,7 @@ astro-rocket/
 ├── src/
 │   ├── assets/              # Images and icons (processed by Astro)
 │   ├── components/
-│   │   ├── ui/              # UI component library (31 components)
+│   │   ├── ui/              # UI component library (34 components)
 │   │   │   ├── form/        # Button, Input, Textarea, Select, Checkbox, Radio, Switch
 │   │   │   ├── data-display/ # Card, Badge, Avatar, Table, Pagination, Progress, Skeleton
 │   │   │   ├── feedback/    # Alert, Toast, Tooltip
@@ -541,7 +541,7 @@ Foreground tokens are documented with their contrast ratios inline. When customi
 
 ## Components
 
-Astro Rocket includes 57 components across 7 categories. All UI components use [class-variance-authority (CVA)](https://cva.style) for type-safe variant management.
+Astro Rocket includes 44 components across four categories. All UI components use [class-variance-authority (CVA)](https://cva.style) for type-safe variant management.
 
 ### UI Components (31)
 

--- a/src/__tests__/component-count.test.ts
+++ b/src/__tests__/component-count.test.ts
@@ -11,7 +11,7 @@
  * without the copy following, so the claim cannot drift again.
  */
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import registry from '../../component-registry.json';
@@ -39,11 +39,48 @@ describe('component count', () => {
   });
 
   it('the English dictionary quotes it', () => {
-    const json = JSON.stringify(en);
-    expect(json).toContain(`${COUNT} designed components`);
-    // Nothing should still be carrying the old figure.
-    expect(json).not.toMatch(/\b57\+? (designed )?[Cc]omponents/);
-    expect(json).not.toMatch(/\b50\+ production components/);
+    expect(JSON.stringify(en)).toContain(`${COUNT} designed components`);
+  });
+
+  it('no file anywhere quotes a count the registry cannot justify', () => {
+    // Named files are not enough. The first sweep listed the files it thought
+    // mattered and missed the Dutch dictionary, a homepage stat tile, the
+    // project page, the post body, two README paragraphs, and the number
+    // drawn on the post's cover image. So walk the tree instead.
+    //
+    // Any two-digit figure next to the word component has to be either the
+    // total or one of the per-category counts — both taken from the registry,
+    // so this keeps working when components are added.
+    const byCategory: Record<string, number> = {};
+    for (const entry of Object.values(registry.components)) {
+      byCategory[entry.category] = (byCategory[entry.category] ?? 0) + 1;
+    }
+    const allowed = new Set<number>([COUNT, ...Object.values(byCategory)]);
+
+    const roots = ['src', 'README.md', 'AGENTS.md'];
+    const skip = /node_modules|\/dist\/|\.vercel|__tests__|CHANGELOG/;
+    const exts = /\.(md|mdx|astro|ts|tsx|json|svg)$/;
+
+    const files: string[] = [];
+    const walk = (rel: string) => {
+      const full = join(process.cwd(), rel);
+      if (skip.test(full)) return;
+      if (statSync(full).isDirectory()) {
+        for (const e of readdirSync(full)) walk(join(rel, e));
+      } else if (exts.test(rel)) files.push(rel);
+    };
+    for (const r of roots) walk(r);
+
+    const claim =
+      /\b(\d{2})\+?[\s-]+(?:designed,?\s+|production-ready\s+|ontworpen\s+|)(?:accessible,?\s+|)(?:UI\s+|)[Cc]omponent/g;
+
+    const wrong: string[] = [];
+    for (const f of files) {
+      for (const m of readFileSync(join(process.cwd(), f), 'utf8').matchAll(claim)) {
+        if (!allowed.has(Number(m[1]))) wrong.push(`${f}: "${m[0].trim()}"`);
+      }
+    }
+    expect(wrong, `not a total (${COUNT}) or a category count`).toEqual([]);
   });
 
   it('the showcase page and its post quote it', () => {

--- a/src/assets/blog/component-library.svg
+++ b/src/assets/blog/component-library.svg
@@ -10,8 +10,8 @@
     .num { fill: var(--brand-50); font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif; font-weight: 800; fill-opacity: 0.18; }
   </style>
   <rect width="1200" height="630" class="bg"/>
-  <!-- Large faint "57" in background -->
-  <text x="600" y="435" font-size="340" text-anchor="middle" letter-spacing="-8" class="num">57</text>
+  <!-- Large faint "44" in background -->
+  <text x="600" y="435" font-size="340" text-anchor="middle" letter-spacing="-8" class="num">44</text>
   <!-- Lucide layout-dashboard icon: 4 panels of different sizes, scale=5, centered at (600,255) -->
   <g transform="translate(540, 195) scale(5)" class="ico" opacity="0.9">
     <rect width="7" height="9" x="3" y="3" rx="1"/>

--- a/src/components/landing/Credibility.astro
+++ b/src/components/landing/Credibility.astro
@@ -9,7 +9,7 @@ const steps = [
 
 const stats = [
   { value: '3', label: 'steps to start' },
-  { value: '57+', label: 'components included' },
+  { value: '44', label: 'components included' },
   { value: '40+', label: 'pages & layouts' },
 ];
 ---

--- a/src/content/blog/en/component-library.mdx
+++ b/src/content/blog/en/component-library.mdx
@@ -1,6 +1,6 @@
 ---
 title: "44 Components Ready to Use"
-description: "A 57-component UI library: buttons, cards, dialogs, forms, data display, and full page-structure components. All accessible, all themed."
+description: "A 44-component UI library: buttons, cards, dialogs, forms, data display, and full page-structure components. All accessible, all themed."
 publishedAt: 2026-04-17
 author: "Hans Martens"
 tags: ["astro-rocket", "components", "ui", "velocity"]
@@ -8,13 +8,13 @@ featured: false
 locale: en
 image: "../../../assets/blog/component-library.svg"
 svgSlug: "component-library"
-imageAlt: "Dashboard layout icon above the word 'components' with a large faint '57' in the background"
+imageAlt: "Dashboard layout icon above the word 'components' with a large faint '44' in the background"
 ---
 
 import Button from '@/components/ui/form/Button/Button.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 
-Astro Rocket ships with a complete UI component library — 57 production-ready components available the moment you install the theme, no npm packages to install, no extra setup. The library's foundations came from [Velocity](https://github.com/southwellmedia/velocity) by Southwell Media, the theme Astro Rocket was originally forked from, and it has been extended and reworked since. Every component is already styled with the design system's color tokens, so they adapt automatically when you switch themes or toggle dark mode.
+Astro Rocket ships with a complete UI component library — 44 production-ready components available the moment you install the theme, no npm packages to install, no extra setup. The library's foundations came from [Velocity](https://github.com/southwellmedia/velocity) by Southwell Media, the theme Astro Rocket was originally forked from, and it has been extended and reworked since. Every component is already styled with the design system's color tokens, so they adapt automatically when you switch themes or toggle dark mode.
 
 <div class="my-8">
   <Button href="/components" class="!bg-brand-500 ![background-image:none] !text-white dark:!border-transparent hover:!bg-brand-600"><Icon name="component" />See every component live<Icon name="arrow-right" /></Button>
@@ -26,7 +26,7 @@ The library is organized in three layers: 33 UI primitives that form the buildin
 
 ## UI primitives
 
-These 33 components cover every common UI need. They accept variants and sizes through props and are built with accessibility in mind — keyboard navigation, ARIA attributes, and focus management are handled for you.
+These 34 components cover every common UI need. They accept variants and sizes through props and are built with accessibility in mind — keyboard navigation, ARIA attributes, and focus management are handled for you.
 
 ### Form (7 components)
 
@@ -285,8 +285,8 @@ import { Counter } from '@/components/ui';
 
 ## Browse the live demo
 
-The fastest way to get a feel for all 57 components is the live component demo. Every component is rendered with live props you can inspect:
+The fastest way to get a feel for all 44 components is the live component demo. Every component is rendered with live props you can inspect:
 
 **[/components](/components)**
 
-This showcase is built into Astro Rocket itself. All 57 components are rendered there — same markup, same variants, same props you will use in your own project.
+This showcase is built into Astro Rocket itself. All 44 components are rendered there — same markup, same variants, same props you will use in your own project.

--- a/src/content/projects/en/astro-rocket.mdx
+++ b/src/content/projects/en/astro-rocket.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Astro Rocket Theme"
 locale: en
-description: "My free, open-source Astro 7 starter theme to build anything on: 57 designed components, 12 colour themes, and 100/100/100/100 Lighthouse out of the box."
+description: "My free, open-source Astro 7 starter theme to build anything on: 44 designed components, 12 colour themes, and 100/100/100/100 Lighthouse out of the box."
 url: "https://astrorocket.dev"
 repo: "https://github.com/hansmartensdev/Astro-Rocket"
 tags: ["Astro", "TypeScript", "Tailwind CSS", "Open Source"]
@@ -20,7 +20,7 @@ import LighthouseScoresGrid from '@/components/landing/LighthouseScoresGrid.astr
 
 ## What it is
 
-**Astro Rocket** is my own free, open-source theme, built on **Astro 7** and **Tailwind CSS v4**. It isn't a boilerplate you spend a week wiring up — it's a complete foundation built around a component library: **57 designed, accessible components** that all speak one design language, so whatever you build with them looks right.
+**Astro Rocket** is my own free, open-source theme, built on **Astro 7** and **Tailwind CSS v4**. It isn't a boilerplate you spend a week wiring up — it's a complete foundation built around a component library: **44 designed, accessible components** that all speak one design language, so whatever you build with them looks right.
 
 I made it for the people I know best: designers, freelancers, and developers who want to build a beautiful website without starting from zero. It's MIT-licensed, [up on GitHub](https://github.com/hansmartensdev/Astro-Rocket), and listed on the [official Astro themes directory](https://astro.build/themes/details/astro-rocket/). The full thing runs live at [astrorocket.dev](https://astrorocket.dev).
 
@@ -53,7 +53,7 @@ The heroes are the part I'm happiest with, and they behave differently depending
 
 ## What's in the box
 
-The heart of the project is the **component library — 57 components** (33 UI, plus blog, landing, layout, pattern, and SEO pieces), every one typed with TypeScript, dark-mode aware, and built on a three-tier design-token system. Around that, the things a real portfolio or marketing site needs are already wired up:
+The heart of the project is the **component library — 44 components** (34 UI, plus patterns, layout and hero pieces), every one typed with TypeScript, dark-mode aware, and built on a three-tier design-token system. Around that, the things a real portfolio or marketing site needs are already wired up:
 
 - A full **MDX blog** with tags, RSS, an optional [table of contents](/blog/table-of-contents), and optional [comments](/blog/giscus-comments) via Giscus or Cusdis
 - The complete **SEO layer** — JSON-LD, sitemap, robots, Open Graph, and a ready-made social image

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -193,12 +193,12 @@
     "about": {
       "meta": {
         "title": "Over — Gratis open-source Astro 7 thema",
-        "description": "Wat Astro Rocket is en hoe het gebouwd is: een gratis, razendsnel Astro 7 starter-thema met 57 ontworpen componenten, 12 kleurthema's, ingebouwde i18n en donkere modus."
+        "description": "Wat Astro Rocket is en hoe het gebouwd is: een gratis, razendsnel Astro 7 starter-thema met 44 ontworpen componenten, 12 kleurthema's, ingebouwde i18n en donkere modus."
       },
       "hero": {
         "badge": "Over",
         "titleLead": "Astro Rocket —",
-        "typingWords": ["Razendsnel", "Starter-thema", "57 Componenten", "12 Thema's", "Donkere modus", "Ingebouwde i18n"],
+        "typingWords": ["Razendsnel", "Starter-thema", "44 Componenten", "12 Thema's", "Donkere modus", "Ingebouwde i18n"],
         "typingWordsMobile": ["Razendsnel", "Starter-thema", "12 Thema's", "Donkere modus", "Ingebouwde i18n"],
         "description": "Een gratis, open-source Astro 7 starter-thema om alles op te bouwen."
       },
@@ -209,7 +209,7 @@
         "items": [
           {
             "icon": "component",
-            "title": "57 ontworpen componenten",
+            "title": "44 ontworpen componenten",
             "description": "Van knoppen tot complete hero-secties: getypeerd, toegankelijk, consistent en gedocumenteerd in een live showcase."
           },
           {
@@ -492,15 +492,15 @@
     "home": {
       "meta": {
         "title": "Gratis open-source Astro 7 thema",
-        "description": "Astro Rocket is een gratis, razendsnel Astro 7 starter-thema om alles op te bouwen — met 57+ ontworpen componenten, 12 kleurthema's, donkere modus en ingebouwde i18n aan boord."
+        "description": "Astro Rocket is een gratis, razendsnel Astro 7 starter-thema om alles op te bouwen — met 44 ontworpen componenten, 12 kleurthema's, donkere modus en ingebouwde i18n aan boord."
       },
       "hero": {
         "badge": "Beschikbaar voor nieuwe projecten",
         "titleLine1": "Astro Rocket —",
         "titleLine2": "Webdesigner",
         "titleLine3": "& Ontwikkelaar",
-        "description": "Een gratis, razendsnel Astro 7 starter-thema om alles op te bouwen: 57+ ontworpen componenten, 12 kleurthema's en donkere modus.",
-        "descriptionMobile": "Een gratis, razendsnel Astro 7 starter-thema om alles op te bouwen, met 57+ ontworpen componenten.",
+        "description": "Een gratis, razendsnel Astro 7 starter-thema om alles op te bouwen: 44 ontworpen componenten, 12 kleurthema's en donkere modus.",
+        "descriptionMobile": "Een gratis, razendsnel Astro 7 starter-thema om alles op te bouwen, met 44 ontworpen componenten.",
         "github": "Bekijk op GitHub",
         "getStarted": "Aan de slag"
       },


### PR DESCRIPTION
Merging the count branch left thirteen more claims of 57 in place. The sweep that produced it grepped a list of files someone had thought of, which is why it missed the Dutch dictionary entirely, a stat tile on the homepage reading "57+ components included", the project page, three sentences in the body of the component-library post, two README paragraphs, and the number drawn into that post's cover SVG — the alt text describes it, so the image had to change too.

Two more were wrong in a different way: "these 33 components cover every common UI need" and a directory comment reading "(31 components)" were both stale sub-counts of the UI category, which holds 34.

The test now walks src, README.md and AGENTS.md rather than a list, and takes the figures it will accept from the registry: the total, or any per-category count. That way it keeps working when a component is added, and it fails on a number nobody can point at. It found the last two by itself, and it fails if 57 is put back.

CHANGELOG.md keeps its 57 — it records what a release contained at the time, which did not change.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
