### PR TITLE
Change the drawing's kicker to "Launch your next site with"

### DIFF
--- a/src/assets/projects/astro-rocket.svg
+++ b/src/assets/projects/astro-rocket.svg
@@ -184,7 +184,7 @@
       <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05"/>
   </g>
 
-  <text x="600" y="322" text-anchor="middle" class="sh-kicker">Start building with</text>
+  <text x="600" y="322" text-anchor="middle" class="sh-kicker">Launch your next site with</text>
   <text x="600" y="400" text-anchor="middle" class="sh-word">Astro Rocket</text>
 
   <ellipse cx="600" cy="960" rx="900" ry="512" class="sh-planet"/>
@@ -334,7 +334,7 @@
       <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 .05 5 .05"/>
   </g>
 
-  <text x="360" y="384" text-anchor="middle" class="sh-kicker">Start building with</text>
+  <text x="360" y="384" text-anchor="middle" class="sh-kicker">Launch your next site with</text>
   <text x="360" y="462" text-anchor="middle" class="sh-word">Astro Rocket</text>
 
   <ellipse cx="360" cy="920" rx="620" ry="420" class="sh-planet"/>

--- a/src/components/pages/views/AboutView.astro
+++ b/src/components/pages/views/AboutView.astro
@@ -131,7 +131,7 @@ const cta = tData<{ badge: string; heading: string; description: string; button:
     <div class="mt-[calc(var(--space-section-gap)_-_var(--space-stack-lg))] w-full max-w-4xl mx-auto">
       <ProjectImageSVG
         slug="astro-rocket"
-        title="Start building with Astro Rocket — the rocket mark over a lit planet's edge, against a starfield."
+        title="Launch your next site with Astro Rocket — the rocket mark over a lit planet's edge, against a starfield."
       />
     </div>
   </Hero>


### PR DESCRIPTION
It read "Start building with" on both canvases of astro-rocket.svg. The image's `title` on the About page repeated the old line, so a screen reader would have been given wording the drawing no longer shows; it now matches.

At the kicker's 36px the new line measures 411 units against the wordmark's 450, so it stays the narrower of the two and the pairing holds. Nothing moved: the baselines, the mark and the horizon are where they were, and both canvases were checked on the built page — 394-806 inside the 1200 wide one, 154-566 inside the 720 tall one.

The drawing is the About hero here and also the Astro Rocket project image, so both carry the new line. The "Stop configuring. Start building." headline in CTA.astro is separate copy and is untouched.


Claude-Session: https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
