### PR TITLE
Make the blog surfaces consistent, and give every locale its own RSS feed

### DIFF
--- a/src/components/blog/FollowAlong.astro
+++ b/src/components/blog/FollowAlong.astro
@@ -18,6 +18,7 @@ import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
 import NewsletterForm from '@/components/patterns/NewsletterForm.astro';
 import { resolveSocialLinks } from '@/lib/utils';
+import { getRssUrl } from '@/lib/blog';
 import siteConfig from '@/config/site.config';
 import { t } from '@/i18n';
 
@@ -53,7 +54,7 @@ const showNewsletter = newsletter && !!siteConfig.newsletter?.enabled;
  * new tab; the feed and the mailto stay in place.
  */
 const pills = [
-  { href: '/rss.xml', icon: 'rss', label: t('blog.rssFeed', locale), external: false },
+  { href: getRssUrl(locale), icon: 'rss', label: t('blog.rssFeed', locale), external: false },
   ...socialLinks.map((link) => ({
     href: link.href,
     icon: link.icon,

--- a/src/components/blog/FollowAlong.astro
+++ b/src/components/blog/FollowAlong.astro
@@ -1,0 +1,142 @@
+---
+/**
+ * FollowAlong — the subscribe block that closes every blog surface.
+ *
+ * This markup used to live inline in three files as five separate copies:
+ * `BlogIndexView` and `BlogLayout` each carried a mobile CTA and a desktop
+ * LetterGlitch band, and `BlogPageView` carried the CTA alone. They drifted,
+ * which is why `/blog/page/2` has no glitch band and no newsletter form while
+ * the blog index has both, and why `/blog/tag/…` has no block at all.
+ *
+ * The differences that survive are wrapper-level and are props here; the pill
+ * list is built once and rendered twice, differing only in its class string
+ * because the band sits on a dark backdrop.
+ *
+ * Two inconsistencies are preserved deliberately rather than fixed, so this
+ * component is a like-for-like replacement that renders byte-identical output:
+ *
+ * - `BlogPageView` passes `glitchBand={false}` and `newsletter={false}`. The
+ *   second has no visible effect while `siteConfig.newsletter.enabled` is off,
+ *   but turning that on would give the blog index a signup form and page two
+ *   none.
+ * - Tag pages still render nothing. Adding it there is a change of behaviour,
+ *   not a refactor.
+ */
+import CTA from '@/components/ui/marketing/CTA/CTA.astro';
+import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
+import Icon from '@/components/ui/primitives/Icon/Icon.astro';
+import NewsletterForm from '@/components/patterns/NewsletterForm.astro';
+import { resolveSocialLinks } from '@/lib/utils';
+import siteConfig from '@/config/site.config';
+import { t } from '@/i18n';
+
+interface Props {
+  locale: string;
+  /** Render the desktop LetterGlitch band beneath the mobile CTA. */
+  glitchBand?: boolean;
+  /** Classes for the mobile CTA element. */
+  ctaClass?: string;
+  /** Classes for the section wrapping the desktop band. */
+  bandSectionClass?: string;
+  /** Inner width of the desktop band. Matches LetterGlitchBand's own prop. */
+  bandMaxWidth?: '6xl' | '7xl';
+  /** Offer the newsletter form when the site has newsletters enabled. */
+  newsletter?: boolean;
+}
+
+const {
+  locale,
+  glitchBand = true,
+  ctaClass,
+  bandSectionClass,
+  bandMaxWidth,
+  newsletter = true,
+} = Astro.props;
+
+const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
+const showNewsletter = newsletter && !!siteConfig.newsletter?.enabled;
+
+/**
+ * One list, rendered twice. RSS first and email last, with the socials
+ * between them — the order the inline copies used. Only the socials open in a
+ * new tab; the feed and the mailto stay in place.
+ */
+const pills = [
+  { href: '/rss.xml', icon: 'rss', label: t('blog.rssFeed', locale), external: false },
+  ...socialLinks.map((link) => ({
+    href: link.href,
+    icon: link.icon,
+    label: link.label,
+    external: true,
+  })),
+  {
+    href: `mailto:${siteConfig.email}`,
+    icon: 'mail',
+    label: t('blog.emailLabel', locale),
+    external: false,
+  },
+];
+
+const PILL_LIGHT =
+  'inline-flex items-center gap-2 rounded-full border border-brand-500/40 bg-background px-4 py-2 text-sm font-medium text-brand-700 dark:text-brand-400 transition-colors hover:border-brand-500/80';
+const PILL_BAND =
+  'inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-brand-400 hover:bg-brand-500/20 hover:text-foreground';
+---
+
+<CTA variant="default" size="md" maxWidth="lg" glow={false} data-reveal class={ctaClass}>
+  <h2 slot="heading" class="!text-4xl">{t('blog.followAlong', locale)}</h2>
+  <p slot="description" class="!text-lg text-balance">{t('blog.followAlongLead', locale)}</p>
+
+  <div class="flex flex-wrap items-center justify-center gap-3">
+    {pills.map((pill) => (
+      <a
+        href={pill.href}
+        target={pill.external ? '_blank' : undefined}
+        rel={pill.external ? 'noopener noreferrer' : undefined}
+        class={PILL_LIGHT}
+      >
+        <Icon name={pill.icon} size="sm" />
+        {pill.label}
+      </a>
+    ))}
+  </div>
+
+  {showNewsletter && (
+    <div class="mx-auto mt-8 max-w-md border-t border-border px-6 pt-8 sm:px-0">
+      <NewsletterForm description={t('newsletter.description', locale)} buttonClass="cta-btn-brand" />
+    </div>
+  )}
+</CTA>
+
+{glitchBand && (
+  <section class={bandSectionClass}>
+    <LetterGlitchBand maxWidth={bandMaxWidth}>
+      <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">
+        {t('blog.followAlong', locale)}
+      </h2>
+      <p class="text-lg text-foreground-muted mb-8 text-balance">
+        {t('blog.followAlongLead', locale)}
+      </p>
+
+      <div class="flex flex-wrap items-center justify-center gap-3">
+        {pills.map((pill) => (
+          <a
+            href={pill.href}
+            target={pill.external ? '_blank' : undefined}
+            rel={pill.external ? 'noopener noreferrer' : undefined}
+            class={PILL_BAND}
+          >
+            <Icon name={pill.icon} size="sm" />
+            {pill.label}
+          </a>
+        ))}
+      </div>
+
+      {showNewsletter && (
+        <div class="mx-auto mt-8 max-w-md border-t border-white/20 pt-8">
+          <NewsletterForm description={t('newsletter.description', locale)} buttonClass="hero-btn-brand" />
+        </div>
+      )}
+    </LetterGlitchBand>
+  </section>
+)}

--- a/src/components/blog/FollowAlong.astro
+++ b/src/components/blog/FollowAlong.astro
@@ -2,25 +2,16 @@
 /**
  * FollowAlong — the subscribe block that closes every blog surface.
  *
- * This markup used to live inline in three files as five separate copies:
- * `BlogIndexView` and `BlogLayout` each carried a mobile CTA and a desktop
- * LetterGlitch band, and `BlogPageView` carried the CTA alone. They drifted,
- * which is why `/blog/page/2` has no glitch band and no newsletter form while
- * the blog index has both, and why `/blog/tag/…` has no block at all.
+ * The markup used to live inline in three files as five separate copies, and
+ * they had drifted: `/blog/page/2` offered no desktop band and no newsletter
+ * form, and `/blog/tag/…` offered nothing at all. Which subscribe options a
+ * reader saw depended on how they had arrived at the blog.
  *
- * The differences that survive are wrapper-level and are props here; the pill
- * list is built once and rendered twice, differing only in its class string
- * because the band sits on a dark backdrop.
- *
- * Two inconsistencies are preserved deliberately rather than fixed, so this
- * component is a like-for-like replacement that renders byte-identical output:
- *
- * - `BlogPageView` passes `glitchBand={false}` and `newsletter={false}`. The
- *   second has no visible effect while `siteConfig.newsletter.enabled` is off,
- *   but turning that on would give the blog index a signup form and page two
- *   none.
- * - Tag pages still render nothing. Adding it there is a change of behaviour,
- *   not a refactor.
+ * One copy now serves all four surfaces — the index, a single post, the
+ * paginated pages and the tag pages. The differences that survive are
+ * wrapper-level and are props here; the pill list is built once and rendered
+ * twice, differing only in its class string because the band sits on a dark
+ * backdrop.
  */
 import CTA from '@/components/ui/marketing/CTA/CTA.astro';
 import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';

--- a/src/components/blog/views/BlogIndexView.astro
+++ b/src/components/blog/views/BlogIndexView.astro
@@ -13,13 +13,9 @@ import Pagination from '@/components/blog/Pagination.astro';
 import TagList from '@/components/blog/TagList.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
-import CTA from '@/components/ui/marketing/CTA/CTA.astro';
-import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
-import NewsletterForm from '@/components/patterns/NewsletterForm.astro';
 import { Hero } from '@/components/hero';
-import siteConfig from '@/config/site.config';
-import { resolveSocialLinks } from '@/lib/utils';
 import { t, defaultLocale } from '@/i18n';
+import FollowAlong from '@/components/blog/FollowAlong.astro';
 import {
   BLOG_POSTS_PER_PAGE,
   BLOG_TAG_CLOUD_LIMIT,
@@ -36,10 +32,8 @@ interface Props {
 
 const { locale = defaultLocale } = Astro.props;
 
-const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
 
 // Newsletter signup — opt-in, since the endpoint needs Resend keys to work.
-const showNewsletter = !!siteConfig.newsletter?.enabled;
 
 const posts = await getPublishedPosts(locale);
 
@@ -151,86 +145,10 @@ const topTags = collectTopTags(posts, BLOG_TAG_CLOUD_LIMIT);
     </div>
   </section>
 
-  <!-- Follow CTA Section -->
-  <!-- Mobile: standard CTA, no LetterGlitch -->
-  <CTA variant="default" size="md" maxWidth="lg" glow={false} data-reveal class:list={['glitch:hidden', featuredPosts.length > 0 && '!bg-background-secondary']}>
-    <h2 slot="heading" class="!text-4xl">{t('blog.followAlong', locale)}</h2>
-    <p slot="description" class="!text-lg text-balance">{t('blog.followAlongLead', locale)}</p>
-
-    <div class="flex flex-wrap items-center justify-center gap-3">
-      <a
-        href="/rss.xml"
-        class="inline-flex items-center gap-2 rounded-full border border-brand-500/40 bg-background px-4 py-2 text-sm font-medium text-brand-700 dark:text-brand-400 transition-colors hover:border-brand-500/80"
-      >
-        <Icon name="rss" size="sm" />
-        {t('blog.rssFeed', locale)}
-      </a>
-      {socialLinks.map((link) => (
-        <a
-          href={link.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center gap-2 rounded-full border border-brand-500/40 bg-background px-4 py-2 text-sm font-medium text-brand-700 dark:text-brand-400 transition-colors hover:border-brand-500/80"
-        >
-          <Icon name={link.icon} size="sm" />
-          {link.label}
-        </a>
-      ))}
-      <a
-        href={`mailto:${siteConfig.email}`}
-        class="inline-flex items-center gap-2 rounded-full border border-brand-500/40 bg-background px-4 py-2 text-sm font-medium text-brand-700 dark:text-brand-400 transition-colors hover:border-brand-500/80"
-      >
-        <Icon name="mail" size="sm" />
-        {t('blog.emailLabel', locale)}
-      </a>
-    </div>
-
-    {showNewsletter && (
-      <div class="mx-auto mt-8 max-w-md border-t border-border px-6 pt-8 sm:px-0">
-        <NewsletterForm description={t('newsletter.description', locale)} buttonClass="cta-btn-brand" />
-      </div>
-    )}
-  </CTA>
-
-  <!-- Desktop: contained LetterGlitch band with glass card -->
-  <section class:list={['hidden glitch:block relative z-10 py-[var(--space-section-md)]', featuredPosts.length > 0 ? 'bg-background-secondary' : 'bg-background']}>
-    <LetterGlitchBand>
-      <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">{t('blog.followAlong', locale)}</h2>
-      <p class="text-lg text-foreground-muted mb-8 text-balance">{t('blog.followAlongLead', locale)}</p>
-
-      <div class="flex flex-wrap items-center justify-center gap-3">
-        <a
-          href="/rss.xml"
-          class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-brand-400 hover:bg-brand-500/20 hover:text-foreground"
-        >
-          <Icon name="rss" size="sm" />
-          {t('blog.rssFeed', locale)}
-        </a>
-        {socialLinks.map((link) => (
-          <a
-            href={link.href}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-brand-400 hover:bg-brand-500/20 hover:text-foreground"
-          >
-            <Icon name={link.icon} size="sm" />
-            {link.label}
-          </a>
-        ))}
-        <a
-          href={`mailto:${siteConfig.email}`}
-          class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-brand-400 hover:bg-brand-500/20 hover:text-foreground"
-        >
-          <Icon name="mail" size="sm" />
-          {t('blog.emailLabel', locale)}
-        </a>
-      </div>
-
-      {showNewsletter && (
-        <div class="mx-auto mt-8 max-w-md border-t border-white/20 pt-8">
-          <NewsletterForm description={t('newsletter.description', locale)} buttonClass="hero-btn-brand" />
-        </div>
-      )}
-    </LetterGlitchBand>
-  </section>
+  <!-- Subscribe block: RSS, socials, email, and the newsletter form -->
+  <FollowAlong
+    locale={locale}
+    ctaClass={['glitch:hidden', featuredPosts.length > 0 && '!bg-background-secondary'].filter(Boolean).join(' ')}
+    bandSectionClass={`hidden glitch:block relative z-10 py-[var(--space-section-md)] ${featuredPosts.length > 0 ? 'bg-background-secondary' : 'bg-background'}`}
+  />
 </PageLayout>

--- a/src/components/blog/views/BlogPageView.astro
+++ b/src/components/blog/views/BlogPageView.astro
@@ -13,11 +13,9 @@ import Pagination from '@/components/blog/Pagination.astro';
 import TagList from '@/components/blog/TagList.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
-import CTA from '@/components/ui/marketing/CTA/CTA.astro';
 import { Hero } from '@/components/hero';
-import siteConfig from '@/config/site.config';
-import { resolveSocialLinks } from '@/lib/utils';
 import { t, defaultLocale } from '@/i18n';
+import FollowAlong from '@/components/blog/FollowAlong.astro';
 import {
   BLOG_POSTS_PER_PAGE,
   BLOG_TAG_CLOUD_LIMIT,
@@ -48,7 +46,6 @@ const pagePosts = regularPostsAll.slice(start, start + BLOG_POSTS_PER_PAGE);
 
 const topTags = collectTopTags(posts, BLOG_TAG_CLOUD_LIMIT);
 
-const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
 ---
 
 <PageLayout
@@ -111,36 +108,5 @@ const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
     </div>
   </section>
 
-  <CTA variant="default" size="md" maxWidth="lg" glow={false} data-reveal>
-    <h2 slot="heading" class="!text-4xl">{t('blog.followAlong', locale)}</h2>
-    <p slot="description" class="!text-lg text-balance">{t('blog.followAlongLead', locale)}</p>
-
-    <div class="flex flex-wrap items-center justify-center gap-3">
-      <a
-        href="/rss.xml"
-        class="inline-flex items-center gap-2 rounded-full border border-brand-500/40 bg-background px-4 py-2 text-sm font-medium text-brand-700 dark:text-brand-400 transition-colors hover:border-brand-500/80"
-      >
-        <Icon name="rss" size="sm" />
-        {t('blog.rssFeed', locale)}
-      </a>
-      {socialLinks.map((link) => (
-        <a
-          href={link.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center gap-2 rounded-full border border-brand-500/40 bg-background px-4 py-2 text-sm font-medium text-brand-700 dark:text-brand-400 transition-colors hover:border-brand-500/80"
-        >
-          <Icon name={link.icon} size="sm" />
-          {link.label}
-        </a>
-      ))}
-      <a
-        href={`mailto:${siteConfig.email}`}
-        class="inline-flex items-center gap-2 rounded-full border border-brand-500/40 bg-background px-4 py-2 text-sm font-medium text-brand-700 dark:text-brand-400 transition-colors hover:border-brand-500/80"
-      >
-        <Icon name="mail" size="sm" />
-        {t('blog.emailLabel', locale)}
-      </a>
-    </div>
-  </CTA>
+  <FollowAlong locale={locale} glitchBand={false} newsletter={false} />
 </PageLayout>

--- a/src/components/blog/views/BlogPageView.astro
+++ b/src/components/blog/views/BlogPageView.astro
@@ -108,5 +108,9 @@ const topTags = collectTopTags(posts, BLOG_TAG_CLOUD_LIMIT);
     </div>
   </section>
 
-  <FollowAlong locale={locale} glitchBand={false} newsletter={false} />
+  <FollowAlong
+    locale={locale}
+    ctaClass="glitch:hidden"
+    bandSectionClass="hidden glitch:block relative z-10 py-[var(--space-section-md)] bg-background"
+  />
 </PageLayout>

--- a/src/components/blog/views/BlogTagView.astro
+++ b/src/components/blog/views/BlogTagView.astro
@@ -18,6 +18,7 @@ import { Hero } from '@/components/hero';
 import { t, defaultLocale } from '@/i18n';
 import { getBlogBaseUrl, getPostUrl, tagToSlug } from '@/lib/blog';
 import { getBlogTagOgPath } from '@/lib/og/svg';
+import FollowAlong from '@/components/blog/FollowAlong.astro';
 
 interface Props {
   /** Locale whose posts this archive renders. Defaults to the site default. */
@@ -108,4 +109,10 @@ const countKey = posts.length === 1 ? 'blog.tagCountOne' : 'blog.tagCountOther';
       )}
     </div>
   </section>
+
+  <FollowAlong
+    locale={locale}
+    ctaClass="glitch:hidden"
+    bandSectionClass="hidden glitch:block relative z-10 py-[var(--space-section-md)] bg-background"
+  />
 </PageLayout>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,6 +11,7 @@ import { createWebsiteSchema, createOrganizationSchema, createPersonSchema, crea
 import type { Thing, WithContext } from 'schema-dts';
 import siteConfig from '@/config/site.config';
 import { t, getLocaleFromPath } from '@/i18n';
+import { getRssUrl } from '@/lib/blog';
 
 interface Props {
   title?: string;
@@ -122,7 +123,7 @@ if (commentsConfig?.enabled) {
     />
 
     <!-- RSS Feed -->
-    <link rel="alternate" type="application/rss+xml" title={`${siteConfig.name} RSS Feed`} href="/rss.xml" />
+    <link rel="alternate" type="application/rss+xml" title={`${siteConfig.name} RSS Feed`} href={getRssUrl(locale)} />
 
     <!-- JSON-LD Structured Data -->
     <JsonLd schema={schemas} />

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -10,24 +10,19 @@ import ShareButtons from '@/components/blog/ShareButtons.astro';
 import RelatedPosts from '@/components/blog/RelatedPosts.astro';
 import TableOfContents from '@/components/blog/TableOfContents.astro';
 import Comments from '@/components/blog/Comments.astro';
-import CTA from '@/components/ui/marketing/CTA/CTA.astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import Icon from '@/components/ui/primitives/Icon/Icon.astro';
-import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
-import NewsletterForm from '@/components/patterns/NewsletterForm.astro';
-import { resolveSocialLinks } from '@/lib/utils';
 import { createBlogPostSchema, createFAQSchema } from '@/lib/schema';
 import { getBlogOgPath, getDefaultOgPath, isShareableImage } from '@/lib/og/svg';
 import { t, getLocaleFromPath, localizedPath, getLocales } from '@/i18n';
 import { getPostSlug, getBlogBaseUrl } from '@/lib/blog';
 import { getPostTranslations } from '@/lib/post-links';
+import FollowAlong from '@/components/blog/FollowAlong.astro';
 
 const locale = getLocaleFromPath(Astro.url.pathname);
 
-const socialLinks = resolveSocialLinks(siteConfig.socialLinks);
 
 // Newsletter signup — opt-in, since the endpoint needs Resend keys to work.
-const showNewsletter = !!siteConfig.newsletter?.enabled;
 
 interface Props {
   title: string;
@@ -287,87 +282,12 @@ const languageAlternates = Object.fromEntries(
   )}
 
   <!-- Follow Along -->
-  <!-- Mobile: standard CTA, no LetterGlitch -->
-  <CTA variant="default" size="md" maxWidth="lg" glow={false} data-reveal class="glitch:hidden bg-background-secondary">
-    <h2 slot="heading" class="!text-4xl">{t('blog.followAlong', locale)}</h2>
-    <p slot="description" class="!text-lg text-balance">{t('blog.followAlongLead', locale)}</p>
-
-    <div class="flex flex-wrap items-center justify-center gap-3">
-      <a
-        href="/rss.xml"
-        class="inline-flex items-center gap-2 rounded-full border border-brand-500/40 bg-background px-4 py-2 text-sm font-medium text-brand-700 dark:text-brand-400 transition-colors hover:border-brand-500/80"
-      >
-        <Icon name="rss" size="sm" />
-        {t('blog.rssFeed', locale)}
-      </a>
-      {socialLinks.map((link) => (
-        <a
-          href={link.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center gap-2 rounded-full border border-brand-500/40 bg-background px-4 py-2 text-sm font-medium text-brand-700 dark:text-brand-400 transition-colors hover:border-brand-500/80"
-        >
-          <Icon name={link.icon} size="sm" />
-          {link.label}
-        </a>
-      ))}
-      <a
-        href={`mailto:${siteConfig.email}`}
-        class="inline-flex items-center gap-2 rounded-full border border-brand-500/40 bg-background px-4 py-2 text-sm font-medium text-brand-700 dark:text-brand-400 transition-colors hover:border-brand-500/80"
-      >
-        <Icon name="mail" size="sm" />
-        {t('blog.emailLabel', locale)}
-      </a>
-    </div>
-
-    {showNewsletter && (
-      <div class="mx-auto mt-8 max-w-md border-t border-border px-6 pt-8 sm:px-0">
-        <NewsletterForm description={t('newsletter.description', locale)} buttonClass="cta-btn-brand" />
-      </div>
-    )}
-  </CTA>
-
-  <!-- Desktop: contained LetterGlitch band with glass card -->
-  <section class="hidden glitch:block relative z-10 py-[var(--space-section-md)] bg-background-secondary">
-    <LetterGlitchBand maxWidth="7xl">
-      <h2 class="font-display text-4xl font-bold text-foreground mb-4 text-balance">{t('blog.followAlong', locale)}</h2>
-      <p class="text-lg text-foreground-muted mb-8 text-balance">{t('blog.followAlongLead', locale)}</p>
-
-      <div class="flex flex-wrap items-center justify-center gap-3">
-        <a
-          href="/rss.xml"
-          class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-brand-400 hover:bg-brand-500/20 hover:text-foreground"
-        >
-          <Icon name="rss" size="sm" />
-          {t('blog.rssFeed', locale)}
-        </a>
-        {socialLinks.map((link) => (
-          <a
-            href={link.href}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-brand-400 hover:bg-brand-500/20 hover:text-foreground"
-          >
-            <Icon name={link.icon} size="sm" />
-            {link.label}
-          </a>
-        ))}
-        <a
-          href={`mailto:${siteConfig.email}`}
-          class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:border-brand-400 hover:bg-brand-500/20 hover:text-foreground"
-        >
-          <Icon name="mail" size="sm" />
-          {t('blog.emailLabel', locale)}
-        </a>
-      </div>
-
-      {showNewsletter && (
-        <div class="mx-auto mt-8 max-w-md border-t border-white/20 pt-8">
-          <NewsletterForm description={t('newsletter.description', locale)} buttonClass="hero-btn-brand" />
-        </div>
-      )}
-    </LetterGlitchBand>
-  </section>
+  <FollowAlong
+    locale={locale}
+    ctaClass="glitch:hidden bg-background-secondary"
+    bandSectionClass="hidden glitch:block relative z-10 py-[var(--space-section-md)] bg-background-secondary"
+    bandMaxWidth="7xl"
+  />
   </div>
 
   <Footer slot="footer" layout="centered" background="default" maxWidth="7xl" />

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -66,6 +66,17 @@ export function getTagUrl(tag: string, locale: string = defaultLocale): string {
 }
 
 /**
+ * URL of the RSS feed for a locale (`/rss.xml` or `/<locale>/rss.xml`).
+ *
+ * There used to be one feed. It carried the default locale's posts and
+ * declared `<language>` to match, but every page in every locale linked to it,
+ * so a Dutch reader was offered a feed of English posts.
+ */
+export function getRssUrl(locale: string = defaultLocale): string {
+  return localizedPath('/rss.xml', locale);
+}
+
+/**
  * The non-default locales that should get their own prefixed blog routes
  * (`/<locale>/blog/...`). Empty when i18n is off or only one locale is
  * configured, so the locale-prefixed `getStaticPaths` emit nothing and

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,0 +1,85 @@
+import { getCollection } from 'astro:content';
+import siteConfig from '@/config/site.config';
+import { getPostUrl } from '@/lib/blog';
+import { defaultLocale } from '@/i18n';
+
+/**
+ * RSS feed generation, shared by `/rss.xml` and `/<locale>/rss.xml`.
+ *
+ * The feed used to be built inline in the default-locale route, filtered to
+ * the default locale's posts and hardcoded `/blog/<slug>` links. Every page in
+ * every locale linked to it, so a reader on a translated page was offered a
+ * feed in a language they had not asked for, with links to pages in that other
+ * language. Moving the body here lets each locale have its own feed without
+ * two copies of the XML drifting apart.
+ */
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function formatRfc822Date(date: Date): string {
+  return date.toUTCString();
+}
+
+interface BuildFeedOptions {
+  /** The locale this feed is for. Decides the posts, the links and the language. */
+  locale?: string;
+  /** The site's own address, from `Astro.site` where available. */
+  site?: string;
+  /** Path this feed is served at, for the self-referencing atom:link. */
+  feedPath?: string;
+}
+
+export async function buildRssFeed({
+  locale = defaultLocale,
+  site,
+  feedPath = '/rss.xml',
+}: BuildFeedOptions = {}): Promise<string> {
+  const posts = await getCollection('blog', ({ data }) => data.locale === locale && !data.draft);
+
+  const sortedPosts = posts.sort(
+    (a, b) => new Date(b.data.publishedAt).getTime() - new Date(a.data.publishedAt).getTime()
+  );
+
+  const base = (site ?? siteConfig.url).replace(/\/$/, '');
+
+  const items = sortedPosts
+    .map((post) => {
+      // getPostUrl prefixes the locale for every locale but the default one,
+      // so a translated feed links to the translated pages.
+      const link = `${base}${getPostUrl(post.id, locale)}/`;
+      const categories = post.data.tags
+        .map((tag) => `<category>${escapeXml(tag)}</category>`)
+        .join('\n        ');
+
+      return `    <item>
+      <title>${escapeXml(post.data.title)}</title>
+      <link>${link}</link>
+      <guid>${link}</guid>
+      <description>${escapeXml(post.data.description)}</description>
+      <pubDate>${formatRfc822Date(post.data.publishedAt)}</pubDate>
+      <author>${escapeXml(post.data.author)}</author>
+      ${categories}
+    </item>`;
+    })
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(siteConfig.name)}</title>
+    <description>${escapeXml(siteConfig.description)}</description>
+    <link>${base}</link>
+    <atom:link href="${base}${feedPath}" rel="self" type="application/rss+xml"/>
+    <language>${locale}</language>
+    <lastBuildDate>${formatRfc822Date(new Date())}</lastBuildDate>
+${items}
+  </channel>
+</rss>`;
+}

--- a/src/pages/[locale]/rss.xml.ts
+++ b/src/pages/[locale]/rss.xml.ts
@@ -1,0 +1,31 @@
+import type { APIContext } from 'astro';
+import { buildRssFeed } from '@/lib/rss';
+import { getRssUrl, getSecondaryLocales } from '@/lib/blog';
+
+/**
+ * A feed per secondary locale, at `/<locale>/rss.xml`.
+ *
+ * Emits nothing when i18n is off or only one locale is configured, so
+ * single-locale builds are unchanged — the same rule the locale-prefixed blog
+ * routes follow. A locale with no posts yet still gets a feed rather than a
+ * 404, so the link in the page head is never broken.
+ */
+export function getStaticPaths() {
+  return getSecondaryLocales().map((locale) => ({ params: { locale } }));
+}
+
+export async function GET(context: APIContext) {
+  const locale = context.params.locale as string;
+
+  const rss = await buildRssFeed({
+    locale,
+    site: context.site?.toString(),
+    feedPath: getRssUrl(locale),
+  });
+
+  return new Response(rss, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
+}

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,76 +1,19 @@
-import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
-import siteConfig from '@/config/site.config';
-import { getPostSlug } from '@/lib/blog';
+import { buildRssFeed } from '@/lib/rss';
+import { getRssUrl } from '@/lib/blog';
 import { defaultLocale } from '@/i18n';
 
 /**
- * Escapes XML special characters
+ * The default locale's feed, at the site root. Secondary locales get their own
+ * at `/<locale>/rss.xml` — see `src/pages/[locale]/rss.xml.ts`. The XML itself
+ * lives in `lib/rss` so the two routes cannot drift.
  */
-function escapeXml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
-}
-
-/**
- * Formats a date to RFC-822 format for RSS
- */
-function formatRfc822Date(date: Date): string {
-  return date.toUTCString();
-}
-
 export async function GET(context: APIContext) {
-  // Get only the default locale's non-draft posts for RSS
-  const posts = await getCollection('blog', ({ data }) =>
-    data.locale === defaultLocale && !data.draft
-  );
-
-  // Sort posts by date (newest first)
-  const sortedPosts = posts.sort(
-    (a, b) => new Date(b.data.publishedAt).getTime() - new Date(a.data.publishedAt).getTime()
-  );
-
-  // Generate slug from post id (strip the default-locale folder prefix)
-  const getSlug = (id: string) => getPostSlug(id, defaultLocale);
-
-  const site = context.site?.toString() ?? siteConfig.url;
-  const siteUrl = site.endsWith('/') ? site.slice(0, -1) : site;
-
-  const items = sortedPosts
-    .map((post) => {
-      const link = `${siteUrl}/blog/${getSlug(post.id)}/`;
-      const categories = post.data.tags
-        .map((tag) => `<category>${escapeXml(tag)}</category>`)
-        .join('\n        ');
-
-      return `    <item>
-      <title>${escapeXml(post.data.title)}</title>
-      <link>${link}</link>
-      <guid>${link}</guid>
-      <description>${escapeXml(post.data.description)}</description>
-      <pubDate>${formatRfc822Date(post.data.publishedAt)}</pubDate>
-      <author>${escapeXml(post.data.author)}</author>
-      ${categories}
-    </item>`;
-    })
-    .join('\n');
-
-  const rss = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>${escapeXml(siteConfig.name)}</title>
-    <description>${escapeXml(siteConfig.description)}</description>
-    <link>${siteUrl}</link>
-    <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml"/>
-    <language>${defaultLocale}</language>
-    <lastBuildDate>${formatRfc822Date(new Date())}</lastBuildDate>
-${items}
-  </channel>
-</rss>`;
+  const rss = await buildRssFeed({
+    locale: defaultLocale,
+    site: context.site?.toString(),
+    feedPath: getRssUrl(defaultLocale),
+  });
 
   return new Response(rss, {
     headers: {


### PR DESCRIPTION
## What does this PR do?

Two bugs a reader could hit, and the refactor that made both cheap to fix.

### The blog surfaces disagreed with each other

The "Follow along" subscribe block lived inline in three files as five copies. They had drifted:

| page | before |
|---|---|
| `/blog` | mobile CTA **and** desktop LetterGlitch band |
| a single post | mobile CTA **and** desktop band |
| `/blog/page/2` | mobile CTA only — no band, no newsletter form |
| `/blog/tag/…` | nothing at all |

So which subscribe options a reader was offered depended on how they had arrived at the blog, and nothing in the code said so — five copies is exactly how that drift stays invisible.

The first commit moves it into `src/components/blog/FollowAlong.astro`, changing nothing on screen. The second gives all four surfaces the same block, which is now two props and one call site.

### Every locale was offered the same feed

There was one feed. It carried the default locale's posts, linked to `/blog/<slug>` with no locale prefix, and declared `<language>` to match — yet every page in every locale linked to it. A reader on a Dutch page was offered a feed of English posts pointing at English pages.

The XML moves to `src/lib/rss.ts` so both routes share it, and takes a locale, which decides the posts, the item URLs (via `getPostUrl`, so a translated feed links to translated pages) and the `<language>`. `src/pages/[locale]/rss.xml.ts` adds the secondary-locale feeds, guarded by `getSecondaryLocales()` — the same rule the locale-prefixed blog routes already use.

`getRssUrl(locale)` joins the other URL helpers in `lib/blog.ts`. The two places that linked the feed — the pill in `FollowAlong` and the `<link rel="alternate">` in `BaseLayout` — go through it, so no hardcoded `/rss.xml` is left outside the library.

## Type of change

- [x] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [x] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm check` passes with 0 errors
- [x] `pnpm build` completes successfully
- [x] I have tested this change in the browser
- [x] No unnecessary files are included in this PR

Test suite: 13 files, 121 tests, all passing.

## Verification

**The refactor changes nothing.** I built `main`, kept every blog page, then built the extraction and diffed all 73. With per-build random ids (`mobile-menu-…`, `search-modal-…`, `toc-heading-…`) and collapsible whitespace normalised, the rendered output is identical. Two pages differ only in the ordering of inlined scoped CSS, and `/blog/page/2` gains ~200 bytes of `LetterGlitchBand`'s scoped rules because the import is unconditional — selectors that match nothing on that page.

**The feeds were checked by building with i18n temporarily switched on** (`enabled: true`, `locales: ['en', 'nl']`), then restoring the config and confirming the diff against `main` was empty:

| | `/rss.xml` | `/nl/rss.xml` |
|---|---|---|
| exists | yes | yes |
| `<language>` | `en` | `nl` |
| `atom:link` self-reference | `/rss.xml` | `/nl/rss.xml` |
| items | English posts | 0 — no Dutch posts exist in the demo |

The head link follows the page: `/blog` points at `/rss.xml`, `/nl/blog` at `/nl/rss.xml`. An empty feed for a locale with no posts is deliberate and matches what the blog routes already do — a locale with no posts still gets a page so the language switcher never lands on a 404.

**Single-locale builds are unchanged.** Rebuilt with the shipped config (i18n off): only `/rss.xml` is emitted.

## Screenshots (if relevant)

No visual change on any page that already had the block. `/blog/page/2` and `/blog/tag/…` gain the subscribe block they were missing, matching the blog index.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST)_