### PR TITLE
Point two i18n tests at content that still exists

### DIFF
--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -42,10 +42,23 @@ describe('i18n t() helper', () => {
 
 describe('i18n tData() helper', () => {
   it('returns a structured (array) value by dotted key', () => {
-    const facts = tData<{ icon: string; title: string }[]>('pages.about.intro.facts', 'en');
-    expect(Array.isArray(facts)).toBe(true);
-    expect(facts?.length).toBe(6);
-    expect(facts?.[0]?.title).toBe('Astro 7');
+    // Asserts the shape rather than the copy. The previous version read
+    // `pages.about.intro.facts` and checked for the literal "Astro 7"; the
+    // about page was later restructured, `intro` stopped existing, and the
+    // test failed for a reason that had nothing to do with tData().
+    const items = tData<{ icon: string; title: string; description: string }[]>(
+      'pages.about.principles.items',
+      'en'
+    );
+    expect(Array.isArray(items)).toBe(true);
+    expect(items?.length).toBeGreaterThan(0);
+    expect(items?.[0]).toEqual(
+      expect.objectContaining({
+        icon: expect.any(String),
+        title: expect.any(String),
+        description: expect.any(String),
+      })
+    );
   });
 
   it('returns the Dutch structured value when locale is nl', () => {

--- a/src/__tests__/nav-i18n.test.ts
+++ b/src/__tests__/nav-i18n.test.ts
@@ -26,6 +26,7 @@ describe('nav config — locale resolution (en default, nl secondary)', () => {
   it('prefixes secondary-locale hrefs with the locale', () => {
     const items = getNavItems('nl');
     expect(items.map((i) => i.href)).toEqual([
+      '/nl',
       '/nl/services',
       '/nl/projects',
       '/nl/blog',


### PR DESCRIPTION
## What does this PR do?

Two tests have been failing on `main`. Neither is broken code — both are tests that outlived the thing they described.

**`src/__tests__/nav-i18n.test.ts` — "prefixes secondary-locale hrefs with the locale"**

The test listed five expected hrefs for the Dutch nav. `navItems` in `nav.config.ts` gained a Home entry at `/` and the expectation was never updated, so the test failed on a sixth item being present and correct. Adds `/nl` to the expected list.

**`src/__tests__/i18n.test.ts` — "tData() returns a structured (array) value by dotted key"**

The test read `pages.about.intro.facts` and checked for the literal `"Astro 7"`. The about page was restructured into `whatYouGet`, `principles`, `stack`, `faq`, `openSource` and `cta` — `intro` no longer exists in either locale file. So `tData()` correctly returned `undefined` and the test reported it as a fault in the helper.

It now reads `pages.about.principles.items` and asserts the *shape* of the first entry — `icon`, `title` and `description` all present as strings — rather than its wording. Rewording the about page can no longer fail it. The sibling test above it already uses `pages.about.faq.cards`, so the key is in the same family.

`tData()` itself needed no change and was working correctly throughout.

## Type of change

- [x] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm check` passes with 0 errors
- [x] `pnpm build` completes successfully
- [ ] I have tested this change in the browser — not applicable, no rendered output changes
- [x] No unnecessary files are included in this PR

Test suite: **13 files, 121 tests, all passing.** Before this change: 2 files failed, 2 tests failed, 119 passed.

## Screenshots (if relevant)

None — test-only change, nothing rendered is affected.