### PR TITLE
Blur the hero behind the floating header

### DIFF
--- a/src/components/layout/header.variants.ts
+++ b/src/components/layout/header.variants.ts
@@ -24,8 +24,11 @@ export const headerVariants = cva('z-50', {
     { shape: 'floating', position: 'sticky', class: '!top-4 mx-auto max-w-6xl' },
     // Floating + static: centered
     { shape: 'floating', position: 'static', class: 'mx-auto max-w-6xl' },
-    // Floating + transparent: glass effect
-    { shape: 'floating', variant: 'transparent', class: 'bg-white/[0.08] border border-white/[0.1]' },
+    // Floating + transparent: frosted glass. The backdrop blur is for
+    // readability, not for looks — at rest this header sits over a hero, and
+    // whatever the hero draws behind the nav links is detail beside small
+    // text. Clear glass looks better and reads worse.
+    { shape: 'floating', variant: 'transparent', class: 'bg-white/[0.08] backdrop-blur-md border border-white/[0.1]' },
     // Floating + default: semi-transparent with blur
     { shape: 'floating', variant: 'default', class: '!bg-background/90 backdrop-blur-xl !border border-border/50 !border-b-border/50' },
     // Floating + solid: opaque


### PR DESCRIPTION
At rest the floating header is clear glass, so a hero's own detail sits directly behind the nav links — a starfield, a gradient, whatever the page draws there. Clear glass looks better and reads worse: detail beside small text costs legibility for anyone on a dim screen or with lower vision.

A 12px backdrop blur flattens what is behind the capsule without making it opaque. The header stays see-through; what shows through stops competing with the nav.

Contrast does not measure this. On the built site the blur moves nav contrast by nothing — 4.18 either way in light mode, 3.83 in dark, with the same flat ground behind the links. What changes is the noise beside the text, which a contrast ratio has no way to express.

The 24px blur on [data-scrolled] is untouched. hansmartens.dev has carried this at rest all along; the two headers now match apart from the colour tokens each site defines for itself.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
