### PR TITLE
Draw a planet across the foot of the homepage hero

### DIFF
--- a/src/components/effects/HeroScene.astro
+++ b/src/components/effects/HeroScene.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * HeroScene — the homepage hero's horizon.
+ *
+ * A planet's lit edge across the foot of the hero. The gradient wash the hero
+ * already carries is the sky; this draws the curve the sky ends on.
+ *
+ * Every size, phones included. Portrait phones keep the four static stack
+ * logos at the hero's floor and the curve runs behind them.
+ *
+ * Requires a positioned, clipping parent. `.hero-dark-gradient` is
+ * `position: relative` with `isolation: isolate`, and Hero's section is
+ * `overflow-hidden`, so the curve cannot escape the hero.
+ */
+---
+
+<!-- Stretched rather than sliced.
+
+     The curve has to meet the bottom corners of the screen at every size, and
+     a fixed-aspect canvas cannot do that: `slice` crops by a different amount
+     at every aspect, so an ellipse that reaches the corners at 1920×1080 exits
+     the bottom edge 107 units short of them at 1440×900, and goes nearly flat
+     at 768×1024.
+
+     `preserveAspectRatio="none"` makes the curve fill the width exactly, so
+     its ends are the corners by construction. Non-uniform scaling would
+     normally smear the stroke; `vector-effect="non-scaling-stroke"` keeps each
+     rim an even width whatever the box is stretched to. -->
+<svg
+  class="hero-planet"
+  viewBox="0 0 100 100"
+  preserveAspectRatio="none"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
+>
+  <path d="M0 100 Q50 0 100 100 Z" class="hp-body"/>
+  <path d="M0 100 Q50 0 100 100" class="hp-atmo-3" vector-effect="non-scaling-stroke"/>
+  <path d="M0 100 Q50 0 100 100" class="hp-atmo-2" vector-effect="non-scaling-stroke"/>
+  <path d="M0 100 Q50 0 100 100" class="hp-atmo-1" vector-effect="non-scaling-stroke"/>
+  <path d="M0 100 Q50 0 100 100" class="hp-rim" vector-effect="non-scaling-stroke"/>
+</svg>
+
+<style>
+  /* The curve's height is what sets how much planet shows. 15% of the hero
+     leaves the arc shallow on a wide screen; a phone is narrower than it is
+     tall, so the same curve across less width reads steeper, and 11% keeps
+     the two looking alike. */
+  .hero-planet {
+    position: absolute;
+    inset: auto 0 0 0;
+    width: 100%;
+    height: 15%;
+    z-index: 0;
+    pointer-events: none;
+  }
+
+  @media (max-width: 639px) {
+    .hero-planet { height: 11%; }
+  }
+
+  /* Darker than brand-900 on purpose: the wash is the sky, and a planet the
+     same value as the sky has no edge. */
+  .hp-body   { fill: color-mix(in oklch, var(--brand-900) 45%, #000); }
+  .hp-atmo-3 { fill: none; stroke: var(--brand-500); stroke-opacity: 0.18; stroke-width: 46; }
+  .hp-atmo-2 { fill: none; stroke: var(--brand-400); stroke-opacity: 0.20; stroke-width: 22; }
+  .hp-atmo-1 { fill: none; stroke: var(--brand-300); stroke-opacity: 0.26; stroke-width: 9; }
+  .hp-rim    { fill: none; stroke: var(--brand-100); stroke-opacity: 0.85; stroke-width: 3; }
+</style>

--- a/src/components/hero/Hero.astro
+++ b/src/components/hero/Hero.astro
@@ -50,6 +50,9 @@ const hasDescriptionSlot = Astro.slots.has('description');
 const hasActionsSlot = Astro.slots.has('actions');
 const hasAsideSlot = Astro.slots.has('aside');
 const hasBottomSlot = Astro.slots.has('bottom');
+// Rendered first and inside the section, so anything passed in sits behind the
+// content and clips to the hero.
+const hasBackgroundSlot = Astro.slots.has('background');
 
 // Compute alignment based on layout
 const alignment = layout === 'centered' ? 'text-center items-center' : 'text-left items-start';
@@ -94,6 +97,8 @@ const gridClasses = cn(
 ---
 
 <section class={sectionClasses} {...attrs}>
+  {hasBackgroundSlot && <slot name="background" />}
+
   {showHeroHalo && <HeroGrid />}
   {showHeroHalo && <HeroBeam />}
 

--- a/src/components/pages/views/HomeView.astro
+++ b/src/components/pages/views/HomeView.astro
@@ -13,6 +13,7 @@
 import LandingLayout from '@/layouts/LandingLayout.astro';
 import { Hero } from '@/components/hero';
 import HeroRocket from '@/components/effects/HeroRocket.astro';
+import HeroScene from '@/components/effects/HeroScene.astro';
 import Button from '@/components/ui/form/Button/Button.astro';
 import Badge from '@/components/ui/data-display/Badge/Badge.astro';
 import Card from '@/components/ui/data-display/Card/Card.astro';
@@ -154,6 +155,12 @@ const basedInDisplay = `${city ?? 'Your City'}${country ? `, ${country}` : ''}`;
 >
   <!-- Hero -->
   <Hero layout="centered" size="xl" class="hero-dark-gradient" fullHeight>
+    {/* Hero renders the background slot before its content and inside the
+        section, which is `position: relative` with `isolation: isolate` — so
+        the horizon clips to the hero and cannot escape behind the page. The
+        gradient wash stays underneath it. */}
+    <HeroScene slot="background" />
+
     <Fragment slot="badge">
       {/* Zero-height and absolutely positioned, so the badge and everything
           under it stay exactly where they are — see HeroRocket. */}


### PR DESCRIPTION
The same horizon hansmartens.dev carries: a lit curve at the bottom of the hero, with the gradient wash above it as the sky.

Stretched rather than sliced. The curve has to meet both bottom corners at every size and a fixed-aspect canvas cannot do that — `slice` crops by a different amount at every aspect, so an ellipse that reaches the corners at 1920x1080 exits the bottom edge 107 units short of them at 1440x900. `preserveAspectRatio="none"` fills the width exactly, so the ends ARE the corners; `vector-effect="non-scaling-stroke"` keeps the rims even under the non-uniform scale. Measured flush left and right at 1920x1080, 1440x900, 1366x768, 1280x720, 1024x768, 768x1024, 430x932, 390x844, 360x640 and 844x390.

Every size, phones included, and portrait phones keep their four stack logos — the curve runs behind them. 15% of the hero's height on a wide screen, 11% below 640px, because the same curve across less width reads steeper.

Hero gains a `background` slot to carry it: rendered first and inside the section, so the content stays in front and the section's own `overflow-hidden` clips the curve to the hero. Nothing else uses it yet.

Where the hero is taller than the window the foot of the curve falls below the fold — 27px at 390x844, 73px at 1280x720. That is the hero's existing height, not the planet's doing.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
