### PR TITLE
Drop the e2e command that had no tests to run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,6 @@ pnpm-debug.log*
 
 # Testing
 coverage/
-playwright-report/
-test-results/
 
 # Misc
 *.local

--- a/README.md
+++ b/README.md
@@ -334,7 +334,6 @@ astro-rocket/
 | `pnpm format:check` | Check code formatting |
 | `pnpm test` | Run Vitest tests, watching for changes |
 | `pnpm test:run` | Run Vitest once and exit — what CI runs |
-| `pnpm test:e2e` | Run Playwright E2E tests |
 | `pnpm validate` | Everything CI runs: lint, types, tests, build, output check |
 
 ---

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "astro-rocket",
   "version": "2.5.0",
   "packageManager": "pnpm@10.33.0",
-  "description": "Astro Rocket \u2014 A production-ready Astro 7 theme built on Tailwind CSS v4",
+  "description": "Astro Rocket — A production-ready Astro 7 theme built on Tailwind CSS v4",
   "type": "module",
   "author": "Hans Martens",
   "license": "MIT",
@@ -40,8 +40,7 @@
     "format:check": "prettier --check .",
     "validate": "pnpm lint && pnpm check && pnpm test:run && pnpm build && pnpm verify",
     "test": "vitest",
-    "test:run": "vitest run",
-    "test:e2e": "playwright test"
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^14.0.1",
@@ -73,7 +72,6 @@
   "devDependencies": {
     "@astrojs/check": "0.9.9",
     "@eslint/js": "^9.17.0",
-    "@playwright/test": "^1.49.0",
     "@tailwindcss/vite": "^4.3.1",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,9 +90,6 @@ importers:
       '@eslint/js':
         specifier: ^9.17.0
         version: 9.39.2
-      '@playwright/test':
-        specifier: ^1.49.0
-        version: 1.58.0
       '@tailwindcss/vite':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@22.19.7)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -1622,11 +1619,6 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
-
-  '@playwright/test@1.58.0':
-    resolution: {integrity: sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -3376,11 +3368,6 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
-  fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4680,16 +4667,6 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
-
-  playwright-core@1.58.0:
-    resolution: {integrity: sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.58.0:
-    resolution: {integrity: sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   png-to-ico@3.0.1:
     resolution: {integrity: sha512-S8BOAoaGd9gT5uaemQ62arIY3Jzco7Uc7LwUTqRyqJDTsKqOAiyfyN4dSdT0D+Zf8XvgztgpRbM5wnQd7EgYwg==}
@@ -7671,10 +7648,6 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.58.0':
-    dependencies:
-      playwright: 1.58.0
-
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -9646,9 +9619,6 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  fsevents@2.3.2:
-    optional: true
-
   fsevents@2.3.3:
     optional: true
 
@@ -11274,14 +11244,6 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
-
-  playwright-core@1.58.0: {}
-
-  playwright@1.58.0:
-    dependencies:
-      playwright-core: 1.58.0
-    optionalDependencies:
-      fsevents: 2.3.2
 
   png-to-ico@3.0.1:
     dependencies:


### PR DESCRIPTION
The README documented `pnpm test:e2e`, @playwright/test was a dependency, and there was no Playwright config and no spec file anywhere in the repository. Running the documented command failed with "No tests found" — a starter theme handing somebody a command that errors is worse than not offering it.

What e2e would have covered is covered. The suite has 136 unit tests, and the container job in CI exercises the built site over HTTP: the home page, a nested page, a 404, and a POST to an API route.

Playwright's output directories leave .gitignore with it.

Every command the README documents is now a script that exists.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
