### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2.4.0] — 2026-08-08
+
+> **This release can stop a build that used to succeed.** If your pages'
+> canonical tags and their JSON-LD name different domains, `verify-site-url`
+> now fails the build and prints both. That output was always wrong; it never
+> announced itself. The usual cause is `SITE_URL` reaching one of the two and
+> not the other — set it in your host's environment variables, where both read
+> it, and the build passes.
+
 ### Fixed
 
 - **`SITE_URL` in a `.env` file now reaches the whole build.** `.env.example` lists it under "Required" and tells you to copy the file to `.env`, and doing that configured half the site: the JSON-LD, share cards and footer took the value, while the canonical tags, sitemap, RSS links and robots.txt kept the `https://example.com` fallback. `astro.config.mjs` runs before Astro loads any `.env` file, so `process.env.SITE_URL` was empty there however the file was written. Nothing failed and nothing looked wrong — and search engines act on canonical tags, so a site could lose its own pages to a domain nobody owns while its author saw a green deploy. The config now loads `.env.local` and `.env` itself before reading anything, in that order, because `process.loadEnvFile` leaves an already-set variable alone and Astro gives `.env.local` precedence. Real environment variables are set before any of it runs, so a host's own configuration still wins. Reported with a full diagnosis and a working fix by [@Mohamed3nan](https://github.com/Mohamed3nan) in [#643](https://github.com/hansmartensdev/astro-rocket/issues/643).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-rocket",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Astro Rocket \u2014 A production-ready Astro 7 theme built on Tailwind CSS v4",
   "type": "module",
   "author": "Hans Martens",


### PR DESCRIPTION
Minor rather than patch: the release adds a build check that did not exist before. Minor rather than major, on this project's precedent — 2.0.0 was the Astro 6 to 7 upgrade, which forced every user to act. Nothing here does.

The release note leads with the one way this can surprise someone: a build that used to succeed can now fail. Only a site whose canonical tags and JSON-LD already named different domains is affected, and that site was publishing wrong canonical tags either way. The note says what to set.

Astro 7.2.0, the .env fix and verify-site-url all land together, and the first of those needs nothing from anyone upgrading.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
