### PR TITLE
Run the tests in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,13 +8,14 @@ on:
 
 jobs:
   quality:
-    name: Lint and type check
+    name: Lint, type check and tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # No version here on purpose: pnpm/action-setup reads `packageManager`
+      # from package.json, so CI, Docker and a developer's machine cannot
+      # drift onto three different pnpm versions.
       - uses: pnpm/action-setup@v3
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -22,6 +23,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
       - run: pnpm run check
+      - run: pnpm run test:run
 
   # Every deploy target gets built and inspected.
   #
@@ -40,9 +42,10 @@ jobs:
         target: [vercel, netlify, cloudflare]
     steps:
       - uses: actions/checkout@v4
+      # No version here on purpose: pnpm/action-setup reads `packageManager`
+      # from package.json, so CI, Docker and a developer's machine cannot
+      # drift onto three different pnpm versions.
       - uses: pnpm/action-setup@v3
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://astro.build"><img src="https://img.shields.io/badge/Astro-7.0-bc52ee?logo=astro&logoColor=white" alt="Astro" /></a>
   <a href="https://tailwindcss.com"><img src="https://img.shields.io/badge/Tailwind-4.0-38bdf8?logo=tailwindcss&logoColor=white" alt="Tailwind CSS" /></a>
   <a href="https://www.typescriptlang.org"><img src="https://img.shields.io/badge/TypeScript-5.7-3178c6?logo=typescript&logoColor=white" alt="TypeScript" /></a>
+  <a href="https://github.com/hansmartensdev/astro-rocket/actions/workflows/deploy.yml"><img src="https://github.com/hansmartensdev/astro-rocket/actions/workflows/deploy.yml/badge.svg" alt="Build, lint, type check and tests" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-22c55e" alt="License" /></a>
   <a href="https://github.com/hansmartensdev/astro-rocket"><img src="https://img.shields.io/github/stars/hansmartensdev/astro-rocket?style=flat&label=%E2%AD%90%20Star%20on%20GitHub&color=f59e0b" alt="Star on GitHub" /></a>
   <a href="https://github.com/hansmartensdev/astro-rocket"><img src="https://visitor-badge.laobi.icu/badge?page_id=hansmartensdev.astro-rocket" alt="Visitors" /></a>
@@ -301,8 +302,10 @@ astro-rocket/
 | `pnpm lint:fix` | Fix ESLint issues |
 | `pnpm format` | Format code with Prettier |
 | `pnpm format:check` | Check code formatting |
-| `pnpm test` | Run Vitest tests |
+| `pnpm test` | Run Vitest tests, watching for changes |
+| `pnpm test:run` | Run Vitest once and exit — what CI runs |
 | `pnpm test:e2e` | Run Playwright E2E tests |
+| `pnpm validate` | Everything CI runs: lint, types, tests, build, output check |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "astro-rocket",
   "version": "2.4.1",
+  "packageManager": "pnpm@10.33.0",
   "description": "Astro Rocket \u2014 A production-ready Astro 7 theme built on Tailwind CSS v4",
   "type": "module",
   "author": "Hans Martens",
@@ -37,8 +38,9 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "validate": "pnpm lint && pnpm check && pnpm build && pnpm verify",
+    "validate": "pnpm lint && pnpm check && pnpm test:run && pnpm build && pnpm verify",
     "test": "vitest",
+    "test:run": "vitest run",
     "test:e2e": "playwright test"
   },
   "dependencies": {


### PR DESCRIPTION
The workflow ran lint and check. It never ran the tests, and neither did the validate script, so 136 tests only ran when somebody typed the command. Every guarantee the theme's suite encodes was unenforced between commits — the site-url agreement, the component count, and the check added this week that stops the LetterGlitch tutorial drifting from the component it publishes.

test:run is vitest without the watcher, so CI and validate both terminate. validate runs it before the build, because two seconds of tests should fail ahead of twenty seconds of building.

pnpm is pinned once, in packageManager, and the workflow's explicit version is removed so pnpm/action-setup reads it from there. CI was on 9 while the lockfile was written by 10.33; three environments each choosing for themselves is how the version drifts.

The README gains the build badge, which now means the tests passed rather than only the linter, and the commands table lists test:run and validate.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
