### PR TITLE
Flip the header at the section edge

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -679,7 +679,7 @@ const buttonId = `${menuId}-button`;
           if (isFloating) {
             header.classList.remove('rounded-t-2xl');
             header.classList.add('rounded-2xl');
-            if (window.scrollY <= 60) {
+            if (window.scrollY <= flipPoint(header)) {
               header.removeAttribute('data-scrolled');
             }
           } else {
@@ -745,6 +745,39 @@ const buttonId = `${menuId}-button`;
   // without re-introducing a critical-path reflow.
   const SCROLL_THRESHOLD = 60;
   const AUTO_HIDE_THRESHOLD = 150;
+
+  /* WHERE THE HEADER FLIPS.
+     60px of scroll by default. On a page with a full-height hero that is
+     wrong: the header's at-rest look is built to sit ON the hero — dark glass
+     in light mode, no shadow — so flipping to the light, shadowed state after
+     60px leaves it in the wrong costume for the remaining height of the hero.
+
+     A page overrides it by marking the element the header should stay over:
+
+         <section data-header-flip-anchor>
+
+     The flip then happens when that element's bottom edge reaches the header's
+     own bottom edge, which is the moment the next section arrives underneath
+     the header. Not before it — a light bar over the last of a dark hero is
+     the same mismatch, just briefer — and not after.
+
+     `offsetTop + offsetHeight` rather than a bounding rect: the header is
+     fixed, so offsetTop resolves to its CSS `top`, and neither value moves
+     when the auto-hide transform runs. Re-measured on resize, because the
+     anchor's height is viewport-dependent. */
+  function measureFlipPoint(header: HTMLElement) {
+    const anchor = document.querySelector<HTMLElement>('[data-header-flip-anchor]');
+    if (!anchor) {
+      header.dataset.flipAt = String(SCROLL_THRESHOLD);
+      return;
+    }
+    const anchorBottom = anchor.getBoundingClientRect().bottom + window.scrollY;
+    const headerBottom = header.offsetTop + header.offsetHeight;
+    header.dataset.flipAt = String(Math.max(SCROLL_THRESHOLD, Math.round(anchorBottom - headerBottom)));
+  }
+
+  /** The scroll position this header changes costume at. */
+  const flipPoint = (header: HTMLElement) => Number(header.dataset.flipAt) || SCROLL_THRESHOLD;
   const BAR_SCROLLED_CLASSES = ['bg-background/80', 'backdrop-blur-lg', 'border-b', 'border-border/50'];
 
   let docMaxScrollY = 0;
@@ -773,6 +806,9 @@ const buttonId = `${menuId}-button`;
       if (header.dataset.scrollInit) return;
       header.dataset.scrollInit = 'true';
 
+      measureFlipPoint(header);
+      window.addEventListener('resize', () => measureFlipPoint(header), { passive: true });
+
       const isBar = header.dataset.headerShape === 'bar';
       const isFloating = header.dataset.headerShape === 'floating';
       const isAutoHide = header.dataset.headerAutoHide !== 'false';
@@ -794,7 +830,7 @@ const buttonId = `${menuId}-button`;
           const wasHidden = header.hasAttribute('data-header-hidden');
 
           // ── WRITES ──
-          if (currentScrollY > SCROLL_THRESHOLD) {
+          if (currentScrollY > flipPoint(header)) {
             header.setAttribute('data-scrolled', '');
             if (isTransparentBar) {
               header.classList.add(...BAR_SCROLLED_CLASSES);

--- a/src/components/pages/views/HomeView.astro
+++ b/src/components/pages/views/HomeView.astro
@@ -152,7 +152,10 @@ const basedInDisplay = `${city ?? 'Your City'}${country ? `, ${country}` : ''}`;
   includeProfessionalServiceSchema={true}
 >
   <!-- Hero -->
-  <Hero layout="centered" size="xl" class="hero-dark-gradient" fullHeight>
+  <!-- data-header-flip-anchor: the floating header keeps its over-the-hero
+       look until this section is nearly out from under it. See the flip
+       threshold in Header.astro. -->
+  <Hero layout="centered" size="xl" class="hero-dark-gradient" fullHeight data-header-flip-anchor>
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">{hero.badge}</Badge>
 
     {/* 12.6vw fills the mobile column (~95-98% at 320-390px), sized to the


### PR DESCRIPTION
The floating header changed out of its over-the-hero look after 60px of scroll, then sat in the wrong one for the rest of the hero: light glass with a shadow, over a dark full-height section.

A page now marks the element the header should stay over — `data-header-flip-anchor`, on the homepage hero — and the flip happens when that element's bottom edge reaches the header's own bottom edge, which is the moment the next section arrives underneath it. Flipping earlier puts a light bar over the last of a dark hero; flipping later puts a dark bar over a light section.

`offsetTop + offsetHeight` rather than a bounding rect: the header is fixed, so neither value moves when the auto-hide transform runs. Re-measured on resize, since the anchor's height is viewport-dependent. The mobile menu's close path tested the same 60px inline and now shares the computed point, so closing the menu over the hero no longer drops the header into the wrong state.

Measured in light mode on the built site: desktop 1440x900 flips at 818 — hero bottom 900 less header bottom 82 — dark at 0, 100, 400 and 788, light at 848 and beyond; phone 393x852 flips at 789 on the same arithmetic. Pages without the anchor keep the 60px default.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
