### PR TITLE
Name the colour themes in the phone hero description too

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -512,7 +512,7 @@
         "titleLine2": "Web Designer",
         "titleLine3": "& Developer",
         "description": "A free, lightning-fast Astro 7 starter theme to build anything on: 44 designed components, 12 colour themes, and dark mode.",
-        "descriptionMobile": "A free, lightning-fast Astro 7 starter theme to build anything on, with 44 designed components.",
+        "descriptionMobile": "A free, lightning-fast Astro 7 starter theme to build anything on: 44 designed components and 12 colour themes.",
         "github": "Get it on GitHub",
         "getStarted": "Get started"
       },

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -512,7 +512,7 @@
         "titleLine2": "Webdesigner",
         "titleLine3": "& Ontwikkelaar",
         "description": "Een gratis, razendsnel Astro 7 starter-thema om alles op te bouwen: 44 ontworpen componenten, 12 kleurthema's en donkere modus.",
-        "descriptionMobile": "Een gratis, razendsnel Astro 7 starter-thema om alles op te bouwen, met 44 ontworpen componenten.",
+        "descriptionMobile": "Een gratis, razendsnel Astro 7 starter-thema om alles op te bouwen: 44 ontworpen componenten en 12 kleurthema's.",
         "github": "Bekijk op GitHub",
         "getStarted": "Aan de slag"
       },


### PR DESCRIPTION
Mobile portrait now reads "A free, lightning-fast Astro 7 starter theme to build anything on: 44 designed components and 12 colour themes." — the desktop line minus dark mode, instead of the shorter components-only version. The Dutch string follows the same shape as its own desktop line.

It costs nothing on the phones it is written for: 3 lines and an identical hero height at 430x932, 412x915, 393x852 and 390x844, the same as before. On 375x667 and 360x640 it takes a fourth line, which adds 30px to a hero that already runs past those screens by about 200px.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
