### PR TITLE
Fix the export service's site address, and the container CI job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,22 +71,38 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build the image
-        run: docker build -t astro-rocket-preview .
-
+      # Through compose rather than `docker build`, because compose is what the
+      # README tells people to run and what carries SITE_URL into the build.
       - name: Serve it
+        env:
+          SITE_URL: https://ci.example
         run: |
-          docker run -d --name preview -p 4321:8080 astro-rocket-preview
+          docker compose up --build -d
           for i in $(seq 1 30); do
-            curl -fsS http://localhost:4321/ > /dev/null && break
+            curl -fsS http://localhost:4321/ > /dev/null && ready=1 && break
             sleep 1
           done
+          # Without this the loop simply ends and the step passes: its last
+          # command is `sleep`, which succeeds. A readiness check that cannot
+          # report a dead container is not a check.
+          if [ -z "$ready" ]; then
+            echo "::error::the container did not answer on :4321 within 30s"
+            docker compose logs --no-color
+            exit 1
+          fi
 
       - name: The home page is served
         run: curl -fsS http://localhost:4321/ | grep -q '<title>'
 
       - name: A nested page is served
         run: curl -fsS http://localhost:4321/blog/ | grep -q '<title>'
+
+      # SITE_URL reaches the build through compose, so a preview built with an
+      # address writes that address and not the localhost default.
+      - name: The preview writes the address it was given
+        run: |
+          curl -fsS http://localhost:4321/ -o home.html
+          grep -q 'rel="canonical" href="https://ci.example/"' home.html
 
       # The static build has no API routes. nginx has to say so in the shape
       # the contact form parses, or the form shows "Failed to send message"
@@ -100,9 +116,23 @@ jobs:
       - name: A missing page is a 404
         run: test "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4321/no-such-page/)" = "404"
 
+      # The export service builds the files people put on a host. It shipped
+      # once with no SITE_URL argument at all, writing localhost into every
+      # canonical tag while both build-time guards stayed quiet — one because
+      # SITE_URL was set, the other because the canonical and the JSON-LD
+      # agreed with each other. Neither can catch a wrong address; only
+      # reading the output can.
+      - name: The export writes the address it was given
+        env:
+          SITE_URL: https://ci.example
+        run: |
+          docker compose --profile export run --rm export
+          grep -q 'rel="canonical" href="https://ci.example/"' dist/index.html
+          grep -q '<loc>https://ci.example/</loc>' dist/sitemap-0.xml
+
       - name: Stop
         if: always()
-        run: docker rm -f preview || true
+        run: docker compose --profile export down -v --remove-orphans || true
 
 # Deployment is left to the platform's own Git integration by default.
 # To deploy from here instead, add one of these to a job that runs after

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,18 @@ trust the theme, so a commit message is part of the product.
   with a fragment like "…arsing". The body is where detail belongs; it has no
   limit.
 
+## Checks
+
+- **A check is not finished until it has failed once on purpose.** Write it,
+  run it against the broken state it exists to catch, watch it go red, then fix
+  the code and watch it go green. A check only ever run against working code is
+  an assumption with a green tick on it.
+- **Verify the path that fails, not only the path that works.** A container CI
+  job whose readiness loop ended in `sleep` passed while the container was
+  dead, and an export service with no `SITE_URL` argument shipped localhost
+  canonical tags with both build-time guards silent. Both were tested only in
+  the state where everything works.
+
 ## Commands
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`docker compose run --rm export` wrote `http://localhost:4321` into every canonical tag.** The export service builds the files people put on a host, and it was the one service in `compose.yml` with no `SITE_URL` build argument, so it took the Dockerfile's preview default. A site exported that way told search engines its canonical home was `localhost:4321`, and said so in the sitemap and `og:image` too. Nothing warned: `[site-url-check]` only speaks when `SITE_URL` is unset, and it was set — to the wrong thing — while `verify-site-url` compares the canonical against the JSON-LD, and both agreed. The service now takes `SITE_URL` the way the preview does, defaulting to empty rather than to localhost, so a build with no address falls back to the placeholder domain and warns instead of shipping a wrong one in silence. `docker compose up --build` was never affected.
+
 ## [2.5.1] — 2026-08-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - **`docker compose run --rm export` wrote `http://localhost:4321` into every canonical tag.** The export service builds the files people put on a host, and it was the one service in `compose.yml` with no `SITE_URL` build argument, so it took the Dockerfile's preview default. A site exported that way told search engines its canonical home was `localhost:4321`, and said so in the sitemap and `og:image` too. Nothing warned: `[site-url-check]` only speaks when `SITE_URL` is unset, and it was set — to the wrong thing — while `verify-site-url` compares the canonical against the JSON-LD, and both agreed. The service now takes `SITE_URL` the way the preview does, defaulting to empty rather than to localhost, so a build with no address falls back to the placeholder domain and warns instead of shipping a wrong one in silence. `docker compose up --build` was never affected.
+- **The container CI job could not fail.** Its readiness step tried thirty times to reach the container and then ended on `sleep`, which succeeds — so a container that never served passed the step that exists to notice. It now prints the compose logs and exits 1. The job also runs through `docker compose` rather than `docker build`, so it exercises what the README documents, and it reads the canonical tag and the sitemap out of both the served preview and the exported files: the guards inside the build cannot see a wrong address, only the output can.
 
 ## [2.5.1] — 2026-08-12
 

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,18 @@ services:
     build:
       context: .
       target: build
+      args:
+        # These files are the ones that go on a host, so SITE_URL matters here
+        # in a way it does not for the preview above. Without this the build
+        # took the Dockerfile's own default and wrote http://localhost:4321
+        # into every canonical tag, the sitemap and og:image — and said
+        # nothing, because SITE_URL was set, just to the wrong thing.
+        #
+        # Empty rather than a localhost default on purpose: an empty value is
+        # falsy, so the build falls back to the placeholder domain AND
+        # [site-url-check] warns that SITE_URL is not set. A wrong address that
+        # announces itself beats a wrong address that does not.
+        SITE_URL: ${SITE_URL:-}
     volumes:
       - ./dist:/export
     command: >


### PR DESCRIPTION
## What does this PR do?

Two fixes, both found through the follow-up questions on #652.

**`docker compose run --rm export` wrote `http://localhost:4321` into every canonical tag.** The export service builds the files people put on a host, and it was the only service in `compose.yml` with no `SITE_URL` build argument, so it took the Dockerfile's preview default. The sitemap and `og:image` carried it too. Both build-time guards stayed silent: `[site-url-check]` only warns when `SITE_URL` is *unset* and it was set — to the wrong thing — while `verify-site-url` compares the canonical against the JSON-LD, and both agreed. The service now takes `SITE_URL` the way the preview does, defaulting to empty rather than localhost, so a build with no address falls back to the placeholder domain and warns rather than shipping a wrong one in silence. `docker compose up --build` was never affected.

**The container CI job could not fail.** Its readiness step made thirty attempts and then ended on `sleep`, which succeeds — so a container that never answered passed the step whose job is to notice. It now prints the compose logs and exits 1. The job also runs through `docker compose` rather than `docker build`, which is what the README documents and what carries `SITE_URL` into the build, and it reads the address out of the output: the canonical tag from the served preview, the canonical tag and the sitemap from the exported files.

`AGENTS.md` gains the rule both defects came from missing — a check is not finished until it has failed once on purpose.

## Type of change

- [x] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm check` passes with 0 errors
- [x] `pnpm build` completes successfully
- [x] I have tested this change in the browser — build output inspected directly; see below
- [x] No unnecessary files are included in this PR

### How it was verified

Compose resolution, with and without `SITE_URL` in `.env`:

| `.env` | `export` service resolves |
|---|---|
| `SITE_URL=https://verify.example` | `args: SITE_URL: https://verify.example` |
| absent | `args: SITE_URL: ""` |

Builds, reading the canonical straight out of the output:

| `SITE_URL` | canonical | warning |
|---|---|---|
| `https://verify.example` | `https://verify.example/` | — |
| unset | `https://example.com/` | `[site-url-check]` warns |
| `""` | `https://example.com/` | `[site-url-check]` warns |
| `http://localhost:4321` (the old export) | `http://localhost:4321/` | **none** |

The new CI assertion was run against the broken state before being trusted: built as the export service used to be, the canonical check fails; built with the address passed through, it and the sitemap check pass.

Docker's daemon was not reachable where this was written, so the container wiring itself is proven by this job's own first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST)_