### PR TITLE
Read the flip point from the element in the menu's close path

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -679,7 +679,10 @@ const buttonId = `${menuId}-button`;
           if (isFloating) {
             header.classList.remove('rounded-t-2xl');
             header.classList.add('rounded-2xl');
-            if (window.scrollY <= flipPoint(header)) {
+            // Written by measureFlipPoint() in the scroll-watcher script
+            // below. Read straight off the element because each <script>
+            // block is its own module — the helper there is not in scope here.
+            if (window.scrollY <= (Number(header.dataset.flipAt) || 60)) {
               header.removeAttribute('data-scrolled');
             }
           } else {


### PR DESCRIPTION
## What does this PR do?

Fixes the type error that is failing on `main`.

`astro check` reports `Cannot find name 'flipPoint'` in `Header.astro`. The mobile menu's close handler lives in a different `<script>` block from the scroll watcher, and Astro compiles each block as its own module, so the helper defined in one is not in scope in the other.

It reads `header.dataset.flipAt` directly instead — the same value, written by `measureFlipPoint()`, with no cross-block reference.

`pnpm build` and the test suite both pass with the bug present, which is why it reached `main`: only the type check catches it.

One commit, one file, four lines.

## Type of change

- [x] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [x] `pnpm lint` passes with 0 errors
- [x] `pnpm check` passes with 0 errors — 0 errors, 0 warnings, 9 hints
- [x] `pnpm build` completes successfully
- [x] I have tested this change in the browser — the header still flips at the section edge; measured at 818 on desktop and 789 on phone
- [x] No unnecessary files are included in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST


---
_Generated by [Claude Code](https://claude.ai/code/session_01BwJB1u6U3vdEZ9LrHRebST)_