### PR TITLE
Change README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,6 @@ docker compose up --build
 
 Either way the site is on **http://localhost:4321**. [Quick Start](#quick-start) has the detail.
 
-### Good to know
-
-Three things people reasonably expect that this theme does not do:
-
-- **There is no CMS or admin.** Posts, projects and pages are Markdown files in `src/content/`, edited in your editor and deployed by pushing. That is what keeps the whole site static and fast.
-- **The contact form and newsletter need a key.** They post to server routes that send through [Resend](https://resend.com), so they need `RESEND_API_KEY` before they will deliver. Both forms say so themselves rather than failing silently.
-- **Search is built, not live.** Pagefind indexes the site at build time, so `astro dev` has no index and the search modal explains that instead of erroring. Run `pnpm build && pnpm preview` to try it.
-
 > **Origins & credits.** Astro Rocket was originally forked from [Velocity](https://github.com/southwellmedia/velocity) by [Southwell Media](https://southwellmedia.com). Velocity provided the solid base — a well-engineered Astro boilerplate with a thoughtful design system and component library — and full credit for that foundation goes to the Southwell Media team. Since then, Astro Rocket has evolved into a theme in its own right, with far more to offer than the original: live colour-theme switching, built-in i18n, static search, project galleries with video, blog comments, durable internal links, and much more — see [What Astro Rocket has to offer](#what-astro-rocket-has-to-offer) below.
 
 ---


### PR DESCRIPTION
Removes the `### Good to know` section from the README — the heading, the "Three things people reasonably expect that this theme does not do" line, and the three bullets under it. The **Origins & credits** note now follows straight after the quick-start block.

It framed the theme by what it does not do, three items in, before a reader had seen what it does.

**Nothing is lost by removing it.** Each fact it carried is documented elsewhere in the same README:

| Fact | Where it still lives |
|---|---|
| `RESEND_API_KEY` is needed for the contact form and newsletter | four other places in the README |
| Pagefind indexes at build time, so `astro dev` has no index | its own section, plus a row in the feature table |
| Content is Markdown in `src/content/` | the content-collections section |

8 lines removed, one file. `pnpm build` and all 142 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST)_