### PR TITLE
Publish the LetterGlitch wrapper the theme actually ships

### DIFF
--- a/src/__tests__/letter-glitch-post.test.ts
+++ b/src/__tests__/letter-glitch-post.test.ts
@@ -3,39 +3,44 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 /**
- * The LetterGlitch tutorial publishes the component's whole source in a code
- * block, so a reader following it copies that block into their own project.
+ * The LetterGlitch tutorial publishes two whole files in code blocks — the
+ * React canvas component and the Astro wrapper around it — so a reader
+ * following it copies both into their own project.
  *
- * Between May and August 2026 the component was fixed twice and the post was
- * not, so the code being handed to readers was two versions behind the code
- * shipping in the theme — including a performance fault that was reported as
- * a bug (#646). Nothing failed, because nothing compared them.
+ * Both had drifted. The component was two versions behind, carrying the fault
+ * reported as #646 and a per-frame layout read fixed before that. The wrapper
+ * was missing a `maxWidth` prop and the whole shadow treatment. Nothing
+ * failed, because nothing compared them.
  *
- * This does. The block has to be the file, character for character.
+ * This does. Each block has to be its file, character for character.
  */
-const COMPONENT = fileURLToPath(
-  new URL('../components/effects/LetterGlitch.tsx', import.meta.url)
-);
+const files = {
+  component: '../components/effects/LetterGlitch.tsx',
+  wrapper: '../components/patterns/LetterGlitchBand.astro',
+} as const;
+
 const POST = fileURLToPath(
   new URL('../content/blog/en/letter-glitch-astro-7.mdx', import.meta.url)
 );
 
-/** The first ```tsx block in the post. */
-function publishedSource(markdown: string): string | null {
-  const match = /^```tsx\n([\s\S]*?)^```$/m.exec(markdown);
+/** The first fenced block of a given language in the post. */
+function publishedSource(markdown: string, lang: string): string | null {
+  const fence = new RegExp(`^\`\`\`${lang}\\n([\\s\\S]*?)^\`\`\`$`, 'm');
+  const match = fence.exec(markdown);
   return match ? match[1] : null;
 }
 
 describe('the LetterGlitch tutorial', () => {
   const post = readFileSync(POST, 'utf8');
-  const component = readFileSync(COMPONENT, 'utf8');
-
-  it('publishes a tsx block', () => {
-    expect(publishedSource(post)).not.toBeNull();
-  });
+  const read = (rel: string) =>
+    readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
 
   it('publishes exactly the component the theme ships', () => {
-    expect(publishedSource(post)).toBe(component);
+    expect(publishedSource(post, 'tsx')).toBe(read(files.component));
+  });
+
+  it('publishes exactly the wrapper the theme ships', () => {
+    expect(publishedSource(post, 'astro')).toBe(read(files.wrapper));
   });
 
   it('does not tell readers the loop is unthrottled', () => {

--- a/src/content/blog/en/letter-glitch-astro-7.mdx
+++ b/src/content/blog/en/letter-glitch-astro-7.mdx
@@ -499,27 +499,57 @@ The canvas alone isn't enough. You also need:
 - A contained band so it doesn't go full-bleed
 - An overlay glass card so headline copy stays readable
 - A breakpoint gate so it only renders on desktop with a real pointer
+- A shadow that works against a near-black band in both colour modes
 
-I package all three into a single Astro file. Save this as `src/components/patterns/LetterGlitchBand.astro`:
+I package all four into a single Astro file. Save this as `src/components/patterns/LetterGlitchBand.astro`:
 
 ```astro
 ---
 import LetterGlitch from '@/components/effects/LetterGlitch';
+
+interface Props {
+  maxWidth?: '6xl' | '7xl';
+}
+
+const { maxWidth = '6xl' } = Astro.props;
+
+const maxWidthClass = maxWidth === '7xl' ? 'max-w-7xl' : 'max-w-6xl';
 ---
 
-<div class="hidden glitch:block mx-auto max-w-6xl px-6">
-  <div class="invert-section relative overflow-hidden rounded-3xl border border-white/10">
-    <div class="absolute inset-0" aria-hidden="true">
-      <LetterGlitch client:visible outerVignette />
-    </div>
-    <div class="relative z-10 px-6 py-16 sm:py-24" data-reveal>
-      <div class="mx-auto max-w-2xl rounded-2xl border border-white/10 bg-brand-900/85 px-6 py-10 sm:px-10 text-center shadow-xl backdrop-blur-md">
-        <slot />
+<div class:list={['hidden glitch:block mx-auto px-6', maxWidthClass]}>
+  <div class="relative isolate">
+    <div class="lgb-band invert-section relative overflow-hidden rounded-3xl bg-background border border-transparent dark:border-white/10">
+      <div class="absolute inset-0" aria-hidden="true">
+        <LetterGlitch client:visible outerVignette />
+      </div>
+      <div class="relative z-10 px-6 py-16 sm:py-24" data-reveal>
+        <div class="mx-auto max-w-2xl rounded-2xl border border-white/10 bg-brand-900/85 px-6 py-10 sm:px-10 text-center shadow-xl backdrop-blur-md">
+          <slot />
+        </div>
       </div>
     </div>
   </div>
 </div>
+
+<style>
+  /* The band is near-black, so the theme's shadow tiers (a ~14% grey wash)
+     can't register against its high-contrast edge. Light mode gets a heavy
+     drop shadow; dark mode gets a brand glow instead — a dark shadow can
+     never show on a dark page, but a glow can. */
+  .lgb-band {
+    box-shadow:
+      0 32px 64px -12px rgb(0 0 0 / 0.55),
+      0 0 32px -4px rgb(0 0 0 / 0.25);
+  }
+  :global(html.dark) .lgb-band {
+    box-shadow:
+      0 0 48px -6px color-mix(in oklab, var(--color-brand-500) 35%, transparent),
+      0 24px 48px -12px rgb(0 0 0 / 0.6);
+  }
+</style>
 ```
+
+Two details worth noting. `maxWidth` lets a page choose between a `6xl` and a `7xl` band, so the CTA can match whatever container it sits under. And the shadow is written by hand rather than taken from the theme's tiers: those are a grey wash of around 14%, which cannot register against an edge this dark. Light mode gets a heavy drop shadow; dark mode gets a brand-coloured glow, because a dark shadow can never show on a dark page but a glow can.
 
 The `glitch:` prefix is a custom Tailwind v4 variant I define once in `src/styles/global.css`:
 


### PR DESCRIPTION
The tutorial publishes two whole files, not one. The Astro wrapper had drifted as well: no maxWidth prop, no isolation wrapper, and none of the shadow treatment, so a reader copying it got a band with no shadow at all in either colour mode.

The block is now the file, the test covers both blocks, and the prose lists the four things the wrapper packages rather than three.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
