### PR TITLE
Add a Docker preview of the built site

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,55 @@
+# Everything the build does not need, so the context stays small and a code
+# edit does not invalidate the dependency layer.
+
+# Git
+.git
+.github
+
+# Dependencies and build output — reinstalled and rebuilt inside the image
+node_modules/
+dist/
+.astro/
+.vercel/
+.netlify/
+.wrangler/
+public/pagefind/
+
+# Docker's own files
+Dockerfile
+compose.yml
+.dockerignore
+
+# Secrets never belong in a build context
+.env
+.env.local
+.env.*.local
+
+# Editor and OS
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+*.swp
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Testing
+coverage/
+playwright-report/
+test-results/
+
+# Misc
+*.local
+*.tsbuildinfo
+package-lock.json
+.claude/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,48 @@ jobs:
       - name: Verify the output is a usable site
         run: pnpm run verify
 
+  # The container is documented in the README, so it has to keep working.
+  # Nothing else here would notice it breaking: it is not part of `validate`,
+  # and a developer who never runs Docker would not see it fail.
+  docker:
+    name: Local preview container
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the image
+        run: docker build -t astro-rocket-preview .
+
+      - name: Serve it
+        run: |
+          docker run -d --name preview -p 4321:8080 astro-rocket-preview
+          for i in $(seq 1 30); do
+            curl -fsS http://localhost:4321/ > /dev/null && break
+            sleep 1
+          done
+
+      - name: The home page is served
+        run: curl -fsS http://localhost:4321/ | grep -q '<title>'
+
+      - name: A nested page is served
+        run: curl -fsS http://localhost:4321/blog/ | grep -q '<title>'
+
+      # The static build has no API routes. nginx has to say so in the shape
+      # the contact form parses, or the form shows "Failed to send message"
+      # and the reason is lost.
+      - name: The API routes answer honestly
+        run: |
+          code=$(curl -s -o body.json -w '%{http_code}' -X POST http://localhost:4321/api/contact)
+          test "$code" = "501"
+          node -e "const b=require('./body.json'); if(b.success!==false||!b.errors?.form?.[0]) process.exit(1)"
+
+      - name: A missing page is a 404
+        run: test "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4321/no-such-page/)" = "404"
+
+      - name: Stop
+        if: always()
+        run: docker rm -f preview || true
+
 # Deployment is left to the platform's own Git integration by default.
 # To deploy from here instead, add one of these to a job that runs after
 # `build`, guarded by `if: github.ref == 'refs/heads/main'`:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# Local preview of the built site, in two stages.
+#
+# The build stage installs dependencies and runs `astro build`. The runtime
+# stage is nginx with the generated files copied in — no Node, no pnpm, no
+# Astro, and none of the dependency tree.
+#
+# Two things this is good for:
+#
+#   Trying the theme without installing anything but Docker. `docker compose
+#   up --build` and the site is on localhost:4321.
+#
+#   Keeping `pnpm install` away from your own machine. Installing a
+#   dependency tree runs other people's install scripts; here they run in a
+#   container that can see this repository and nothing else of yours.
+#
+# It is not how you deploy. See the README for that — the theme builds for
+# Vercel, Netlify and Cloudflare, and only those builds carry the API routes.
+
+# ── Build ────────────────────────────────────────────────────────────────────
+# Node 22 matches .nvmrc and the `engines` floor of 22.12.0.
+FROM node:22 AS build
+
+WORKDIR /app
+
+# pnpm comes from the `packageManager` field rather than a version pinned
+# here, so the container, CI and a developer's machine cannot drift apart.
+RUN corepack enable
+
+# Dependency manifests first: this layer is cached until they change, so
+# editing a page does not reinstall the tree.
+COPY package.json pnpm-lock.yaml ./
+RUN corepack install && pnpm install --frozen-lockfile
+
+COPY . .
+
+# SITE_URL is what canonical tags, og:image, RSS and the sitemap are written
+# against. A preview is not the deployed site, so it says so plainly rather
+# than baking in a domain that is not yours.
+ARG SITE_URL=http://localhost:4321
+ENV SITE_URL=$SITE_URL
+
+RUN pnpm run build
+
+# ── Runtime ──────────────────────────────────────────────────────────────────
+FROM nginx:alpine AS runtime
+
+# `dist/client` is what Astro writes for every deploy target. The adapters
+# then copy it into their own layout — .vercel/output/static and so on — so
+# this is the one path that does not depend on which target was built.
+COPY --from=build /app/dist/client /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# 8080 rather than 80, so the image runs as a non-root user if you ask it to.
+EXPOSE 8080
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -247,6 +247,36 @@ Visit `http://localhost:4321` to see your site.
 
 ---
 
+### Or try it in Docker, without installing anything
+
+If you would rather not put a dependency tree on your own machine yet:
+
+```bash
+docker compose up --build
+```
+
+The site is then on **http://localhost:4321**. The build runs inside the
+container, which can see this repository and nothing else of yours, and the
+image that serves the site is nginx with the generated files in it — no Node,
+no pnpm, no Astro.
+
+To get the built files out instead of serving them:
+
+```bash
+docker compose run --rm export
+```
+
+That writes the site into `./dist`.
+
+**What the container does not cover.** It serves the static build, and the
+contact form and newsletter are the theme's only routes that are not
+prerendered — they become a serverless function on a real deploy. In the
+container they answer with an explanation instead, which the form displays.
+Everything else — all pages, search, the colour themes, RSS, the sitemap — is
+the real thing. For a full preview including the forms, use `pnpm dev` or
+deploy to Vercel, Netlify or Cloudflare.
+
+
 ## Project Structure
 
 ```

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,35 @@
+# Local preview only. This is not how the theme deploys — see the README.
+#
+#   docker compose up --build     build and serve on http://localhost:4321
+#   docker compose run --rm export  build and copy the site into ./dist
+#
+# The host filesystem is mounted at /export and nowhere else, so the build
+# never sees anything of yours but this repository.
+
+services:
+  # Serves the built site from nginx. No Node in this container.
+  astro:
+    build:
+      context: .
+      args:
+        # What canonical tags, og:image, RSS and the sitemap are written
+        # against. Override when previewing with your own domain.
+        SITE_URL: ${SITE_URL:-http://localhost:4321}
+    ports:
+      - '4321:8080'
+
+  # Builds and hands the files back, for looking at the output itself.
+  # Not started by `up`; run it on demand.
+  export:
+    profiles: ['export']
+    build:
+      context: .
+      target: build
+    volumes:
+      - ./dist:/export
+    command: >
+      sh -c "echo '[clearing ./dist]' &&
+             find /export -mindepth 1 -delete &&
+             echo '[copying the build to ./dist]' &&
+             cp -a /app/dist/client/. /export/ &&
+             echo '[done]'"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,58 @@
+worker_processes  1;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+  sendfile      on;
+
+  server {
+    listen      8080;
+    server_name _;
+
+    root  /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_min_length 1000;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types text/plain text/css application/json application/javascript
+               application/x-javascript text/xml application/xml
+               application/xml+rss text/javascript image/svg+xml;
+
+    # The contact form and the newsletter are the theme's only routes that
+    # are not prerendered. They compile to a serverless function on Vercel,
+    # Netlify or Cloudflare, and are not in the static output this container
+    # serves — so there is nothing here to answer them.
+    #
+    # A bare 404 would reach the form as unparseable text and it would show
+    # "Failed to send message. Please try again", which reads like a bug in
+    # the theme. This answers in the shape the form already understands, so
+    # the reason appears in the form itself.
+    location ^~ /api/ {
+      default_type application/json;
+      add_header Cache-Control "no-store" always;
+      return 501 '{"success":false,"errors":{"form":["This preview serves the static build only. The contact form and newsletter need a server, so they work on a real deploy — Vercel, Netlify or Cloudflare — not in this container."]}}';
+    }
+
+    # Astro writes a directory with an index.html per page.
+    location / {
+      try_files $uri $uri/ $uri/index.html =404;
+    }
+
+    # Hashed assets never change under the same name.
+    location /_astro/ {
+      expires 1y;
+      add_header Cache-Control "public, immutable";
+      try_files $uri =404;
+    }
+
+    error_page 404 /404.html;
+    location = /404.html {
+      internal;
+    }
+  }
+}


### PR DESCRIPTION
Two stages. The build stage installs and runs astro build; the runtime stage is nginx with the generated files copied in, carrying no Node, no pnpm and none of the dependency tree. `docker compose up --build` serves the site on localhost:4321; `docker compose run --rm export` writes it to ./dist instead.

It answers two things. Somebody evaluating the theme can see it running without installing a toolchain, and somebody wary of installing a dependency tree can keep the install in a container that sees this repository and nothing else of theirs.

The contact form and the newsletter are the only routes that are not prerendered, so they are absent from the static build this serves. A bare 404 would reach the form as unparseable text and surface as "Failed to send message", which reads like a fault in the theme. nginx answers /api/ with 501 and a JSON body in the shape the form already parses, so the reason appears in the form itself.

pnpm comes from the packageManager field rather than a version pinned in the Dockerfile, and Node 22 matches .nvmrc. dist/client is what every adapter writes before copying it into its own layout, so serving that path does not tie the container to one deploy target.

A CI job builds the image and exercises it: the home page, a nested page, a 404, and a POST to /api/contact that has to answer 501 with a parseable body. Nothing else would notice this breaking, because it is not part of validate and a developer who never runs Docker would never see it fail.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
