### PR TITLE
Render "More projects" with the shared card too

### DIFF
--- a/src/components/projects/ProjectCard.astro
+++ b/src/components/projects/ProjectCard.astro
@@ -21,9 +21,15 @@ interface Props {
    * `/projects/...`; other locales are prefixed (`/<locale>/projects/...`).
    */
   locale?: string;
+  /**
+   * Add the scroll-reveal trigger. Turn it off where a parent already reveals
+   * the whole section — nesting one reveal inside another leaves the cards
+   * waiting on a trigger that has already fired.
+   */
+  reveal?: boolean;
 }
 
-const { project, index = 0, locale = defaultLocale } = Astro.props;
+const { project, index = 0, locale = defaultLocale, reveal = true } = Astro.props;
 const { data } = project;
 ---
 
@@ -33,8 +39,8 @@ const { data } = project;
   padding="none"
   href={data.placeholder ? undefined : getProjectUrl(project.id, locale)}
   class="group flex flex-col"
-  data-reveal
-  data-reveal-delay={index % 2 || undefined}
+  data-reveal={reveal || undefined}
+  data-reveal-delay={reveal ? index % 2 || undefined : undefined}
 >
   <!--
     Bottom padding is larger than the rest on purpose. Above the icon sits the

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -9,7 +9,7 @@ import Breadcrumbs from '@/components/seo/Breadcrumbs.astro';
 import ProjectHero from '@/components/projects/ProjectHero.astro';
 import TableOfContents from '@/components/blog/TableOfContents.astro';
 import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
-import Card from '@/components/ui/data-display/Card/Card.astro';
+import ProjectCard from '@/components/projects/ProjectCard.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
@@ -18,7 +18,6 @@ import { getDefaultOgPath, getProjectOgPath, isShareableImage } from '@/lib/og/s
 import { t, getLocaleFromPath, localizedPath, getLocales } from '@/i18n';
 import {
   getProjectSlug,
-  getProjectUrl,
   getProjectsBaseUrl,
   getProjectTranslations,
 } from '@/lib/projects';
@@ -216,42 +215,11 @@ const languageAlternates = Object.fromEntries(
         <div class="mx-auto max-w-7xl px-6">
           <h2 class="font-display text-2xl md:text-3xl font-bold text-foreground mb-8 text-center">{t('projects.moreProjects', locale)}</h2>
           <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {related.map((project) => (
-              <Card
-                variant="elevated"
-                hover
-                padding="none"
-                href={project.data.placeholder ? undefined : getProjectUrl(project.id, locale)}
-                class="group flex flex-col"
-              >
-                <div class="flex flex-1 flex-col p-6">
-                  <div class="mb-3 flex items-start justify-between gap-4">
-                    <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500/20 to-brand-500/5 flex items-center justify-center text-brand-500 shrink-0">
-                      <Icon name="layers" size="sm" />
-                    </div>
-                    <Icon name="arrow-up-right" size="sm" class="text-foreground-muted group-hover:text-brand-500 transition-colors shrink-0 ml-auto" />
-                  </div>
-                  <div class="mb-2 flex items-baseline gap-2">
-                    <h3 class="font-display text-lg font-bold text-foreground">{project.data.title}</h3>
-                    {project.data.year && (
-                      <span class="text-xs text-foreground-muted">{project.data.year}</span>
-                    )}
-                  </div>
-                  <p class="text-sm text-foreground-muted leading-relaxed mb-4 flex-1 line-clamp-3">{project.data.description}</p>
-                  {project.data.tags && project.data.tags.length > 0 && (
-                    <div class="flex flex-wrap gap-1.5">
-                      {project.data.tags.map((tag, i) => (
-                        <>
-                          {i === 3 && <div class="basis-full" aria-hidden="true"></div>}
-                          <span class="inline-flex items-center rounded-full bg-transparent px-2.5 py-0.5 text-xs font-medium text-brand-700 dark:text-brand-400 ring-1 ring-inset ring-brand-500/40 transition-colors group-hover:ring-brand-500/80">
-                            #{tag}
-                          </span>
-                        </>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </Card>
+            {/* The same card the projects index, the paginated pages, the tag
+                archives and the homepage use. `reveal={false}` because the
+                section above already carries the trigger. */}
+            {related.map((project, i) => (
+              <ProjectCard project={project} index={i} locale={locale} reveal={false} />
             ))}
           </div>
         </div>


### PR DESCRIPTION
The strip at the foot of a project page carried its own copy of the card markup, so it kept the old design after the other four places had changed. That is the third copy found today — the homepage had one, this had one, and the component's own docstring claimed it was already the single source.

ProjectCard gains a `reveal` prop. This section already carries `data-reveal` on its wrapper, and nesting one reveal inside another leaves the cards waiting on a trigger that has already fired. Verified after building: the three cards render at opacity 1.

The copy also forced a line break after the third tag. Dropped — the tags are centred now, and a forced break through the middle of a centred row reads as a mistake.

`Card` and `getProjectUrl` are no longer used in ProjectLayout and are removed; `astro check` reports no unused imports.

Swept for others afterwards: every project card in the theme now comes from ProjectCard — the projects index, the paginated pages, the tag archives, the homepage and this strip. The one remaining instance of the old tile markup is on the 404 page, which is not a project card.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
