### PR TITLE
Show the columns footer at the size the theme is aimed at

### DIFF
--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -643,50 +643,67 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
             <span class="showcase-hint">Newsletter block, four link groups, social row in the bottom bar</span>
           </div>
           <div class="showcase-content !p-0 overflow-hidden rounded-b-xl">
-            <Footer layout="columns" columns={2} background="secondary">
-              <div slot="logo">
+            <Footer layout="columns" columns={2} hideLogo background="secondary">
+              <!--
+                One child spanning the whole row, holding its own asymmetric
+                grid. The layout's own grid is two equal halves, so capping the
+                signup block inside one of them leaves dead space rather than
+                giving the link groups room — the halves stay 50/50 whatever
+                the content does. Spanning it and splitting it here is the only
+                way to get a narrow signup column beside a wide link area, and
+                it is still slots and utility classes, with nothing changed in
+                the component.
+              -->
+              <div
+                slot="columns"
+                class="md:col-span-2 grid gap-y-[var(--space-stack-lg)] gap-x-12 md:grid-cols-[minmax(0,300px)_1fr] lg:grid-cols-[minmax(0,340px)_1fr]"
+              >
                 <NewsletterForm
                   layout="stacked"
+                  size="sm"
                   heading="Let's keep in touch"
                   description="Get new components and releases in your inbox."
                 />
-              </div>
 
-              <div slot="columns" class="grid grid-cols-2 md:grid-cols-4 gap-[var(--space-stack-lg)]">
-                {[
-                  {
-                    title: 'Product',
-                    links: ['Features', 'Pricing', 'Changelog', 'Roadmap', 'Status'],
-                  },
-                  {
-                    title: 'Resources',
-                    links: ['Documentation', 'Components', 'Blog', 'Guides', 'Showcase'],
-                  },
-                  {
-                    title: 'Company',
-                    links: ['About', 'Careers', 'Partners', 'Press'],
-                  },
-                  {
-                    title: 'Legal',
-                    links: ['Privacy Policy', 'Terms of Service', 'Cookies'],
-                  },
-                ].map((group) => (
-                  <div class="space-y-[var(--space-stack-md)]">
-                    <h3 class="font-semibold text-sm text-foreground">{group.title}</h3>
-                    <ul class="space-y-2">
-                      {group.links.map((label) => (
-                        <li>
-                          <a
-                            href="#"
-                            class="text-sm transition-colors text-foreground-muted hover:text-foreground"
-                          >
-                            {label}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
+                <!-- Four across only at `xl`. Below that each column falls
+                     under about 130px and labels like "Terms of Service" break
+                     across two lines. -->
+                <div class="grid grid-cols-2 xl:grid-cols-4 gap-y-[var(--space-stack-lg)] gap-x-8">
+                  {[
+                    {
+                      title: 'Product',
+                      links: ['Features', 'Pricing', 'Changelog', 'Roadmap', 'Status'],
+                    },
+                    {
+                      title: 'Resources',
+                      links: ['Documentation', 'Components', 'Blog', 'Guides', 'Showcase'],
+                    },
+                    {
+                      title: 'Company',
+                      links: ['About', 'Careers', 'Partners', 'Press'],
+                    },
+                    {
+                      title: 'Legal',
+                      links: ['Privacy Policy', 'Terms of Service', 'Cookies'],
+                    },
+                  ].map((group) => (
+                    <div class="space-y-[var(--space-stack-md)]">
+                      <h3 class="font-semibold text-sm text-foreground">{group.title}</h3>
+                      <ul class="space-y-2">
+                        {group.links.map((label) => (
+                          <li>
+                            <a
+                              href="#"
+                              class="text-sm transition-colors text-foreground-muted hover:text-foreground"
+                            >
+                              {label}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
               </div>
 
               <Fragment slot="bottom">

--- a/src/pages/components.astro
+++ b/src/pages/components.astro
@@ -623,6 +623,92 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
           </div>
         </div>
 
+        <!--
+          Footer Columns Layout — large site
+
+          The same layout as above, arranged the way a medium or large site
+          uses it: a wide first column carrying a newsletter block, four link
+          groups beside it, and the social row moved down into the bottom bar.
+
+          Nothing here is a new component. `columns={2}` splits the row into
+          the wide column and the link area, and the four groups get their own
+          grid inside `slot="columns"` — that is what produces one wide column
+          beside four narrow ones rather than five equal ones. The `bottom`
+          slot is already `justify-between`, so the licence line and the icons
+          land at opposite ends of it.
+        -->
+        <div class="component-showcase">
+          <div class="showcase-header">
+            <span class="showcase-label">Columns Layout — large site</span>
+            <span class="showcase-hint">Newsletter block, four link groups, social row in the bottom bar</span>
+          </div>
+          <div class="showcase-content !p-0 overflow-hidden rounded-b-xl">
+            <Footer layout="columns" columns={2} background="secondary">
+              <div slot="logo">
+                <NewsletterForm
+                  layout="stacked"
+                  heading="Let's keep in touch"
+                  description="Get new components and releases in your inbox."
+                />
+              </div>
+
+              <div slot="columns" class="grid grid-cols-2 md:grid-cols-4 gap-[var(--space-stack-lg)]">
+                {[
+                  {
+                    title: 'Product',
+                    links: ['Features', 'Pricing', 'Changelog', 'Roadmap', 'Status'],
+                  },
+                  {
+                    title: 'Resources',
+                    links: ['Documentation', 'Components', 'Blog', 'Guides', 'Showcase'],
+                  },
+                  {
+                    title: 'Company',
+                    links: ['About', 'Careers', 'Partners', 'Press'],
+                  },
+                  {
+                    title: 'Legal',
+                    links: ['Privacy Policy', 'Terms of Service', 'Cookies'],
+                  },
+                ].map((group) => (
+                  <div class="space-y-[var(--space-stack-md)]">
+                    <h3 class="font-semibold text-sm text-foreground">{group.title}</h3>
+                    <ul class="space-y-2">
+                      {group.links.map((label) => (
+                        <li>
+                          <a
+                            href="#"
+                            class="text-sm transition-colors text-foreground-muted hover:text-foreground"
+                          >
+                            {label}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+
+              <Fragment slot="bottom">
+                <p class="text-sm text-foreground-muted">
+                  MIT License © 2026 &nbsp;·&nbsp; Astro Rocket
+                </p>
+                <div class="flex items-center gap-[var(--space-inline-lg)]">
+                  {['github', 'bluesky', 'linkedin', 'instagram', 'x-twitter'].map((platform) => (
+                    <a
+                      href="#"
+                      aria-label={platform}
+                      class="transition-colors text-foreground-muted hover:text-foreground"
+                    >
+                      <Icon name={platform} size="md" />
+                    </a>
+                  ))}
+                </div>
+              </Fragment>
+            </Footer>
+          </div>
+        </div>
+
         <!-- Footer Props Reference -->
         <div class="component-showcase">
           <div class="showcase-header">
@@ -634,7 +720,7 @@ import StackMarquee from '@/components/landing/StackMarquee.astro';
               <div>
                 <h3 class="font-semibold text-foreground mb-2">Layout</h3>
                 <ul class="space-y-1 text-foreground-muted">
-                  <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">layout</code> simple | columns | minimal | stacked</li>
+                  <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">layout</code> simple | columns | minimal | stacked | centered</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">columns</code> 2 | 3 | 4</li>
                   <li><code class="text-xs bg-secondary px-1.5 py-0.5 rounded">background</code> default | secondary | invert</li>
                 </ul>


### PR DESCRIPTION
## What does this PR do?

The Columns layout was already on the components page, but the example was three short link groups and a tagline. Beside a large site's footer it did not read as the same kind of thing, which is why #619 asked for a footer the theme already builds.

This adds a second showcase using the same components at the size a medium or large site needs: a signup block in a narrow track, four link groups in a wide one, and the social row moved down into the bottom bar. The original example stays, so the page shows both ends of the layout.

Nothing in the `Footer` component changed. The arrangement is slots and utility classes only, so no existing site moves.

**How the asymmetric row works.** The layout's own grid is two equal halves, so capping the signup block inside one of them leaves dead space rather than giving the link groups room — the halves stay 50/50 whatever the content does. Instead, one child spans both columns and carries its own `minmax(0,340px) 1fr` grid. That is what puts the signup in a narrow track and the groups in a wide one.

Also adds `centered` to the Footer props reference, which listed four of the five layouts and left out the one every demo page uses.

Related to #619

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [x] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors (2 pre-existing warnings in `scripts/verify-build.mjs`, untouched here)
- [x] `pnpm check` passes with 0 errors (0 warnings, 9 hints)
- [x] `pnpm build` completes successfully
- [x] I have tested this change in the browser
- [x] No unnecessary files are included in this PR

**On the test suite.** `vitest` reports 2 failed / 119 passed. Both failures are pre-existing on `main` and unrelated to this change — confirmed by stashing the diff and re-running on a clean tree:

- `src/__tests__/nav-i18n.test.ts` — "prefixes secondary-locale hrefs with the locale"
- `src/__tests__/i18n.test.ts` — "tData() returns a structured (array) value by dotted key"

## Screenshots (if relevant)

Measured in a browser against the production build, at six widths. No label wraps onto a second line and there is no horizontal overflow at any of them:

| width | signup track | each link column | column gap |
|---|---|---|---|
| 1440 | 340px | 143px | 48px |
| 1280 | 340px | 143px | 48px |
| 1024 | 340px | 253px | 48px |
| 900 | 300px | 211px | 48px |
| 768 | 300px | 145px | 48px |
| 500 | stacked | 185px | — |

Four columns only from `xl`. Below that each one falls under about 130px and labels such as "Terms of Service" break across two lines, so it is two-by-two down to the stacked phone layout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST)_