### PR TITLE
Check the README's claims, and fix three that had drifted

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </p>
 
 <p align="center">
-  <a href="https://astro.build"><img src="https://img.shields.io/badge/Astro-7.0-bc52ee?logo=astro&logoColor=white" alt="Astro" /></a>
-  <a href="https://tailwindcss.com"><img src="https://img.shields.io/badge/Tailwind-4.0-38bdf8?logo=tailwindcss&logoColor=white" alt="Tailwind CSS" /></a>
+  <a href="https://astro.build"><img src="https://img.shields.io/badge/Astro-7.2-bc52ee?logo=astro&logoColor=white" alt="Astro" /></a>
+  <a href="https://tailwindcss.com"><img src="https://img.shields.io/badge/Tailwind-4.3-38bdf8?logo=tailwindcss&logoColor=white" alt="Tailwind CSS" /></a>
   <a href="https://www.typescriptlang.org"><img src="https://img.shields.io/badge/TypeScript-5.7-3178c6?logo=typescript&logoColor=white" alt="TypeScript" /></a>
   <a href="https://github.com/hansmartensdev/astro-rocket/actions/workflows/deploy.yml"><img src="https://github.com/hansmartensdev/astro-rocket/actions/workflows/deploy.yml/badge.svg" alt="Build, lint, type check and tests" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-22c55e" alt="License" /></a>
@@ -62,6 +62,31 @@ Astro Rocket is a **free, lightning-fast Astro 7 starter theme to build anything
 Built on Astro 7 and Tailwind CSS v4.
 
 **[Live demo → astrorocket.dev](https://astrorocket.dev)** · **[Built by Hans Martens → hansmartens.dev](https://hansmartens.dev)**
+
+### Run it
+
+With Node 22.12+ and pnpm:
+
+```bash
+git clone https://github.com/hansmartensdev/astro-rocket.git my-project
+cd my-project && pnpm install && pnpm dev
+```
+
+Or with only Docker installed, building nothing on your own machine:
+
+```bash
+docker compose up --build
+```
+
+Either way the site is on **http://localhost:4321**. [Quick Start](#quick-start) has the detail.
+
+### Good to know
+
+Three things people reasonably expect that this theme does not do:
+
+- **There is no CMS or admin.** Posts, projects and pages are Markdown files in `src/content/`, edited in your editor and deployed by pushing. That is what keeps the whole site static and fast.
+- **The contact form and newsletter need a key.** They post to server routes that send through [Resend](https://resend.com), so they need `RESEND_API_KEY` before they will deliver. Both forms say so themselves rather than failing silently.
+- **Search is built, not live.** Pagefind indexes the site at build time, so `astro dev` has no index and the search modal explains that instead of erroring. Run `pnpm build && pnpm preview` to try it.
 
 > **Origins & credits.** Astro Rocket was originally forked from [Velocity](https://github.com/southwellmedia/velocity) by [Southwell Media](https://southwellmedia.com). Velocity provided the solid base — a well-engineered Astro boilerplate with a thoughtful design system and component library — and full credit for that foundation goes to the Southwell Media team. Since then, Astro Rocket has evolved into a theme in its own right, with far more to offer than the original: live colour-theme switching, built-in i18n, static search, project galleries with video, blog comments, durable internal links, and much more — see [What Astro Rocket has to offer](#what-astro-rocket-has-to-offer) below.
 
@@ -224,7 +249,7 @@ The whole system is build-time. No client-side routing, no framework hydration f
 ### Prerequisites
 
 - **Node.js 22.12.0+** (required for Astro 7)
-- **pnpm 9.x** (recommended) or npm/yarn
+- **pnpm 10.33.0** — the version in `packageManager`, which `corepack` installs for you
 
 ### Installation
 

--- a/src/__tests__/readme-claims.test.ts
+++ b/src/__tests__/readme-claims.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The README makes checkable promises, and a README is where somebody decides
+ * whether to trust the theme. Three of them had quietly stopped being true:
+ * it told people to install pnpm 9.x when `packageManager` says 10.33.0, and
+ * two version badges named releases behind the ones in `package.json`.
+ *
+ * `component-count.test.ts` already guards the component figure. This covers
+ * the rest of what can be compared against the repository itself.
+ */
+const root = new URL('../../', import.meta.url);
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, root)), 'utf8');
+
+const readme = read('README.md');
+const pkg = JSON.parse(read('package.json')) as {
+  scripts: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  engines: { node: string };
+  packageManager: string;
+};
+const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+/** "1.2.3", "^1.2.3", ">=1.2.3" → "1.2" */
+const majorMinor = (range: string) => range.replace(/^[^\d]*/, '').split('.').slice(0, 2).join('.');
+
+describe('what the README claims', () => {
+  it('documents only commands that exist', () => {
+    const documented = [...readme.matchAll(/\| `pnpm ([a-z:]+)`/g)].map((m) => m[1]);
+    expect(documented.length).toBeGreaterThan(0);
+    const missing = documented.filter((name) => !(name in pkg.scripts));
+    expect(missing, `documented but not a script: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('asks for the Node version the engines field asks for', () => {
+    const claimed = /- \*\*Node\.js ([\d.]+)\+?\*\*/.exec(readme)?.[1];
+    expect(claimed).toBeDefined();
+    expect(claimed).toBe(pkg.engines.node.replace(/^[^\d]*/, ''));
+  });
+
+  it('asks for the pnpm version packageManager pins', () => {
+    const claimed = /- \*\*pnpm ([\d.]+)\*\*/.exec(readme)?.[1];
+    expect(claimed).toBeDefined();
+    expect(claimed).toBe(pkg.packageManager.split('@')[1]);
+  });
+
+  it.each([
+    ['Astro', 'astro'],
+    ['Tailwind', 'tailwindcss'],
+    ['TypeScript', 'typescript'],
+  ])('badges %s at the version package.json declares', (badge, dep) => {
+    const shown = new RegExp(`badge/${badge}-([\\d.]+)-`).exec(readme)?.[1];
+    expect(shown, `no ${badge} badge found`).toBeDefined();
+    expect(shown).toBe(majorMinor(deps[dep]));
+  });
+});


### PR DESCRIPTION
A README is where somebody decides whether to trust a theme, and three of its checkable claims had stopped being true. It told people to install pnpm 9.x while packageManager pins 10.33.0 — the one that would have wasted a newcomer's first ten minutes. The Astro and Tailwind badges named releases behind the versions package.json declares.

A test now compares them: every pnpm command the README documents has to be a script that exists, the Node and pnpm versions have to match engines and packageManager, and each version badge has to match the dependency it names. component-count.test.ts already guarded the component figure; this covers the rest of what can be compared against the repository.

Two sections are added near the top, where somebody deciding whether to try it is still reading. "Run it" gives both ways in six lines, rather than leaving Quick Start 150 lines below the feature table. "Good to know" names the three things people reasonably expect and do not get: no CMS, forms that need a Resend key, and a search index built rather than live.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
