### PR TITLE
Remove gitignore entries that name nothing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,19 +47,8 @@ test-results/
 *.local
 *.tsbuildinfo
 
-# Pagefind
-public/pagefind/
-
 # Claude Code
 .claude/
 
 # npm lockfile (pnpm only)
 package-lock.json
-
-# Internal docs
-southwell-astro-boilerplate-docs.md
-southwell-astro-boilerplate-prd.md
-claude-ai-web-design.png
-dark-mode-sessionstorage.png
-domain-email-vercel-setup.png
-why-i-build-with-astro.png


### PR DESCRIPTION
Six of them named files that have never existed in this repository — two documents from the boilerplate this theme's ancestor was forked from, and four screenshots belonging to hansmartens.dev. They arrived with the .gitignore when the theme was cloned from that site.

public/pagefind/ goes too. The pagefind integration writes its index into whichever directory the active adapter builds into, so nothing has ever written to public/pagefind.

A .gitignore is read by anyone deciding how a repository is laid out, and entries pointing at files that do not exist tell them about a project that is not this one.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
