### PR TITLE
Release 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2.5.2] — 2026-08-13
+
 ### Fixed
 
 - **`docker compose run --rm export` wrote `http://localhost:4321` into every canonical tag.** The export service builds the files people put on a host, and it was the one service in `compose.yml` with no `SITE_URL` build argument, so it took the Dockerfile's preview default. A site exported that way told search engines its canonical home was `localhost:4321`, and said so in the sitemap and `og:image` too. Nothing warned: `[site-url-check]` only speaks when `SITE_URL` is unset, and it was set — to the wrong thing — while `verify-site-url` compares the canonical against the JSON-LD, and both agreed. The service now takes `SITE_URL` the way the preview does, defaulting to empty rather than to localhost, so a build with no address falls back to the placeholder domain and warns instead of shipping a wrong one in silence. `docker compose up --build` was never affected.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-rocket",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "packageManager": "pnpm@10.33.0",
   "description": "Astro Rocket — A production-ready Astro 7 theme built on Tailwind CSS v4",
   "type": "module",


### PR DESCRIPTION
## What does this PR do?

Tags 2.5.2. Two entries, both about the Docker paths added in 2.5.0, both already merged in #667 — this moves them out of `[Unreleased]` and bumps `package.json`.

**`docker compose run --rm export` wrote `http://localhost:4321` into every canonical tag**, and into the sitemap and `og:image`. The export service builds the files people put on a host, and it was the only service in `compose.yml` with no `SITE_URL` build argument, so it took the Dockerfile's preview default. Nothing warned: `[site-url-check]` only speaks when `SITE_URL` is unset and it was set — to the wrong thing — while `verify-site-url` compares the canonical against the JSON-LD, and both agreed.

**The container CI job could not fail.** Its readiness step made thirty attempts and then ended on `sleep`, which succeeds, so a container that never answered passed the step meant to notice.

Why now rather than in the next feature release: the failure mode is silent and search engines act on canonical tags. Anyone who exported a site with 2.5.0 or 2.5.1 should check the canonical tag in the files they uploaded.

## Type of change

- [x] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm check` passes with 0 errors
- [x] `pnpm build` completes successfully
- [x] I have tested this change in the browser — the fixes themselves verified in #667 and by CI run 1350 on `main`
- [x] No unnecessary files are included in this PR — `CHANGELOG.md` and `package.json` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST)_