### PR TITLE
Add the Astro Rocket hero image to the About page

### DIFF
--- a/src/assets/projects/astro-rocket.svg
+++ b/src/assets/projects/astro-rocket.svg
@@ -1,0 +1,352 @@
+<!--
+  Astro Rocket hero — the rocket leaving a horizon.
+
+  Two drawings, one file, the arrangement client-portal.svg uses. The wide one
+  is 1200×520; the tall one is 720×620 and takes over once the image itself
+  renders under 520px. `ProjectImageSVG.astro` does the switching, on a
+  container query rather than a viewport one, and holds every colour.
+
+  Nothing on it but the rocket and the two lines — no facts, no chips, no
+  drawn interface. What fills the frame is depth: a starfield, a fan of light
+  from below the horizon, a glow behind the rocket, and a planet's edge across
+  the foot so the rocket is leaving something rather than floating.
+
+  The tall canvas is not the wide one squeezed. Its horizon sits higher and is
+  drawn on a tighter radius (620×420 against 900×512), because the flatter
+  curve that reads as a planet across 1200 units leaves the frame at an angle
+  across 720 and reads as a stray line. The three bands — sky, lockup, planet
+  — each take roughly a third of the height.
+
+  The rocket is Lucide's `rocket`, the same icon the badges on /astro-rocket
+  use, unrotated — it is drawn on a diagonal with the nose to the upper right,
+  and that is how it reads everywhere else on the site. Its stroke is set in
+  icon units (1.25 of 24) rather than left at Lucide's 2, so the line lands
+  near 5px on screen in both canvases instead of the 8px a proportional stroke
+  would give at this size.
+
+  Type sizes are identical in both canvases. Legibility at narrow widths comes
+  from the canvas being 720 units across instead of 1200, which makes the same
+  36 units a far larger share of it.
+
+  One treatment, both modes — there is no light variant for `sh-` art.
+-->
+
+<!-- ── Wide: 520px of rendered width and up ────────────────────────────────── -->
+<svg class="no-zoom sh-wide" width="1200" height="520" viewBox="0 0 1200 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <pattern id="ar-grid-w" width="60" height="60" patternUnits="userSpaceOnUse">
+      <path d="M60 0 H0 V60" class="sh-grid"/>
+    </pattern>
+    <radialGradient id="ar-burst-w">
+      <stop offset="0%" class="sh-burst-in"/><stop offset="100%" class="sh-burst-out"/>
+    </radialGradient>
+    <linearGradient id="ar-ray-w" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" class="sh-ray-a"/><stop offset="100%" class="sh-ray-b"/>
+    </linearGradient>
+    <radialGradient id="ar-vig-w">
+      <stop offset="55%" class="sh-vig-in"/><stop offset="100%" class="sh-vig-out"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1200" height="520" class="sh-bg"/>
+  <rect width="1200" height="520" fill="url(#ar-grid-w)"/>
+
+    <circle cx="1089.4" cy="471.7" r="1.2" class="sh-star" opacity="0.21"/>
+    <circle cx="377.4" cy="203.0" r="2.0" class="sh-star" opacity="0.28"/>
+    <circle cx="245.2" cy="233.8" r="1.6" class="sh-star" opacity="0.57"/>
+    <circle cx="1062.7" cy="74.0" r="2.6" class="sh-star" opacity="0.45"/>
+    <circle cx="437.6" cy="51.2" r="1.2" class="sh-star" opacity="0.55"/>
+    <circle cx="1142.3" cy="195.2" r="2.0" class="sh-star" opacity="0.78"/>
+    <circle cx="348.0" cy="484.0" r="3.2" class="sh-star" opacity="0.25"/>
+    <circle cx="764.0" cy="109.9" r="1.6" class="sh-star" opacity="0.52"/>
+    <circle cx="799.7" cy="269.5" r="3.2" class="sh-star" opacity="0.27"/>
+    <circle cx="137.6" cy="42.4" r="2.0" class="sh-star" opacity="0.76"/>
+    <circle cx="149.6" cy="448.9" r="3.2" class="sh-star" opacity="0.38"/>
+    <circle cx="919.8" cy="283.1" r="2.0" class="sh-star" opacity="0.29"/>
+    <circle cx="939.9" cy="256.7" r="2.0" class="sh-star" opacity="0.53"/>
+    <circle cx="1082.4" cy="303.8" r="2.6" class="sh-star" opacity="0.3"/>
+    <circle cx="1147.2" cy="50.4" r="2.6" class="sh-star" opacity="0.44"/>
+    <circle cx="211.3" cy="130.5" r="1.2" class="sh-star" opacity="0.78"/>
+    <circle cx="951.3" cy="471.8" r="3.2" class="sh-star" opacity="0.77"/>
+    <circle cx="42.4" cy="396.0" r="2.6" class="sh-star" opacity="0.32"/>
+    <circle cx="111.4" cy="243.9" r="1.6" class="sh-star" opacity="0.65"/>
+    <circle cx="129.6" cy="286.6" r="1.6" class="sh-star" opacity="0.61"/>
+    <circle cx="139.2" cy="101.8" r="1.2" class="sh-star" opacity="0.47"/>
+    <circle cx="418.9" cy="445.2" r="1.6" class="sh-star" opacity="0.74"/>
+    <circle cx="816.3" cy="218.8" r="1.6" class="sh-star" opacity="0.53"/>
+    <circle cx="1015.2" cy="311.8" r="1.2" class="sh-star" opacity="0.7"/>
+    <circle cx="148.9" cy="321.9" r="2.0" class="sh-star" opacity="0.78"/>
+    <circle cx="863.5" cy="227.2" r="1.6" class="sh-star" opacity="0.77"/>
+    <circle cx="114.5" cy="289.3" r="3.2" class="sh-star" opacity="0.27"/>
+    <circle cx="1045.7" cy="476.0" r="2.6" class="sh-star" opacity="0.79"/>
+    <circle cx="337.5" cy="183.6" r="1.2" class="sh-star" opacity="0.67"/>
+    <circle cx="187.4" cy="433.4" r="1.6" class="sh-star" opacity="0.68"/>
+    <circle cx="58.8" cy="333.0" r="2.6" class="sh-star" opacity="0.77"/>
+    <circle cx="712.1" cy="492.2" r="3.2" class="sh-star" opacity="0.31"/>
+    <circle cx="1168.9" cy="130.9" r="1.2" class="sh-star" opacity="0.72"/>
+    <circle cx="360.0" cy="174.9" r="2.0" class="sh-star" opacity="0.68"/>
+    <circle cx="339.3" cy="463.0" r="1.6" class="sh-star" opacity="0.43"/>
+    <circle cx="574.4" cy="285.4" r="2.0" class="sh-star" opacity="0.52"/>
+    <circle cx="820.1" cy="205.3" r="2.0" class="sh-star" opacity="0.79"/>
+    <circle cx="192.5" cy="199.1" r="3.2" class="sh-star" opacity="0.48"/>
+    <circle cx="163.3" cy="291.2" r="2.6" class="sh-star" opacity="0.2"/>
+    <circle cx="66.7" cy="393.5" r="1.2" class="sh-star" opacity="0.35"/>
+    <circle cx="1156.0" cy="323.3" r="1.2" class="sh-star" opacity="0.44"/>
+    <circle cx="115.7" cy="118.6" r="3.2" class="sh-star" opacity="0.29"/>
+    <circle cx="988.7" cy="66.7" r="3.2" class="sh-star" opacity="0.44"/>
+    <circle cx="806.7" cy="162.3" r="1.2" class="sh-star" opacity="0.57"/>
+    <circle cx="71.2" cy="80.8" r="1.6" class="sh-star" opacity="0.79"/>
+    <circle cx="180.8" cy="346.4" r="2.0" class="sh-star" opacity="0.48"/>
+    <circle cx="911.9" cy="411.8" r="3.2" class="sh-star" opacity="0.66"/>
+    <circle cx="142.0" cy="37.8" r="2.0" class="sh-star" opacity="0.26"/>
+    <circle cx="1011.2" cy="121.3" r="2.6" class="sh-star" opacity="0.8"/>
+    <circle cx="896.7" cy="129.0" r="3.2" class="sh-star" opacity="0.72"/>
+    <circle cx="1090.1" cy="171.2" r="1.6" class="sh-star" opacity="0.41"/>
+    <circle cx="1155.2" cy="170.5" r="1.2" class="sh-star" opacity="0.49"/>
+    <circle cx="427.5" cy="123.3" r="3.2" class="sh-star" opacity="0.3"/>
+    <circle cx="387.9" cy="223.5" r="1.2" class="sh-star" opacity="0.39"/>
+    <circle cx="307.3" cy="172.8" r="2.0" class="sh-star" opacity="0.47"/>
+    <circle cx="223.4" cy="411.9" r="3.2" class="sh-star" opacity="0.5"/>
+    <circle cx="42.8" cy="448.1" r="2.6" class="sh-star" opacity="0.69"/>
+    <circle cx="233.3" cy="231.8" r="1.6" class="sh-star" opacity="0.6"/>
+    <circle cx="991.9" cy="208.8" r="2.6" class="sh-star" opacity="0.35"/>
+    <circle cx="873.1" cy="222.9" r="2.0" class="sh-star" opacity="0.78"/>
+    <circle cx="794.0" cy="152.8" r="1.6" class="sh-star" opacity="0.29"/>
+    <circle cx="1157.5" cy="378.6" r="3.2" class="sh-star" opacity="0.48"/>
+    <circle cx="889.1" cy="461.9" r="2.6" class="sh-star" opacity="0.48"/>
+    <circle cx="191.7" cy="326.8" r="2.0" class="sh-star" opacity="0.27"/>
+    <circle cx="44.4" cy="269.5" r="1.6" class="sh-star" opacity="0.52"/>
+    <circle cx="251.3" cy="187.9" r="2.0" class="sh-star" opacity="0.36"/>
+    <circle cx="351.5" cy="256.8" r="3.2" class="sh-star" opacity="0.76"/>
+    <circle cx="875.3" cy="127.9" r="3.2" class="sh-star" opacity="0.67"/>
+    <circle cx="923.3" cy="89.9" r="1.2" class="sh-star" opacity="0.62"/>
+    <circle cx="381.7" cy="142.3" r="3.2" class="sh-star" opacity="0.25"/>
+    <circle cx="117.6" cy="399.4" r="2.6" class="sh-star" opacity="0.77"/>
+    <circle cx="1167.3" cy="329.2" r="1.6" class="sh-star" opacity="0.75"/>
+    <circle cx="780.8" cy="86.2" r="1.6" class="sh-star" opacity="0.49"/>
+    <circle cx="872.4" cy="447.7" r="2.0" class="sh-star" opacity="0.79"/>
+    <circle cx="24.0" cy="406.1" r="1.2" class="sh-star" opacity="0.54"/>
+    <circle cx="942.0" cy="191.0" r="3.2" class="sh-star" opacity="0.76"/>
+    <circle cx="666.5" cy="484.5" r="1.2" class="sh-star" opacity="0.71"/>
+    <circle cx="118.2" cy="178.0" r="3.2" class="sh-star" opacity="0.22"/>
+    <circle cx="215.8" cy="169.0" r="1.2" class="sh-star" opacity="0.29"/>
+    <circle cx="185.1" cy="299.3" r="1.2" class="sh-star" opacity="0.57"/>
+    <circle cx="956.6" cy="270.5" r="3.2" class="sh-star" opacity="0.59"/>
+    <circle cx="715.9" cy="445.1" r="1.6" class="sh-star" opacity="0.7"/>
+    <circle cx="972.2" cy="363.0" r="1.6" class="sh-star" opacity="0.27"/>
+    <circle cx="804.7" cy="202.6" r="2.0" class="sh-star" opacity="0.66"/>
+    <circle cx="138.2" cy="140.9" r="2.0" class="sh-star" opacity="0.58"/>
+    <circle cx="1145.1" cy="69.4" r="1.6" class="sh-star" opacity="0.64"/>
+    <circle cx="199.8" cy="289.1" r="1.2" class="sh-star" opacity="0.66"/>
+    <circle cx="1092.7" cy="149.3" r="1.6" class="sh-star" opacity="0.48"/>
+    <circle cx="921.6" cy="183.4" r="1.2" class="sh-star" opacity="0.68"/>
+    <circle cx="1073.0" cy="396.7" r="1.2" class="sh-star" opacity="0.44"/>
+    <circle cx="791.8" cy="201.6" r="1.2" class="sh-star" opacity="0.3"/>
+    <circle cx="1037.8" cy="469.8" r="1.2" class="sh-star" opacity="0.22"/>
+    <circle cx="1091.9" cy="179.1" r="1.6" class="sh-star" opacity="0.26"/>
+    <circle cx="745.5" cy="478.8" r="2.6" class="sh-star" opacity="0.58"/>
+    <circle cx="1089.6" cy="91.9" r="2.0" class="sh-star" opacity="0.28"/>
+    <circle cx="340.3" cy="280.4" r="3.2" class="sh-star" opacity="0.58"/>
+    <circle cx="1113.3" cy="213.0" r="1.6" class="sh-star" opacity="0.56"/>
+    <circle cx="201.0" cy="29.1" r="2.0" class="sh-star" opacity="0.67"/>
+    <circle cx="656.0" cy="439.1" r="2.6" class="sh-star" opacity="0.41"/>
+    <circle cx="1090.8" cy="392.4" r="1.2" class="sh-star" opacity="0.36"/>
+    <circle cx="158.0" cy="311.8" r="1.6" class="sh-star" opacity="0.74"/>
+    <circle cx="444.7" cy="446.5" r="1.6" class="sh-star" opacity="0.56"/>
+    <circle cx="961.9" cy="271.2" r="2.0" class="sh-star" opacity="0.35"/>
+    <circle cx="1091.7" cy="483.3" r="1.6" class="sh-star" opacity="0.79"/>
+    <circle cx="1156.6" cy="93.9" r="2.0" class="sh-star" opacity="0.65"/>
+    <circle cx="867.1" cy="184.3" r="3.2" class="sh-star" opacity="0.33"/>
+    <circle cx="884.6" cy="448.0" r="3.2" class="sh-star" opacity="0.67"/>
+    <circle cx="158.3" cy="53.1" r="1.2" class="sh-star" opacity="0.31"/>
+    <circle cx="1023.7" cy="158.1" r="1.6" class="sh-star" opacity="0.41"/>
+    <path d="M201 120 H219 M210 111 V129" class="sh-glint"/>
+    <path d="M1002 96 H1018 M1010 88 V104" class="sh-glint"/>
+    <path d="M143 400 H157 M150 393 V407" class="sh-glint"/>
+    <path d="M1051 420 H1069 M1060 411 V429" class="sh-glint"/>
+    <path d="M613 60 H627 M620 53 V67" class="sh-glint"/>
+
+    <path d="M600 520 L 62 40 L 130 40 Z" fill="url(#ar-ray-w)" opacity="0.21"/>
+    <path d="M600 520 L 188 40 L 256 40 Z" fill="url(#ar-ray-w)" opacity="0.25"/>
+    <path d="M600 520 L 314 40 L 382 40 Z" fill="url(#ar-ray-w)" opacity="0.28"/>
+    <path d="M600 520 L 440 40 L 508 40 Z" fill="url(#ar-ray-w)" opacity="0.32"/>
+    <path d="M600 520 L 566 40 L 634 40 Z" fill="url(#ar-ray-w)" opacity="0.36"/>
+    <path d="M600 520 L 692 40 L 760 40 Z" fill="url(#ar-ray-w)" opacity="0.32"/>
+    <path d="M600 520 L 818 40 L 886 40 Z" fill="url(#ar-ray-w)" opacity="0.28"/>
+    <path d="M600 520 L 944 40 L 1012 40 Z" fill="url(#ar-ray-w)" opacity="0.25"/>
+    <path d="M600 520 L 1070 40 L 1138 40 Z" fill="url(#ar-ray-w)" opacity="0.21"/>
+
+  <ellipse cx="600" cy="180" rx="430" ry="310" fill="url(#ar-burst-w)"/>
+
+  <g class="sh-rocket" transform="translate(500 56) scale(8.333333333333334)" stroke-width="1.25">
+      <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09"/>
+      <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z"/>
+      <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05"/>
+  </g>
+
+  <text x="600" y="322" text-anchor="middle" class="sh-kicker">Start building with</text>
+  <text x="600" y="400" text-anchor="middle" class="sh-word">Astro Rocket</text>
+
+  <ellipse cx="600" cy="960" rx="900" ry="512" class="sh-planet"/>
+  <ellipse cx="600" cy="960" rx="900" ry="512" class="sh-atmo-3"/>
+  <ellipse cx="600" cy="960" rx="900" ry="512" class="sh-atmo-2"/>
+  <ellipse cx="600" cy="960" rx="900" ry="512" class="sh-atmo-1"/>
+  <ellipse cx="600" cy="960" rx="900" ry="512" class="sh-horizon"/>
+
+  <rect width="1200" height="520" fill="url(#ar-vig-w)"/>
+
+  <path d="M36 60 V36 H60" class="sh-cor"/>
+  <path d="M1140 36 H1164 V60" class="sh-cor"/>
+  <path d="M36 460 V484 H60" class="sh-cor"/>
+  <path d="M1140 484 H1164 V460" class="sh-cor"/>
+</svg>
+
+<!-- ── Tall: under 520px of rendered width ─────────────────────────────────── -->
+<svg class="no-zoom sh-tall" width="720" height="620" viewBox="0 0 720 620" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <pattern id="ar-grid-t" width="60" height="60" patternUnits="userSpaceOnUse">
+      <path d="M60 0 H0 V60" class="sh-grid"/>
+    </pattern>
+    <radialGradient id="ar-burst-t">
+      <stop offset="0%" class="sh-burst-in"/><stop offset="100%" class="sh-burst-out"/>
+    </radialGradient>
+    <linearGradient id="ar-ray-t" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" class="sh-ray-a"/><stop offset="100%" class="sh-ray-b"/>
+    </linearGradient>
+    <radialGradient id="ar-vig-t">
+      <stop offset="55%" class="sh-vig-in"/><stop offset="100%" class="sh-vig-out"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="720" height="620" class="sh-bg"/>
+  <rect width="720" height="620" fill="url(#ar-grid-t)"/>
+
+    <circle cx="135.6" cy="546.7" r="3.2" class="sh-star" opacity="0.74"/>
+    <circle cx="214.5" cy="182.3" r="3.2" class="sh-star" opacity="0.21"/>
+    <circle cx="191.4" cy="594.8" r="1.2" class="sh-star" opacity="0.46"/>
+    <circle cx="128.2" cy="109.7" r="2.0" class="sh-star" opacity="0.3"/>
+    <circle cx="64.0" cy="472.6" r="1.2" class="sh-star" opacity="0.46"/>
+    <circle cx="72.9" cy="230.0" r="2.6" class="sh-star" opacity="0.28"/>
+    <circle cx="682.6" cy="54.6" r="2.0" class="sh-star" opacity="0.34"/>
+    <circle cx="41.5" cy="354.5" r="2.6" class="sh-star" opacity="0.73"/>
+    <circle cx="592.9" cy="196.4" r="1.6" class="sh-star" opacity="0.26"/>
+    <circle cx="86.8" cy="36.3" r="2.6" class="sh-star" opacity="0.72"/>
+    <circle cx="178.8" cy="73.1" r="1.2" class="sh-star" opacity="0.48"/>
+    <circle cx="513.4" cy="267.5" r="2.0" class="sh-star" opacity="0.52"/>
+    <circle cx="68.2" cy="46.6" r="1.2" class="sh-star" opacity="0.79"/>
+    <circle cx="497.9" cy="535.8" r="2.6" class="sh-star" opacity="0.59"/>
+    <circle cx="305.2" cy="509.3" r="1.6" class="sh-star" opacity="0.33"/>
+    <circle cx="388.3" cy="555.4" r="1.6" class="sh-star" opacity="0.37"/>
+    <circle cx="627.1" cy="210.3" r="3.2" class="sh-star" opacity="0.43"/>
+    <circle cx="515.9" cy="146.6" r="1.6" class="sh-star" opacity="0.33"/>
+    <circle cx="175.6" cy="292.1" r="1.6" class="sh-star" opacity="0.24"/>
+    <circle cx="128.3" cy="212.2" r="1.6" class="sh-star" opacity="0.43"/>
+    <circle cx="508.9" cy="494.5" r="2.6" class="sh-star" opacity="0.56"/>
+    <circle cx="358.5" cy="579.2" r="2.0" class="sh-star" opacity="0.69"/>
+    <circle cx="44.1" cy="361.2" r="1.6" class="sh-star" opacity="0.58"/>
+    <circle cx="550.7" cy="65.0" r="3.2" class="sh-star" opacity="0.6"/>
+    <circle cx="292.3" cy="557.2" r="2.0" class="sh-star" opacity="0.37"/>
+    <circle cx="198.0" cy="241.2" r="1.6" class="sh-star" opacity="0.7"/>
+    <circle cx="607.9" cy="183.8" r="3.2" class="sh-star" opacity="0.45"/>
+    <circle cx="595.8" cy="79.8" r="2.6" class="sh-star" opacity="0.56"/>
+    <circle cx="180.6" cy="128.4" r="2.6" class="sh-star" opacity="0.37"/>
+    <circle cx="190.0" cy="293.7" r="3.2" class="sh-star" opacity="0.7"/>
+    <circle cx="60.5" cy="496.3" r="3.2" class="sh-star" opacity="0.22"/>
+    <circle cx="534.7" cy="135.8" r="2.6" class="sh-star" opacity="0.39"/>
+    <circle cx="607.0" cy="150.9" r="3.2" class="sh-star" opacity="0.51"/>
+    <circle cx="577.5" cy="179.0" r="1.2" class="sh-star" opacity="0.53"/>
+    <circle cx="511.7" cy="49.3" r="2.0" class="sh-star" opacity="0.55"/>
+    <circle cx="151.5" cy="127.3" r="2.6" class="sh-star" opacity="0.25"/>
+    <circle cx="466.7" cy="559.0" r="2.6" class="sh-star" opacity="0.21"/>
+    <circle cx="565.6" cy="335.5" r="2.0" class="sh-star" opacity="0.6"/>
+    <circle cx="529.6" cy="236.9" r="1.6" class="sh-star" opacity="0.25"/>
+    <circle cx="604.6" cy="122.9" r="1.6" class="sh-star" opacity="0.75"/>
+    <circle cx="67.9" cy="32.3" r="2.0" class="sh-star" opacity="0.74"/>
+    <circle cx="234.3" cy="502.6" r="1.6" class="sh-star" opacity="0.23"/>
+    <circle cx="308.8" cy="495.4" r="1.2" class="sh-star" opacity="0.74"/>
+    <circle cx="638.4" cy="575.3" r="2.0" class="sh-star" opacity="0.52"/>
+    <circle cx="651.9" cy="180.6" r="1.6" class="sh-star" opacity="0.65"/>
+    <circle cx="542.9" cy="255.2" r="2.0" class="sh-star" opacity="0.6"/>
+    <circle cx="41.1" cy="181.8" r="1.2" class="sh-star" opacity="0.32"/>
+    <circle cx="192.5" cy="512.2" r="2.0" class="sh-star" opacity="0.37"/>
+    <circle cx="69.3" cy="175.2" r="3.2" class="sh-star" opacity="0.38"/>
+    <circle cx="296.1" cy="335.5" r="1.2" class="sh-star" opacity="0.42"/>
+    <circle cx="663.3" cy="237.7" r="2.6" class="sh-star" opacity="0.56"/>
+    <circle cx="172.6" cy="497.0" r="1.2" class="sh-star" opacity="0.38"/>
+    <circle cx="404.5" cy="574.8" r="3.2" class="sh-star" opacity="0.23"/>
+    <circle cx="592.2" cy="92.5" r="2.6" class="sh-star" opacity="0.47"/>
+    <circle cx="79.3" cy="534.9" r="1.2" class="sh-star" opacity="0.69"/>
+    <circle cx="668.2" cy="580.0" r="1.2" class="sh-star" opacity="0.25"/>
+    <circle cx="675.4" cy="245.9" r="1.2" class="sh-star" opacity="0.29"/>
+    <circle cx="646.3" cy="490.2" r="3.2" class="sh-star" opacity="0.44"/>
+    <circle cx="82.4" cy="506.3" r="3.2" class="sh-star" opacity="0.3"/>
+    <circle cx="560.6" cy="301.6" r="1.2" class="sh-star" opacity="0.35"/>
+    <circle cx="174.3" cy="38.9" r="1.2" class="sh-star" opacity="0.25"/>
+    <circle cx="627.3" cy="559.6" r="2.0" class="sh-star" opacity="0.68"/>
+    <circle cx="666.0" cy="123.8" r="2.0" class="sh-star" opacity="0.29"/>
+    <circle cx="397.3" cy="557.7" r="2.0" class="sh-star" opacity="0.59"/>
+    <circle cx="85.0" cy="588.3" r="2.0" class="sh-star" opacity="0.35"/>
+    <circle cx="74.9" cy="528.1" r="1.2" class="sh-star" opacity="0.77"/>
+    <circle cx="526.0" cy="130.6" r="2.6" class="sh-star" opacity="0.35"/>
+    <circle cx="166.9" cy="297.4" r="2.0" class="sh-star" opacity="0.25"/>
+    <circle cx="537.3" cy="108.8" r="1.2" class="sh-star" opacity="0.21"/>
+    <circle cx="125.8" cy="272.0" r="2.6" class="sh-star" opacity="0.72"/>
+    <circle cx="659.9" cy="491.2" r="2.0" class="sh-star" opacity="0.34"/>
+    <circle cx="218.7" cy="173.1" r="1.6" class="sh-star" opacity="0.79"/>
+    <circle cx="167.6" cy="27.4" r="3.2" class="sh-star" opacity="0.52"/>
+    <circle cx="422.2" cy="552.7" r="3.2" class="sh-star" opacity="0.62"/>
+    <circle cx="454.1" cy="338.9" r="1.2" class="sh-star" opacity="0.21"/>
+    <circle cx="298.4" cy="502.6" r="2.6" class="sh-star" opacity="0.34"/>
+    <circle cx="210.2" cy="43.3" r="2.0" class="sh-star" opacity="0.32"/>
+    <circle cx="256.0" cy="507.9" r="3.2" class="sh-star" opacity="0.58"/>
+    <circle cx="46.8" cy="211.2" r="2.6" class="sh-star" opacity="0.62"/>
+    <circle cx="606.8" cy="52.4" r="3.2" class="sh-star" opacity="0.48"/>
+    <circle cx="306.9" cy="560.6" r="3.2" class="sh-star" opacity="0.47"/>
+    <circle cx="184.1" cy="299.7" r="1.2" class="sh-star" opacity="0.25"/>
+    <circle cx="123.4" cy="53.1" r="2.0" class="sh-star" opacity="0.68"/>
+    <circle cx="45.3" cy="232.1" r="2.6" class="sh-star" opacity="0.78"/>
+    <circle cx="580.5" cy="209.0" r="1.6" class="sh-star" opacity="0.77"/>
+    <circle cx="649.7" cy="141.3" r="1.2" class="sh-star" opacity="0.46"/>
+    <circle cx="28.1" cy="431.1" r="3.2" class="sh-star" opacity="0.79"/>
+    <circle cx="502.7" cy="563.4" r="2.6" class="sh-star" opacity="0.66"/>
+    <circle cx="143.1" cy="584.3" r="1.2" class="sh-star" opacity="0.52"/>
+    <path d="M104 132 H120 M112 124 V140" class="sh-glint"/>
+    <path d="M604 108 H620 M612 100 V116" class="sh-glint"/>
+    <path d="M79 452 H93 M86 445 V459" class="sh-glint"/>
+    <path d="M628 436 H644 M636 428 V444" class="sh-glint"/>
+    <path d="M353 44 H367 M360 37 V51" class="sh-glint"/>
+
+    <path d="M360 620 L 24 40 L 92 40 Z" fill="url(#ar-ray-t)" opacity="0.21"/>
+    <path d="M360 620 L 100 40 L 168 40 Z" fill="url(#ar-ray-t)" opacity="0.25"/>
+    <path d="M360 620 L 175 40 L 243 40 Z" fill="url(#ar-ray-t)" opacity="0.28"/>
+    <path d="M360 620 L 250 40 L 318 40 Z" fill="url(#ar-ray-t)" opacity="0.32"/>
+    <path d="M360 620 L 326 40 L 394 40 Z" fill="url(#ar-ray-t)" opacity="0.36"/>
+    <path d="M360 620 L 402 40 L 470 40 Z" fill="url(#ar-ray-t)" opacity="0.32"/>
+    <path d="M360 620 L 477 40 L 545 40 Z" fill="url(#ar-ray-t)" opacity="0.28"/>
+    <path d="M360 620 L 552 40 L 620 40 Z" fill="url(#ar-ray-t)" opacity="0.25"/>
+    <path d="M360 620 L 628 40 L 696 40 Z" fill="url(#ar-ray-t)" opacity="0.21"/>
+
+  <ellipse cx="360" cy="236" rx="330" ry="300" fill="url(#ar-burst-t)"/>
+
+  <g class="sh-rocket" transform="translate(252 92) scale(9.0)" stroke-width="1.25">
+      <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09"/>
+      <path d="M9 12a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.4 22.4 0 0 1-4 2z"/>
+      <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05"/>
+  </g>
+
+  <text x="360" y="384" text-anchor="middle" class="sh-kicker">Start building with</text>
+  <text x="360" y="462" text-anchor="middle" class="sh-word">Astro Rocket</text>
+
+  <ellipse cx="360" cy="920" rx="620" ry="420" class="sh-planet"/>
+  <ellipse cx="360" cy="920" rx="620" ry="420" class="sh-atmo-3"/>
+  <ellipse cx="360" cy="920" rx="620" ry="420" class="sh-atmo-2"/>
+  <ellipse cx="360" cy="920" rx="620" ry="420" class="sh-atmo-1"/>
+  <ellipse cx="360" cy="920" rx="620" ry="420" class="sh-horizon"/>
+
+  <rect width="720" height="620" fill="url(#ar-vig-t)"/>
+
+  <path d="M36 60 V36 H60" class="sh-cor"/>
+  <path d="M660 36 H684 V60" class="sh-cor"/>
+  <path d="M36 560 V584 H60" class="sh-cor"/>
+  <path d="M660 584 H684 V560" class="sh-cor"/>
+</svg>

--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -18,6 +18,7 @@ import Card from '@/components/ui/data-display/Card/Card.astro';
 import ProofTile from '@/components/ui/data-display/ProofTile/ProofTile.astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import { Hero } from '@/components/hero';
+import ProjectImageSVG from '@/components/projects/ProjectImageSVG.astro';
 import TypingEffect from '@/components/ui/TypingEffect.astro';
 import TechStack from '@/components/landing/TechStack.astro';
 import LetterGlitchBand from '@/components/patterns/LetterGlitchBand.astro';
@@ -83,7 +84,7 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
   description={t('pages.about.meta.description', locale)}
   footerBackground="secondary"
 >
-  <Hero layout="centered" size="sm" class="isolate" showHeroHalo>
+  <Hero layout="centered" size="sm" class="isolate pb-[var(--space-section-md)]" showHeroHalo>
     <Badge slot="badge" variant="brand" pill>
       <Icon name="rocket" size="sm" />
       {hero.badge}
@@ -101,6 +102,38 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
     <p slot="description" class="!text-balance">
       {hero.description}
     </p>
+
+    <!-- Hero's default slot renders directly under the actions, inside the
+         content column, which is `items-center text-center` on a centred
+         layout — so this needs no centring of its own.
+
+         Spacing is the same two-value scale the hero already runs on:
+         --space-section-md at the section edge, carried by the pb override
+         above, and --space-section-gap between the copy and the image.
+         --space-stack-lg is the block value and leaves an image this size
+         crowding the copy; a section-edge value above it would put a
+         boundary-scale gap inside a section.
+
+         The subtraction is why this is a calc rather than the token on its
+         own. Hero gives the description slot mb-[var(--space-stack-lg)],
+         because a row of buttons normally follows it. Nothing does here, so
+         that 32px stacks under the paragraph before this margin even starts,
+         and the token alone renders 80px at desktop and 64px on a phone
+         against the 48 and 32 it is meant to be. Taking --space-stack-lg back
+         off lands the total on the token at every width: 16 + 32 = 48 at
+         desktop, 0 + 32 = 32 on a phone. Delete the subtraction if the
+         paragraph ever gains buttons after it.
+
+         max-w-4xl also decides which of the two canvases renders, because
+         ProjectImageSVG switches on the image's own width rather than the
+         viewport's: 896px keeps the wide one, a phone's ~382px column takes
+         the tall one. -->
+    <div class="mt-[calc(var(--space-section-gap)_-_var(--space-stack-lg))] w-full max-w-4xl mx-auto">
+      <ProjectImageSVG
+        slug="astro-rocket"
+        title="Start building with Astro Rocket — the rocket mark over a lit planet's edge, against a starfield."
+      />
+    </div>
   </Hero>
 
   <!-- What you get -->

--- a/src/components/projects/ProjectImageSVG.astro
+++ b/src/components/projects/ProjectImageSVG.astro
@@ -1,0 +1,239 @@
+---
+/**
+ * ProjectImageSVG — inline, theme-aware SVG hero for a project.
+ *
+ * Mirrors the blog's BlogImageSVG: the SVG is inlined (not served as an
+ * <img>) so its `var(--brand-*)` classes resolve against the live colour
+ * theme — the artwork recolours with all twelve themes and stays sharp at
+ * any size. Set `svgSlug` in a project's frontmatter to use one instead of
+ * a raster hero image; the file lives in `src/assets/projects/<slug>.svg`.
+ *
+ * Vite 8 (shipped with Astro 7) removed the `as: 'raw'` glob option; the
+ * modern `query: '?raw', import: 'default'` form returns the raw SVG markup
+ * as a string. Without it the glob yields module objects that `set:html`
+ * renders as the literal text "[object Module]".
+ */
+const svgs = import.meta.glob<string>('/src/assets/projects/*.svg', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+});
+
+interface Props {
+  slug: string;
+  title: string;
+}
+
+const { slug, title } = Astro.props;
+const svgContent = svgs[`/src/assets/projects/${slug}.svg`] ?? '';
+---
+
+{svgContent && (
+  <div
+    class="svg-host overflow-hidden rounded-xl media-shadow ring-1 ring-black/5 dark:ring-white/10"
+    role="img"
+    aria-label={title}
+    set:html={svgContent}
+  />
+)}
+
+<style>
+  .svg-host :global(svg) {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+
+  /* Same zoom the blog covers use, so an icon and wordmark read at the same
+     weight on a project hero as they do on a post cover. Art that fills its
+     own canvas — a drawn interface rather than an icon and a word — sets
+     `class="no-zoom"` on the root <svg> to keep its edges inside the frame. */
+  .svg-host :global(svg:not(.no-zoom)) {
+    transform: scale(1.35);
+    transform-origin: center center;
+  }
+
+  /* ── Light mode ─────────────────────────────────────────────────────────
+     Brand-600 background with light icons and text on top, matching the
+     blog covers so a project hero and a post cover read as one system.
+  ── */
+  .svg-host :global(.bg)  { fill: var(--brand-600); }
+  .svg-host :global(.ico) { stroke: var(--brand-50); }
+  .svg-host :global(.txt) { fill: var(--brand-50); }
+  .svg-host :global(.ln)  { stroke: var(--brand-200); stroke-opacity: 0.5; }
+  .svg-host :global(.pil) { fill: var(--brand-300); fill-opacity: 0.35; stroke: var(--brand-100); stroke-opacity: 0.8; }
+  .svg-host :global(.ptx) { fill: var(--brand-50); }
+  .svg-host :global(.cor) { stroke: var(--brand-200); stroke-opacity: 0.7; }
+  .svg-host :global(.num) { fill: var(--brand-100); fill-opacity: 0.18; }
+
+  /* ── Dark mode ──────────────────────────────────────────────────────────
+     Same background, brand colours kept vivid rather than faded.
+  ── */
+  :global(html.dark) .svg-host :global(.bg)  { fill: var(--brand-600); }
+  :global(html.dark) .svg-host :global(.ico) { stroke: var(--brand-200); }
+  :global(html.dark) .svg-host :global(.txt) { fill: var(--brand-50); }
+  :global(html.dark) .svg-host :global(.ln)  { stroke: var(--brand-300); stroke-opacity: 0.5; }
+  :global(html.dark) .svg-host :global(.pil) { fill: var(--brand-600); fill-opacity: 0.4; stroke: var(--brand-300); stroke-opacity: 0.7; }
+  :global(html.dark) .svg-host :global(.ptx) { fill: var(--brand-100); }
+  :global(html.dark) .svg-host :global(.cor) { stroke: var(--brand-300); stroke-opacity: 0.6; }
+  :global(html.dark) .svg-host :global(.num) { fill: var(--brand-50); fill-opacity: 0.18; }
+
+  /* ── Drawn-interface art (`sh-` prefix) ──────────────────────────────────
+     A second vocabulary, for SVGs that draw a piece of the product rather
+     than an icon over a wordmark. Prefixed so the two sets never collide:
+     the classes above paint a full-bleed brand background, these paint a
+     tinted canvas with a raised card on it, the same relationship the
+     Astro Rocket hero image uses.
+  ── */
+  /*
+     Two drawings share one file: a wide frame and a portrait one, swapped on
+     the width of the image itself rather than the width of the window. Those
+     are not the same thing here — the media column gives this image 720px at
+     a 768px viewport but only 482px at 1024px, where a two-column layout
+     takes over. A viewport breakpoint would serve the wide frame at its
+     narrowest and the tall frame at its widest.
+
+     Below 520px of rendered width the wide frame's footnote falls under 11px,
+     so the portrait canvas takes over. The type sizes are identical in both;
+     legibility comes from the canvas being 720 units across instead of 1200,
+     which makes the same 24 units a far larger share of it.
+
+     Where container queries are unsupported the wide frame is what shows,
+     since it is the default and the rule below never applies.
+  */
+  .svg-host {
+    container-type: inline-size;
+  }
+  .svg-host :global(.sh-tall) { display: none; }
+  @container (max-width: 519px) {
+    .svg-host :global(.sh-wide) { display: none; }
+    .svg-host :global(.sh-tall) { display: block; }
+  }
+
+  .svg-host :global(.sh-label),
+  .svg-host :global(.sh-placeholder),
+  .svg-host :global(.sh-hint),
+  .svg-host :global(.sh-btnText),
+  .svg-host :global(.sh-note),
+  .svg-host :global(.sh-kicker),
+  .svg-host :global(.sh-word) {
+    font-family: 'Outfit Variable', Outfit, system-ui, -apple-system, sans-serif;
+  }
+  .svg-host :global(.sh-label) { font-size: 30px; font-weight: 600; }
+  .svg-host :global(.sh-placeholder) { font-size: 32px; font-weight: 400; }
+  .svg-host :global(.sh-hint) { font-size: 24px; font-weight: 400; }
+  .svg-host :global(.sh-btnText) { font-size: 32px; font-weight: 700; }
+  .svg-host :global(.sh-note) { font-size: 24px; font-weight: 400; }
+
+  /* Stroke widths are set against the scale each icon is drawn at, not left
+     at Lucide's 2/24. */
+  .svg-host :global(.sh-fieldIcon),
+  .svg-host :global(.sh-btnIcon) {
+    fill: none;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .svg-host :global(.sh-fieldIcon) { stroke-width: 1.6; }
+  .svg-host :global(.sh-btnIcon) { stroke-width: 1.8; }
+
+  /*
+     One treatment, both modes. These are the dark-mode values, and there is
+     no `html.dark` block for `sh-` art: the light version put a white card on
+     a pale canvas, which left the artwork washed out next to the page it sits
+     on. A dark panel on a white page reads as a screen, which is what it is a
+     drawing of.
+
+     Canvas at brand-900, card up at brand-800, field back down again, so the
+     three surfaces keep their order of depth in either mode.
+  */
+  .svg-host :global(.sh-bg) { fill: var(--brand-900); }
+  .svg-host :global(.sh-grid) { fill: none; stroke: var(--brand-500); stroke-opacity: 0.28; stroke-width: 1; }
+  .svg-host :global(.sh-cor) { fill: none; stroke: var(--brand-400); stroke-opacity: 0.6; stroke-width: 2; }
+  .svg-host :global(.sh-glow-in) { stop-color: var(--brand-400); stop-opacity: 0.35; }
+  .svg-host :global(.sh-glow-out) { stop-color: var(--brand-400); stop-opacity: 0; }
+  .svg-host :global(.sh-card) { fill: var(--brand-800); stroke: var(--brand-400); stroke-opacity: 0.45; stroke-width: 1.5; }
+  .svg-host :global(.sh-label) { fill: var(--brand-100); fill-opacity: 0.9; }
+  .svg-host :global(.sh-field) { fill: var(--brand-900); fill-opacity: 0.55; stroke: var(--brand-400); stroke-opacity: 0.75; stroke-width: 1.5; }
+  .svg-host :global(.sh-fieldRing) { fill: none; stroke: var(--brand-400); stroke-opacity: 0.45; stroke-width: 3; }
+  .svg-host :global(.sh-caret) { fill: var(--brand-200); }
+  .svg-host :global(.sh-fieldIcon) { stroke: var(--brand-300); }
+  .svg-host :global(.sh-placeholder) { fill: var(--brand-50); fill-opacity: 0.95; }
+  /* 5.59:1 on the brand-800 card. brand-300 at 0.8 measured 3.83:1, under the
+     4.5:1 this size needs; full-strength brand-200 reaches 7.09:1 but lands
+     level with the label, flattening the order of the card. */
+  .svg-host :global(.sh-hint) { fill: var(--brand-200); fill-opacity: 0.85; }
+  .svg-host :global(.sh-btn) { fill: var(--brand-500); }
+  .svg-host :global(.sh-btnText) { fill: var(--brand-50); }
+  .svg-host :global(.sh-btnIcon) { stroke: var(--brand-50); }
+  .svg-host :global(.sh-note) { fill: var(--brand-200); fill-opacity: 0.85; }
+
+  /* ── Scene art ───────────────────────────────────────────────────────────
+     The second kind of `sh-` drawing: not a piece of the product, but a
+     picture with depth behind a mark and a name. `astro-rocket.svg` uses all
+     of it; `astro-rocket-climb.svg` uses everything except the planet.
+
+     Same rule as the rest of the `sh-` set — one treatment, no html.dark
+     block. These sit on the brand-900 canvas in both modes.
+  ── */
+
+  /* Sky. Stars carry no meaning, so they take the near-white the text does
+     and are separated by opacity, which is set per star in the file. */
+  .svg-host :global(.sh-star) { fill: var(--brand-100); }
+  .svg-host :global(.sh-glint) {
+    stroke: var(--brand-50);
+    stroke-opacity: 0.55;
+    stroke-width: 1.5;
+    stroke-linecap: round;
+  }
+
+  /* Light. The burst sits behind the mark; the rays fan up from beyond the
+     horizon, so they are drawn before the planet and read as coming from
+     behind it. */
+  .svg-host :global(.sh-burst-in) { stop-color: var(--brand-400); stop-opacity: 0.42; }
+  .svg-host :global(.sh-burst-out) { stop-color: var(--brand-400); stop-opacity: 0; }
+  .svg-host :global(.sh-ray-a) { stop-color: var(--brand-300); stop-opacity: 0.26; }
+  .svg-host :global(.sh-ray-b) { stop-color: var(--brand-300); stop-opacity: 0; }
+
+  /* Planet. A gradient across the ellipse put its lit end in a band a few
+     pixels tall — only the top 7% of the shape is on canvas — so the body is
+     a flat fill and the light is three concentric strokes over it. A stroke
+     straddles its path, so half of each lands in the sky: that overspill is
+     what reads as atmosphere.
+
+     Darker than brand-900 on purpose. The canvas is the sky; a planet the
+     same value as the sky has no edge. */
+  .svg-host :global(.sh-planet) { fill: color-mix(in oklch, var(--brand-900) 45%, #000); }
+  .svg-host :global(.sh-atmo-3) { fill: none; stroke: var(--brand-500); stroke-opacity: 0.20; stroke-width: 34; }
+  .svg-host :global(.sh-atmo-2) { fill: none; stroke: var(--brand-400); stroke-opacity: 0.22; stroke-width: 16; }
+  .svg-host :global(.sh-atmo-1) { fill: none; stroke: var(--brand-300); stroke-opacity: 0.28; stroke-width: 7; }
+  .svg-host :global(.sh-horizon) { fill: none; stroke: var(--brand-100); stroke-opacity: 0.9; stroke-width: 2.5; }
+
+  /* Trail, for the climb variant. */
+  .svg-host :global(.sh-trail-a) { stop-color: var(--brand-500); stop-opacity: 0; }
+  .svg-host :global(.sh-trail-b) { stop-color: var(--brand-400); stop-opacity: 0.45; }
+  .svg-host :global(.sh-trail-c) { stop-color: var(--brand-200); stop-opacity: 0.85; }
+  .svg-host :global(.sh-trail-ln) {
+    fill: none;
+    stroke: var(--brand-300);
+    stroke-width: 2.5;
+    stroke-linecap: round;
+  }
+
+  /* Vignette, painted last over everything but the corner brackets. Without
+     it the starfield runs to the edges at the same brightness as the middle
+     and the frame has no centre. */
+  .svg-host :global(.sh-vig-in) { stop-color: var(--brand-900); stop-opacity: 0; }
+  .svg-host :global(.sh-vig-out) { stop-color: color-mix(in oklch, var(--brand-900) 35%, #000); stop-opacity: 0.5; }
+
+  /* The mark and the name. Stroke width is set in the file, in icon units,
+     because the group is scaled up from Lucide's 24×24 and a stroke scales
+     with it. */
+  .svg-host :global(.sh-rocket) {
+    fill: none;
+    stroke: var(--brand-50);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .svg-host :global(.sh-kicker) { font-size: 36px; font-weight: 500; fill: var(--brand-200); }
+  .svg-host :global(.sh-word) { font-size: 76px; font-weight: 700; fill: var(--brand-50); }
+</style>


### PR DESCRIPTION
The same drawing that sits on hansmartens.dev/astro-rocket, and the same host that renders it, ported unchanged: two canvases in one file, 1200×520 and 720×620, swapped by container query at 520px of the image's own rendered width. Nothing on it but Lucide's `rocket` and the two lines, with a starfield, a fan of light from beyond the horizon, a glow behind the mark and a planet's lit edge across the foot.

It carries over with no adaptation. Every colour resolves from --brand-*, which this repo names the same way, and the type uses the Outfit display font both repos ship — so the image recolours with all twelve themes rather than being fixed to one.

ProjectImageSVG.astro is new here. It is not a catalogued component: the site's registry does not list it either, so the theme's count is untouched, and the component-count test passes.

Spacing matches the site exactly, which took a subtraction to reach. Hero gives the description slot mb-[var(--space-stack-lg)], because a row of buttons normally follows it; nothing does here, so that 32px stacks under the paragraph before the image's own margin starts. --space-section-gap on its own rendered 80px at desktop and 64px on a phone, against the 48 and 32 the token is meant to be. Taking --space-stack-lg back off lands the total on the token at every width.

Measured on /about with animations settled, against the site's own figures: 1440px 48 above and 96 below into a 96px section top, 768px 38 and 64 into 64, 430px 32 and 64 into 64. The image renders on the wide canvas at 896px and the tall one at 382px.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
