### PR TITLE
Cap commit subjects at 72 characters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,11 @@ trust the theme, so a commit message is part of the product.
   links to an AI session. Some tooling adds these by default — remove them.
 - **Present tense, describing the code after the change.** "Scope demo content
   to the demo deployment", not "Fixed the demo leaking".
+- **Keep the subject line to 72 characters, and prefer 50.** GitHub builds a
+  pull request's title from the subject and cuts it at that length, moving what
+  is left into the description — so an over-long subject opens the pull request
+  with a fragment like "…arsing". The body is where detail belongs; it has no
+  limit.
 
 ## Commands
 


### PR DESCRIPTION
GitHub builds a pull request title from the commit subject and cuts it at that length, pushing the remainder into the description. A subject over the limit opens the pull request with a fragment of its own first line.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
