### PR TITLE
Change README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,23 +63,6 @@ Built on Astro 7 and Tailwind CSS v4.
 
 **[Live demo → astrorocket.dev](https://astrorocket.dev)** · **[Built by Hans Martens → hansmartens.dev](https://hansmartens.dev)**
 
-### Run it
-
-With Node 22.12+ and pnpm:
-
-```bash
-git clone https://github.com/hansmartensdev/astro-rocket.git my-project
-cd my-project && pnpm install && pnpm dev
-```
-
-Or with only Docker installed, building nothing on your own machine:
-
-```bash
-docker compose up --build
-```
-
-Either way the site is on **http://localhost:4321**. [Quick Start](#quick-start) has the detail.
-
 > **Origins & credits.** Astro Rocket was originally forked from [Velocity](https://github.com/southwellmedia/velocity) by [Southwell Media](https://southwellmedia.com). Velocity provided the solid base — a well-engineered Astro boilerplate with a thoughtful design system and component library — and full credit for that foundation goes to the Southwell Media team. Since then, Astro Rocket has evolved into a theme in its own right, with far more to offer than the original: live colour-theme switching, built-in i18n, static search, project galleries with video, blog comments, durable internal links, and much more — see [What Astro Rocket has to offer](#what-astro-rocket-has-to-offer) below.
 
 ---


### PR DESCRIPTION
## What does this PR do?

Removes the `### Run it` section from the Overview — 17 lines, one file, nothing added.

That section was inserted between the "Built by Hans Martens" line and the "Origins & credits" note, which pushed the credits below a set of install instructions and left them sitting under a heading about running the project. With it gone the Overview reads in its original order: what the theme is → what it is built on → where the demo is and who built it → where it came from. Origins following authorship.

Nothing is lost. The install steps and `docker compose up --build` are already in Quick Start, in more detail than the six-line version had.

The `### Good to know` removal that was originally part of this branch is not in this PR — that merged separately as #662.

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [x] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors — 0 errors, 2 pre-existing warnings
- [x] `pnpm check` passes with 0 errors — 0 errors, 0 warnings, 9 hints
- [x] `pnpm build` completes successfully
- [x] I have tested this change in the browser — README prose only; rendering verified on GitHub
- [x] No unnecessary files are included in this PR — README.md only

## Screenshots (if relevant)

Not applicable — no visual change to the site.
