### PR TITLE
Give the planet the phone screen back

### DIFF
--- a/src/components/pages/views/HomeView.astro
+++ b/src/components/pages/views/HomeView.astro
@@ -206,17 +206,12 @@ const basedInDisplay = `${city ?? 'Your City'}${country ? `, ${country}` : ''}`;
       <div class="hp-hero-marquee" aria-hidden="true">
         <StackMarquee items={heroStackItems} rows={1} duration={55} pauseOnHover={false} linked={false} cardWidth="auto" gap="1rem" />
       </div>
-      <!-- Portrait phone: a static, non-animated row of the four core-stack logos.
-           No marquee machinery — no duplicated track and no infinite animation — so
-           there's zero ongoing compositor/battery cost on mobile. Logos only,
-           non-interactive, with a one-time fade-in to match the marquee's entrance. -->
-      <div class="hp-hero-logos" aria-hidden="true">
-        {heroStackItems.slice(0, 4).map((item) => (
-          <span class="hp-hero-logo">
-            <Icon name={item.icon} size="lg" />
-          </span>
-        ))}
-      </div>
+      <!-- Nothing on portrait phones. There used to be a static row of four
+           core-stack logos here. It cost 80px, and 80px was the difference
+           between the hero fitting the screen and not: at 390x844 the section
+           came out 871px tall, so the planet — which hangs off the section's
+           floor — fell below the fold. The sky is worth more here than a
+           second logo treatment. -->
     </div>
   </Hero>
 
@@ -629,39 +624,6 @@ const basedInDisplay = `${city ?? 'Your City'}${country ? `, ${country}` : ''}`;
     .hp-hero-marquee { display: none; }
   }
 
-  /* Portrait-phone static stack logos — the lightweight counterpart to the
-     marquee. Hidden by default and shown only on portrait phones, exactly where
-     the marquee is hidden. A centered, non-interactive row: no links and no
-     animation loop, so it costs nothing after paint. */
-  .hp-hero-logos {
-    display: none;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-    pointer-events: none;
-  }
-  @media (max-width: 767px) and (orientation: portrait) {
-    .hp-hero-logos { display: flex; padding-bottom: 2rem; }
-  }
-
-  .hp-hero-logo {
-    display: inline-flex;
-    flex: none;
-    align-items: center;
-    justify-content: center;
-    width: 3rem;
-    height: 3rem;
-    border-radius: 9999px;
-    color: var(--color-brand-500);
-    background: color-mix(in oklch, var(--color-brand-500) 12%, transparent);
-  }
-
-  /* One-time fade-in only (reuses the marquee's keyframe); nothing loops. */
-  @media (prefers-reduced-motion: no-preference) {
-    .hp-hero-logos {
-      animation: hp-hero-marquee-fade 0.6s ease-out 1.2s backwards;
-    }
-  }
 </style>
 
 </LandingLayout>


### PR DESCRIPTION
The static row of four core-stack logos is gone from the hero on portrait phones. It cost 80px, and 80px was the difference between the hero fitting the screen and not: at 390x844 the section came out 871px against an 844px viewport, so the planet — which hangs off the section's floor — fell below the fold.

430x932, 412x915, 393x852 and 390x844 now come out exactly one viewport tall with the planet whole. Nothing changes on tablet or desktop, where the row was never shown and the marquee still runs.

Phones shorter than about 700px are not fixed by this: at 375x667 the section is still 817px and at 360x640 it is 811px, because the copy alone does not fit.

Same change hansmartens.dev made earlier.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
