### PR TITLE
Update the LetterGlitch tutorial to the component it ships

### DIFF
--- a/src/__tests__/letter-glitch-post.test.ts
+++ b/src/__tests__/letter-glitch-post.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The LetterGlitch tutorial publishes the component's whole source in a code
+ * block, so a reader following it copies that block into their own project.
+ *
+ * Between May and August 2026 the component was fixed twice and the post was
+ * not, so the code being handed to readers was two versions behind the code
+ * shipping in the theme — including a performance fault that was reported as
+ * a bug (#646). Nothing failed, because nothing compared them.
+ *
+ * This does. The block has to be the file, character for character.
+ */
+const COMPONENT = fileURLToPath(
+  new URL('../components/effects/LetterGlitch.tsx', import.meta.url)
+);
+const POST = fileURLToPath(
+  new URL('../content/blog/en/letter-glitch-astro-7.mdx', import.meta.url)
+);
+
+/** The first ```tsx block in the post. */
+function publishedSource(markdown: string): string | null {
+  const match = /^```tsx\n([\s\S]*?)^```$/m.exec(markdown);
+  return match ? match[1] : null;
+}
+
+describe('the LetterGlitch tutorial', () => {
+  const post = readFileSync(POST, 'utf8');
+  const component = readFileSync(COMPONENT, 'utf8');
+
+  it('publishes a tsx block', () => {
+    expect(publishedSource(post)).not.toBeNull();
+  });
+
+  it('publishes exactly the component the theme ships', () => {
+    expect(publishedSource(post)).toBe(component);
+  });
+
+  it('does not tell readers the loop is unthrottled', () => {
+    // The post used to say "No throttling beyond requestAnimationFrame",
+    // which stopped being true when the IntersectionObserver was added.
+    expect(post).not.toMatch(/No throttling beyond/i);
+  });
+});

--- a/src/content/blog/en/letter-glitch-astro-7.mdx
+++ b/src/content/blog/en/letter-glitch-astro-7.mdx
@@ -2,6 +2,7 @@
 title: "Add a LetterGlitch Effect to Astro 7"
 description: "How to drop a brand-tinted LetterGlitch canvas effect into an Astro 7 project: the full component, an Astro wrapper, and the production-ready details."
 publishedAt: 2026-05-04
+updatedAt: 2026-08-11
 author: "Hans Martens"
 tags: ["astro-rocket", "astro", "react", "canvas", "tutorial"]
 featured: false
@@ -12,6 +13,13 @@ imageAlt: "A binary-code icon and the word LetterGlitch on a brand-coloured back
 ---
 
 This is the pattern behind Astro Rocket's `LetterGlitchBand` — a field of brand-coloured letters and symbols flickering behind a desktop CTA, with a glass card on top to keep the copy readable. The component ships with the theme, and this post is the full build: how it works, how to drop it into any Astro 7 site, and the small details that make it production-ready.
+
+> **If you copied this component before August 2026, copy it again.** The
+> version published here until now kept the animation loop running while the
+> canvas was off screen, and re-parsed colour strings on every frame. Both are
+> fixed in the code below, and the two notes under it explain what was wrong.
+> Nothing about the effect looks different; it costs a great deal less. The
+> change shipped in Astro Rocket 2.4.1.
 
 ## Credit where it's due
 
@@ -58,6 +66,35 @@ interface LetterGlitchProps {
 const FALLBACK_COLORS = ['#5e4491', '#A476FF', '#241a38'];
 const BRAND_VARS = ['--brand-300', '--brand-600', '--brand-900'];
 
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/**
+ * One cell of the grid.
+ *
+ * Colours are held as numbers rather than CSS strings so a frame can
+ * interpolate with arithmetic instead of parsing. `css` is the string the
+ * canvas needs, rebuilt only on the frames where the colour moves.
+ *
+ * `transitioning` keeps the cell out of the active list twice — see
+ * `activeIndices` below.
+ */
+interface Letter {
+  char: string;
+  r: number;
+  g: number;
+  b: number;
+  targetR: number;
+  targetG: number;
+  targetB: number;
+  colorProgress: number;
+  css: string;
+  transitioning: boolean;
+}
+
 const LetterGlitch = ({
   glitchColors = FALLBACK_COLORS,
   glitchSpeed = 33,
@@ -68,18 +105,31 @@ const LetterGlitch = ({
 }: LetterGlitchProps) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const animationRef = useRef<number | null>(null);
-  const letters = useRef<
-    {
-      char: string;
-      color: string;
-      targetColor: string;
-      colorProgress: number;
-    }[]
-  >([]);
+  const letters = useRef<Letter[]>([]);
+  /**
+   * Indices of the cells whose colour is still moving.
+   *
+   * Around 40% of a grid is mid-transition at any moment with the default
+   * `glitchSpeed`, so scanning every cell each frame to find them was most of
+   * the work the effect did. Entries are removed by swapping in the last one,
+   * which keeps removal O(1) and does not preserve order — nothing here needs
+   * order.
+   */
+  const activeIndices = useRef<number[]>([]);
   const grid = useRef({ columns: 0, rows: 0 });
+  // Cached canvas dimensions — updated only in resizeCanvas (called on init
+  // and on window resize). Reading getBoundingClientRect() per frame from
+  // drawLetters() forced a synchronous layout recompute on every animation
+  // tick (~215ms total reflow time on the homepage per Lighthouse Insights).
+  const dimensions = useRef({ width: 0, height: 0 });
   const context = useRef<CanvasRenderingContext2D | null>(null);
   const lastGlitchTime = useRef(Date.now());
-  const activeColors = useRef<string[]>(glitchColors);
+  /** The palette as numbers, parsed once at mount. */
+  const palette = useRef<Rgb[]>([]);
+  /** The same palette as CSS strings, so an untouched cell allocates nothing. */
+  const paletteCss = useRef<string[]>([]);
+  /** Whether the canvas is in view. The loop does not run when it is not. */
+  const inView = useRef(true);
 
   const fontSize = 16;
   const charWidth = 10;
@@ -93,15 +143,14 @@ const LetterGlitch = ({
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
   ];
 
-  const getRandomChar = () =>
-    lettersAndSymbols[Math.floor(Math.random() * lettersAndSymbols.length)];
-
-  const getRandomColor = () => {
-    const list = activeColors.current;
-    return list[Math.floor(Math.random() * list.length)];
+  const getRandomChar = () => {
+    return lettersAndSymbols[Math.floor(Math.random() * lettersAndSymbols.length)];
   };
 
-  const parseColor = (color: string) => {
+  /** An index into the palette rather than a colour, so nothing is allocated. */
+  const getRandomColorIndex = () => Math.floor(Math.random() * palette.current.length);
+
+  const parseColor = (color: string): Rgb | null => {
     const sixHex = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(color);
     if (sixHex) {
       return {
@@ -129,70 +178,68 @@ const LetterGlitch = ({
     return null;
   };
 
-  const interpolateColor = (
-    start: { r: number; g: number; b: number },
-    end: { r: number; g: number; b: number },
-    factor: number,
-  ) => {
-    const r = Math.round(start.r + (end.r - start.r) * factor);
-    const g = Math.round(start.g + (end.g - start.g) * factor);
-    const b = Math.round(start.b + (end.b - start.b) * factor);
-    return `rgb(${r}, ${g}, ${b})`;
+  /**
+   * Turn the configured colours into numbers once.
+   *
+   * Every colour the effect ever paints is an interpolation between two of
+   * these, so this is the only place a colour string is ever parsed. Anything
+   * unparseable is dropped; if that leaves nothing, the fallback palette is
+   * used, because a grid with no colours draws nothing.
+   */
+  const setPalette = (colors: string[]) => {
+    const parsed = colors.map(parseColor).filter((c): c is Rgb => c !== null);
+    const usable = parsed.length > 0 ? parsed : (FALLBACK_COLORS.map(parseColor) as Rgb[]);
+    palette.current = usable;
+    paletteCss.current = usable.map((c) => `rgb(${c.r}, ${c.g}, ${c.b})`);
   };
 
-  const calculateGrid = (width: number, height: number) => ({
-    columns: Math.ceil(width / charWidth),
-    rows: Math.ceil(height / charHeight),
-  });
+  const calculateGrid = (width: number, height: number) => {
+    const columns = Math.ceil(width / charWidth);
+    const rows = Math.ceil(height / charHeight);
+    return { columns, rows };
+  };
 
   const initializeLetters = (columns: number, rows: number) => {
     grid.current = { columns, rows };
+    activeIndices.current = [];
     const totalLetters = columns * rows;
-    letters.current = Array.from({ length: totalLetters }, () => ({
-      char: getRandomChar(),
-      color: getRandomColor(),
-      targetColor: getRandomColor(),
-      colorProgress: 1,
-    }));
+    letters.current = Array.from({ length: totalLetters }, () => {
+      const from = getRandomColorIndex();
+      const to = getRandomColorIndex();
+      const start = palette.current[from];
+      const target = palette.current[to];
+      return {
+        char: getRandomChar(),
+        r: start.r,
+        g: start.g,
+        b: start.b,
+        targetR: target.r,
+        targetG: target.g,
+        targetB: target.b,
+        colorProgress: 1,
+        css: paletteCss.current[from],
+        transitioning: false,
+      };
+    });
   };
 
   const drawLetters = () => {
     if (!context.current || letters.current.length === 0) return;
     const ctx = context.current;
-    const { width, height } = canvasRef.current!.getBoundingClientRect();
+    const { width, height } = dimensions.current;
     ctx.clearRect(0, 0, width, height);
     ctx.font = `${fontSize}px monospace`;
     ctx.textBaseline = 'top';
 
-    letters.current.forEach((letter, index) => {
-      const x = (index % grid.current.columns) * charWidth;
-      const y = Math.floor(index / grid.current.columns) * charHeight;
-      ctx.fillStyle = letter.color;
+    const columns = grid.current.columns;
+    const all = letters.current;
+    for (let index = 0; index < all.length; index++) {
+      const letter = all[index];
+      const x = (index % columns) * charWidth;
+      const y = Math.floor(index / columns) * charHeight;
+      ctx.fillStyle = letter.css;
       ctx.fillText(letter.char, x, y);
-    });
-  };
-
-  const resizeCanvas = () => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const parent = canvas.parentElement;
-    if (!parent) return;
-
-    const dpr = window.devicePixelRatio || 1;
-    const rect = parent.getBoundingClientRect();
-
-    canvas.width = rect.width * dpr;
-    canvas.height = rect.height * dpr;
-    canvas.style.width = `${rect.width}px`;
-    canvas.style.height = `${rect.height}px`;
-
-    if (context.current) {
-      context.current.setTransform(dpr, 0, 0, dpr, 0, 0);
     }
-
-    const { columns, rows } = calculateGrid(rect.width, rect.height);
-    initializeLetters(columns, rows);
-    drawLetters();
   };
 
   const updateLetters = () => {
@@ -202,35 +249,66 @@ const LetterGlitch = ({
 
     for (let i = 0; i < updateCount; i++) {
       const index = Math.floor(Math.random() * letters.current.length);
-      if (!letters.current[index]) continue;
+      const letter = letters.current[index];
+      if (!letter) continue;
 
-      letters.current[index].char = getRandomChar();
-      letters.current[index].targetColor = getRandomColor();
+      const to = getRandomColorIndex();
+      const target = palette.current[to];
+
+      letter.char = getRandomChar();
+      letter.targetR = target.r;
+      letter.targetG = target.g;
+      letter.targetB = target.b;
 
       if (!smooth) {
-        letters.current[index].color = letters.current[index].targetColor;
-        letters.current[index].colorProgress = 1;
+        letter.r = target.r;
+        letter.g = target.g;
+        letter.b = target.b;
+        letter.colorProgress = 1;
+        letter.css = paletteCss.current[to];
       } else {
-        letters.current[index].colorProgress = 0;
+        letter.colorProgress = 0;
+        // A cell already in the list keeps its single entry and simply
+        // restarts, so the list can never hold a duplicate.
+        if (!letter.transitioning) {
+          letter.transitioning = true;
+          activeIndices.current.push(index);
+        }
       }
     }
   };
 
   const handleSmoothTransitions = () => {
-    let needsRedraw = false;
-    letters.current.forEach((letter) => {
-      if (letter.colorProgress < 1) {
-        letter.colorProgress += 0.05;
-        if (letter.colorProgress > 1) letter.colorProgress = 1;
+    const active = activeIndices.current;
+    if (active.length === 0) return;
 
-        const startRgb = parseColor(letter.color);
-        const endRgb = parseColor(letter.targetColor);
-        if (startRgb && endRgb) {
-          letter.color = interpolateColor(startRgb, endRgb, letter.colorProgress);
-          needsRedraw = true;
-        }
+    const all = letters.current;
+    let needsRedraw = false;
+
+    for (let i = active.length - 1; i >= 0; i--) {
+      const letter = all[active[i]];
+      if (!letter) {
+        active[i] = active[active.length - 1];
+        active.pop();
+        continue;
       }
-    });
+
+      letter.colorProgress += 0.05;
+      if (letter.colorProgress >= 1) letter.colorProgress = 1;
+
+      const factor = letter.colorProgress;
+      letter.r = Math.round(letter.r + (letter.targetR - letter.r) * factor);
+      letter.g = Math.round(letter.g + (letter.targetG - letter.g) * factor);
+      letter.b = Math.round(letter.b + (letter.targetB - letter.b) * factor);
+      letter.css = `rgb(${letter.r}, ${letter.g}, ${letter.b})`;
+      needsRedraw = true;
+
+      if (letter.colorProgress === 1) {
+        letter.transitioning = false;
+        active[i] = active[active.length - 1];
+        active.pop();
+      }
+    }
 
     if (needsRedraw) {
       drawLetters();
@@ -244,10 +322,40 @@ const LetterGlitch = ({
       drawLetters();
       lastGlitchTime.current = now;
     }
+
     if (smooth) {
       handleSmoothTransitions();
     }
+
     animationRef.current = requestAnimationFrame(animate);
+  };
+
+  const resizeCanvas = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const parent = canvas.parentElement;
+    if (!parent) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const rect = parent.getBoundingClientRect();
+
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+
+    // Cache so drawLetters can use these on every frame without forcing
+    // a fresh layout read.
+    dimensions.current = { width: rect.width, height: rect.height };
+
+    if (context.current) {
+      context.current.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    const { columns, rows } = calculateGrid(rect.width, rect.height);
+    initializeLetters(columns, rows);
+    drawLetters();
   };
 
   // Resolves brand tokens (e.g. --brand-500: oklch(...)) to plain rgb(r,g,b)
@@ -280,12 +388,12 @@ const LetterGlitch = ({
 
     context.current = canvas.getContext('2d');
 
+    let colors = glitchColors;
     if (useBrandTokens) {
       const brand = resolveBrandColors();
-      if (brand.length > 0) {
-        activeColors.current = brand;
-      }
+      if (brand.length > 0) colors = brand;
     }
+    setPalette(colors);
 
     resizeCanvas();
 
@@ -293,33 +401,65 @@ const LetterGlitch = ({
       typeof window !== 'undefined' &&
       window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    if (!prefersReducedMotion) {
+    const stop = () => {
+      if (animationRef.current !== null) {
+        cancelAnimationFrame(animationRef.current);
+        animationRef.current = null;
+      }
+    };
+
+    const start = () => {
+      if (prefersReducedMotion || animationRef.current !== null) return;
+      // The loop times itself from this instant, so a restart does not fire a
+      // burst of catch-up glitches for the time it spent off screen.
+      lastGlitchTime.current = Date.now();
       animate();
+    };
+
+    /**
+     * The effect is decorative and usually sits at the foot of a page, where
+     * it ran for the whole visit while the reader was somewhere else. It only
+     * runs while it is on screen now.
+     *
+     * Without IntersectionObserver — no browser the theme supports, but the
+     * component also renders in tests and other non-browser hosts — it runs
+     * as before rather than not at all.
+     */
+    let observer: IntersectionObserver | null = null;
+    if (typeof IntersectionObserver !== 'undefined') {
+      observer = new IntersectionObserver(
+        (entries) => {
+          const visible = entries.some((entry) => entry.isIntersecting);
+          inView.current = visible;
+          if (visible) start();
+          else stop();
+        },
+        { rootMargin: '100px' },
+      );
+      observer.observe(canvas);
+    } else {
+      start();
     }
 
     let resizeTimeout: ReturnType<typeof setTimeout>;
+
     const handleResize = () => {
       clearTimeout(resizeTimeout);
       resizeTimeout = setTimeout(() => {
-        if (animationRef.current !== null) {
-          cancelAnimationFrame(animationRef.current);
-        }
+        stop();
         resizeCanvas();
-        if (!prefersReducedMotion) {
-          animate();
-        }
+        if (inView.current) start();
       }, 100);
     };
 
     window.addEventListener('resize', handleResize);
 
     return () => {
-      if (animationRef.current !== null) {
-        cancelAnimationFrame(animationRef.current);
-      }
+      stop();
+      clearTimeout(resizeTimeout);
+      observer?.disconnect();
       window.removeEventListener('resize', handleResize);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [glitchSpeed, smooth, useBrandTokens]);
 
   return (
@@ -338,13 +478,19 @@ const LetterGlitch = ({
 export default LetterGlitch;
 ```
 
-Three things in there are worth pausing on.
+Four things in there are worth pausing on, and two of them are there because the first version of this component got them wrong.
 
 **The brand-token resolver.** Canvas 2D's `fillStyle` accepts any CSS colour — including OKLCH — but the smooth-transition step needs `{ r, g, b }` triples to lerp between. The trick is a 1×1 helper canvas: set its `fillStyle` to the raw `oklch(...)` string from your CSS variable, paint a single pixel, read it back with `getImageData`. The browser handles the OKLCH → sRGB conversion in C++ and hands you integer RGB channels. Works for any colour the browser can paint, not just OKLCH.
 
 **The reduced-motion guard.** Constant glitching is exactly what `prefers-reduced-motion: reduce` exists to silence. The component reads the preference once on mount and skips `animate()` if it's set — a single static frame of the grid still draws, so the visual still has the right colours and shape, it just doesn't loop.
 
-**No throttling beyond `requestAnimationFrame`.** The animation cost scales with the canvas area (more cells = more letters), which is one reason you'll want to gate it on viewport size.
+**The loop stops when the canvas leaves the viewport.** An `IntersectionObserver` starts it on entry and cancels it on exit. This effect belongs at the foot of a long page, which means that without the observer it animates for the entire time a reader spends above it — and that cost lands on the main thread beside every other animation on the page. The glitch timer resets on restart, so scrolling back does not fire a burst of catch-up frames.
+
+There is a lesson in how long that took to notice. The component is mounted with `client:visible`, which is itself an `IntersectionObserver` — so the observer was already there for *mounting* and never for *running*. Once mounted, the loop ran until the page was closed. A decorative animation that is correct in every visible respect can still be expensive in a way nothing on screen reveals.
+
+**Colours are numbers, not strings.** The obvious way to write the transition step is to keep each cell's colour as the CSS string the canvas wants, and parse it back to channels when interpolating. That is what the first version did, and it meant re-parsing two colour strings per moving cell per frame — with the default `glitchSpeed`, around 40% of the grid is mid-transition at any moment, and an interpolated colour is an `rgb()` string, so each parse failed both hex patterns before matching. The palette is parsed once at mount instead; cells carry their channels with a cached string, and interpolation is arithmetic. The cells whose colour is moving are tracked in a list too, rather than found by scanning the whole grid every frame.
+
+If you take one thing from this section, take that one: a representation convenient at the boundary is not automatically the right one to compute with.
 
 ## Step 3 — Wrap it in an Astro pattern component
 
@@ -450,11 +596,11 @@ That also lets you drop `centerVignette` from the `<LetterGlitch>` props — the
 
 The `glitch:` breakpoint isn't a placeholder for "not optimised for mobile yet." In Astro Rocket the canvas is deliberately desktop-and-fine-pointer-only. Three reasons, in order of weight:
 
-**Lighthouse mobile Performance.** Every feature in Astro Rocket gets weighed against its Lighthouse score before it ships, because the theme keeps 100/100/100/100 on both desktop and mobile deliberately. The mobile LetterGlitch was on the table for a while; running the canvas on a phone-sized viewport cost roughly 2 Performance points and would have broken the perfect mobile score. Two points isn't nothing — and the visual didn't earn them, so it stayed off.
+**Lighthouse mobile Performance.** Every feature in Astro Rocket gets weighed against its Lighthouse score before it ships, because the theme keeps 100/100/100/100 on both desktop and mobile deliberately. The mobile LetterGlitch was on the table for a while; running the canvas on a phone-sized viewport cost roughly 2 Performance points and would have broken the perfect mobile score. That measurement predates the work described above, so the cost today is lower — but the two reasons below stand on their own, and the visual still doesn't earn a phone's battery.
 
 **The composition doesn't survive narrow widths.** The pattern is a contained `max-w-6xl` band with a glass card centred inside. On a 390px screen the band collapses to nearly the full viewport, the rounded corners crowd the headline, and the glass card has nowhere to breathe. The canvas reads as cramped instead of confident — the exact opposite of what a CTA section should feel like.
 
-**The per-frame work scales with cell count.** A 10×20px cell grid that's narrow enough to fit a phone still has to redraw on every frame, with the smooth-transition pass running an interpolation per cycling letter on top. It's not a disaster, but it's the kind of work I'd rather *not* be doing on a battery-powered device while a visitor is reading a CTA.
+**The per-frame work scales with cell count.** A 10×20px cell grid that's narrow enough to fit a phone still redraws on every frame. The transition pass is far cheaper than it used to be — see the two notes under the component above — but redrawing the grid is redrawing the grid, and it's the kind of work I'd rather *not* be doing on a battery-powered device while a visitor is reading a CTA.
 
 The mobile fallback is a flat centred CTA section — the same headline and buttons, on the page background, no canvas and no card. The rhythm of the page survives; the cost doesn't. That same logic gates the cursor trail (desktop, fine pointer, no reduced-motion), the heavier reveal animations, and a few other effects: if the fancy version doesn't earn its keep on a phone, the phone gets the quiet version. This is the choice I'd make again on every project.
 


### PR DESCRIPTION
The post publishes the component's whole source, so a reader following it copies that block into their own project. The block was two versions behind: it still read the canvas size on every frame, and it carried the loop that ran off screen and re-parsed colour strings, reported as #646. Anyone who followed this tutorial has the slowest version of the component.

The block is now the file. A test compares them, because the drift went unnoticed for three months and nothing was comparing them.

The three notes under the block become four. "No throttling beyond requestAnimationFrame" stopped being true when the IntersectionObserver was added, and the two faults are worth teaching: the observer that was already there for mounting and not for running, and a colour representation chosen for the boundary rather than for the arithmetic.

Two claims further down rested on the old cost. The Lighthouse figure is labelled as predating the work, and the per-frame argument for keeping the canvas off phones now rests on redrawing rather than on the transition pass.

A note near the top tells anyone who copied the old code to copy it again.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
