### PR TITLE
Trim comments and changelog to what they document

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,10 @@
 # Copy this file to .env and fill in your values
 # Variables prefixed with PUBLIC_ are exposed to the browser - NEVER prefix secrets
 #
-# Building in Docker: `docker compose up --build` and `docker compose run --rm
-# export` carry these into the container for you. Compose reads this file to
-# resolve them and passes them in as build arguments, so the file itself never
-# enters the build context. The exceptions are RESEND_API_KEY,
-# RESEND_FROM_EMAIL, RESEND_AUDIENCE_ID and NEWSLETTER_API_KEY: those are read
-# by the API routes, and a container serves static files with no routes in it.
+# Building in Docker: Compose reads this file and passes the values in as
+# build arguments, so the file itself stays out of the build context.
+# RESEND_API_KEY, RESEND_FROM_EMAIL, RESEND_AUDIENCE_ID and NEWSLETTER_API_KEY
+# are read by the API routes, which a container does not carry.
 
 # -----------------------------------------------------------------------------
 # Required

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,16 +115,13 @@ jobs:
           curl -fsS http://localhost:4321/ -o home.html
           grep -q 'rel="canonical" href="https://ci.example/"' home.html
 
-      # Astro inlines all of these at build time and every one of them is
-      # optional, so a build that never received them produces a working site
-      # with none of them in it and no warning anywhere. That is what 2.5.0
-      # shipped: compose passed SITE_URL and nothing else, and the other nine
-      # were silently absent from every Docker build. Reading them back out of
-      # the served page is the only thing that catches it.
+      # Astro inlines these at build time and all of them are optional, so a
+      # build that never received them still succeeds. Reading them back out
+      # of the served page is what catches a missing one.
       #
-      # PUBLIC_GOOGLE_MAPS_API_KEY is passed to the build but not asserted
-      # here: GoogleMap is exported by the component library and rendered on no
-      # page of the demo, so the key has nothing to appear in.
+      # PUBLIC_GOOGLE_MAPS_API_KEY is passed to the build but not asserted:
+      # GoogleMap is rendered on no page of the demo, so the key has nothing
+      # to appear in.
       - name: The preview carries the configuration it was given
         run: |
           curl -fsS http://localhost:4321/ -o config.html
@@ -156,12 +153,10 @@ jobs:
       - name: A missing page is a 404
         run: test "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4321/no-such-page/)" = "404"
 
-      # The export service builds the files people put on a host. It shipped
-      # once with no SITE_URL argument at all, writing localhost into every
-      # canonical tag while both build-time guards stayed quiet — one because
-      # SITE_URL was set, the other because the canonical and the JSON-LD
-      # agreed with each other. Neither can catch a wrong address; only
-      # reading the output can.
+      # The export service builds the files that go on a host, so the address
+      # in them matters. The build-time guards cannot catch a wrong one — they
+      # compare the canonical against the JSON-LD, which agree either way — so
+      # this reads it out of the output.
       - name: The export writes what it was given
         env:
           SITE_URL: https://ci.example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,10 +50,9 @@ If a page appears to have hard-coded text, check the locale file first.
 ## Before a feature goes in
 
 **Two questions, before the merge and not after.** Does a general user of this
-theme need it? Does the theme need it? A working contribution answers neither.
-Docker arrived working, was merged the same day, and went out in 2.5.0 without
-either question being asked — then took two emergency patches in its first day
-and a third fix three days later.
+theme need it? Does the theme need it? A working contribution answers neither,
+and a feature merged on the strength of working code arrives with a
+maintenance surface nobody agreed to carry.
 
 Answering no is not a rejection of the contributor. It is cheaper for everyone
 than a feature the theme carries and nobody maintains.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **The dark-mode contrast figure for the primary button.** It recorded 4.54:1 as the worst case across the twelve themes. Measured from each theme's `--brand-600`/`--brand-700` against white, the worst is **amber at 4.56:1** at rest, and all twelve clear WCAG AA.
-- **The README and the configuration guide pointed at `ThemeSelector.astro` for the list of themes.** The registry is `colourThemes` in `src/lib/themes.ts`.
+- Dark-mode contrast figure for the primary button corrected to 4.56:1 (amber, at rest). All twelve themes clear WCAG AA.
+- The README and the configuration guide now point at `colourThemes` in `src/lib/themes.ts` for the list of themes.
 
 ## [2.5.3] — 2026-08-14
 
 ### Fixed
 
-- **Only `SITE_URL` reached a Docker build.** The nine other build-time variables — the Google Analytics, GTM and Umami settings, the Maps key, the consent flag and privacy URL, and the Google and Bing verification tokens — were not passed in, so a site built with `docker compose up --build` or written out with `docker compose run --rm export` carried none of them. The Dockerfile now declares all nine as build arguments and `compose.yml` passes them to both services, resolved from `.env` as `SITE_URL` already was. Empty behaves as unset, so a build with nothing configured is unchanged. The container CI job reads the values back out of the served page and the exported files. Reported by [@0Ky](https://github.com/0Ky) in [#652](https://github.com/hansmartensdev/astro-rocket/issues/652).
-
-- **`PUBLIC_GOOGLE_MAPS_API_KEY` was absent from `.env.example`.** It is declared in the environment schema and read by the `GoogleMap` component, but the one file that lists what the theme accepts never mentioned it, so the only way to learn it existed was to read `astro.config.mjs`. It is documented now, and the file also says which variables reach a Docker build and which do not — the four Resend and newsletter keys are read by the API routes, which a container does not carry.
-- **`AGENTS.md` gave the wrong number of colour themes.**
+- All build-time variables now reach a Docker build. Only `SITE_URL` was passed in, so a site built with `docker compose up --build`, or exported with `docker compose run --rm export`, carried no analytics, consent banner or verification tags. Reported by [@0Ky](https://github.com/0Ky) in [#652](https://github.com/hansmartensdev/astro-rocket/issues/652).
+- `PUBLIC_GOOGLE_MAPS_API_KEY` added to `.env.example`, which also now states which variables reach a Docker build.
+- `AGENTS.md` gave the wrong number of colour themes.
 
 ### Changed
 
-- **A rule for accepting a feature into the theme.** Two questions before a merge rather than after: does a general user of this theme need it, and does the theme need it.
+- A rule for accepting a feature into the theme: does a general user need it, and does the theme need it.
 
 ## [2.5.2] — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Removed
-
-- **The `green` colour theme.** `green.css` was imported in `colors.css`, so it compiled into the stylesheet every visitor downloads, but it was absent from `colourThemes` in `src/lib/themes.ts` and from the bootstrap array in `BaseLayout.astro` — no picker offered it and nothing could select it. Emerald (hue 155°) and lime (130°) already sit either side of it. If you set `data-theme="green"` by hand after reading the configuration guide, which documented the file as available but not in the picker, switch to `emerald` or `lime`.
-
 ### Fixed
 
-- **The header comment in `colors.css` described a theme setup that no longer existed.** It named the default as indigo when it is blue, listed green as active in the selector, and split the rest into "hidden" and "available, not exposed" groups — while `src/lib/themes.ts` offers all twelve. That comment is what someone reads to work out how theming is wired, and every claim in it was wrong. It now points at the registry and says what actually curates the pickers.
-- **The dark-mode contrast figure named a theme that was never in the set.** `global.css` recorded the worst case across the twelve as 4.54:1, attributed to green. Measured across the twelve that ship, the worst is **amber at 4.56:1** at rest, and all twelve clear WCAG AA. The README and the configuration guide also pointed at `ThemeSelector.astro` for the theme list, which moved to `src/lib/themes.ts`.
+- **The dark-mode contrast figure for the primary button.** It recorded 4.54:1 as the worst case across the twelve themes. Measured from each theme's `--brand-600`/`--brand-700` against white, the worst is **amber at 4.56:1** at rest, and all twelve clear WCAG AA.
+- **The README and the configuration guide pointed at `ThemeSelector.astro` for the list of themes.** The registry is `colourThemes` in `src/lib/themes.ts`.
 
 ## [2.5.3] — 2026-08-14
 
 ### Fixed
 
-- **Only `SITE_URL` reached a Docker build.** Nine other variables are inlined into the output at build time — `PUBLIC_GA_MEASUREMENT_ID`, `PUBLIC_GTM_ID`, `PUBLIC_UMAMI_WEBSITE_ID`, `PUBLIC_UMAMI_SRC`, `PUBLIC_GOOGLE_MAPS_API_KEY`, `PUBLIC_CONSENT_ENABLED`, `PUBLIC_PRIVACY_POLICY_URL`, `GOOGLE_SITE_VERIFICATION` and `BING_SITE_VERIFICATION` — and `compose.yml` passed none of them. A site built with `docker compose up --build`, or written out with `docker compose run --rm export` and uploaded to a host, carried no analytics, no consent banner and no search-engine verification tags. All nine are optional, so nothing warned: the build succeeded and the output was simply missing everything that had been configured. The Dockerfile now declares all nine as build arguments and `compose.yml` passes them to both services, resolved from `.env` the same way `SITE_URL` already was — the file itself still never enters the build context. Empty stays empty and behaves as unset, so no measurement id injects no `gtag` and an empty `PUBLIC_CONSENT_ENABLED` resolves to false; a build with nothing configured is unchanged. The container CI job now reads the values back out of the served page and out of the exported files, and was run against a build made without them and watched to fail before it was trusted. `pnpm build` was never affected. Found by [@0Ky](https://github.com/0Ky) in [#652](https://github.com/hansmartensdev/astro-rocket/issues/652).
+- **Only `SITE_URL` reached a Docker build.** The nine other build-time variables — the Google Analytics, GTM and Umami settings, the Maps key, the consent flag and privacy URL, and the Google and Bing verification tokens — were not passed in, so a site built with `docker compose up --build` or written out with `docker compose run --rm export` carried none of them. The Dockerfile now declares all nine as build arguments and `compose.yml` passes them to both services, resolved from `.env` as `SITE_URL` already was. Empty behaves as unset, so a build with nothing configured is unchanged. The container CI job reads the values back out of the served page and the exported files. Reported by [@0Ky](https://github.com/0Ky) in [#652](https://github.com/hansmartensdev/astro-rocket/issues/652).
+
 - **`PUBLIC_GOOGLE_MAPS_API_KEY` was absent from `.env.example`.** It is declared in the environment schema and read by the `GoogleMap` component, but the one file that lists what the theme accepts never mentioned it, so the only way to learn it existed was to read `astro.config.mjs`. It is documented now, and the file also says which variables reach a Docker build and which do not — the four Resend and newsletter keys are read by the API routes, which a container does not carry.
-- **`AGENTS.md` said the theme ships twelve colour themes.** There are thirteen files in `src/styles/themes/`.
+- **`AGENTS.md` gave the wrong number of colour themes.**
 
 ### Changed
 
-- **A rule for accepting a feature into the theme.** Two questions before a merge rather than after: does a general user of this theme need it, and does the theme need it. Docker went in without either being asked and needed three fixes in its first three days.
+- **A rule for accepting a feature into the theme.** Two questions before a merge rather than after: does a general user of this theme need it, and does the theme need it.
 
 ## [2.5.2] — 2026-08-13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,17 +40,15 @@ ARG SITE_URL=http://localhost:4321
 ENV SITE_URL=$SITE_URL
 
 # The rest of the build-time configuration. Astro inlines each of these into
-# the generated files, so one that does not reach this stage is one the site
-# does not have. Every one is optional, so nothing complains — which is how a
-# Docker build shipped with no analytics, no consent banner and no search
-# verification tags, and said nothing about any of it.
+# the generated files, so a value that does not reach this stage is one the
+# built site does not have.
 #
-# Empty is the default, and empty behaves as unset: no measurement id injects
-# no gtag, and an empty PUBLIC_CONSENT_ENABLED resolves to false.
+# Empty is the default and behaves as unset: no measurement id injects no
+# gtag, and an empty PUBLIC_CONSENT_ENABLED resolves to false.
 #
 # RESEND_API_KEY, RESEND_FROM_EMAIL, RESEND_AUDIENCE_ID and NEWSLETTER_API_KEY
-# are absent on purpose. They are read by the API routes, and the runtime image
-# is nginx serving static files — it has no routes in it to read them.
+# are not here: they are read by the API routes, and the runtime image is
+# nginx serving static files.
 ARG PUBLIC_GA_MEASUREMENT_ID=
 ARG PUBLIC_GTM_ID=
 ARG PUBLIC_UMAMI_WEBSITE_ID=

--- a/compose.yml
+++ b/compose.yml
@@ -10,15 +10,12 @@
 # reads it to resolve the ${...} substitutions below, and passes the values in
 # as build arguments. The file stays out; the settings get through.
 
-# Everything Astro inlines into the generated files at build time. Shared by
-# both services, so a preview and an export cannot disagree about what the
-# site contains. Anything missing here is missing from the built site, and
-# nothing says so — every one of them is optional.
+# Everything Astro inlines into the generated files at build time, shared by
+# both services so a preview and an export build the same site.
 #
 # The four server-side secrets (RESEND_API_KEY, RESEND_FROM_EMAIL,
-# RESEND_AUDIENCE_ID, NEWSLETTER_API_KEY) are deliberately not here. They are
-# read by the API routes, and neither service carries routes: the preview is
-# nginx serving static files, and the export is those same files on your disk.
+# RESEND_AUDIENCE_ID, NEWSLETTER_API_KEY) are not here: they are read by the
+# API routes, and neither service carries routes.
 x-build-config: &build-config
   PUBLIC_GA_MEASUREMENT_ID: ${PUBLIC_GA_MEASUREMENT_ID:-}
   PUBLIC_GTM_ID: ${PUBLIC_GTM_ID:-}

--- a/src/__tests__/i18n-coverage.test.ts
+++ b/src/__tests__/i18n-coverage.test.ts
@@ -1,29 +1,17 @@
 /**
- * Keeps interface text out of the component source and inside the locale files.
+ * Every string a reader or a screen reader meets must come from the locale
+ * files, not from a component.
  *
- * The theme already translated everything you can see. It did not translate
- * what a screen reader announces: `aria-label`, `alt`, `placeholder` and
- * `title` carried English literals in the component library, so a Dutch site
- * built on this theme said "Close dialog" and "Previous page" to anyone using
- * one — invisible to a sighted reviewer, which is why it survived a
- * deliberate i18n sweep that got the same attribute right in 24 other places.
+ * Covers `aria-label`, `alt`, `placeholder` and `title` — as attributes, as
+ * prop defaults, as fallbacks and as `setAttribute` calls — across
+ * `src/components/` and `src/layouts/`.
  *
- * `AGENTS.md` said "any visible interface text", and an `aria-label` is not
- * visible. The rule permitted it. Both the rule and these checks now name the
- * attributes, because three manual sweeps of this produced three different
- * counts and the fourth would have too.
+ * `src/pages/components.astro` is out of scope: its strings are demo fixtures
+ * that exist to show a component, not interface text.
  *
- * Scope is `src/components/` and `src/layouts/` — the library that ships into
- * every site built on this theme. `src/pages/components.astro` is deliberately
- * outside it: its strings are demo fixtures ("Sarah Chen", "Build failed")
- * shown to demonstrate a component, and a showcase page is the first thing
- * most people delete. Whether that page should be available in other
- * languages is a question about the demo, not a defect in the library.
- *
- * There is no exception list on purpose. A string that is the same in every
- * language — a product name like "Google Maps" — belongs in the locale files
- * with the same value in each, not in an allowlist here. An allowlist is
- * where the next violation would hide.
+ * There is no exception list. A string that is identical in every language,
+ * such as a product name, belongs in the locale files with the same value in
+ * each.
  */
 import { describe, expect, it } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
@@ -122,8 +110,8 @@ describe('every locale carries every key', () => {
       const expected = flatten(en);
       const actual = new Set(flatten(dictionary));
       // A missing key falls back to the default locale silently, so the page
-      // renders English in place of the translation and nothing reports it —
-      // exactly the failure this theme shipped in its own aria-labels.
+      // renders the default language in place of the translation and nothing
+      // reports it.
       expect(expected.filter((key) => !actual.has(key))).toEqual([]);
     });
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1439,9 +1439,8 @@ summary {
    brand in dark mode too, mirroring the light-mode primary: brand-600 fill,
    brand-700 hover, white label. The same four cooler hues as light mode
    (cyan/emerald/sky/teal) sit on brand-700/800 so the white text keeps
-   WCAG AA — worst case across all 12 themes is 4.56:1 (amber, at rest).
-   Measured from each theme's --brand-600/700 against white; the figure used
-   to name green, which was a theme file nobody could select. */
+   WCAG AA — worst case across all 12 themes is 4.56:1 (amber, at rest),
+   measured from each theme's --brand-600/700 against white. */
 html.dark .btn-primary.project-live-btn,
 html.dark .mobile-menu-cta-wrap .btn-primary {
   background-color: var(--color-brand-600);

--- a/src/styles/tokens/colors.css
+++ b/src/styles/tokens/colors.css
@@ -7,13 +7,13 @@
 
    To add a new theme: create a file in ../themes/ following the same token
    contract, scope it under html[data-theme="name"], import it below, and add
-   it to `colourThemes` in src/lib/themes.ts — that array is the registry the
-   pickers read, and a file imported here but absent from it ships CSS nobody
-   can reach. green.css was exactly that, and was removed.
+   it to `colourThemes` in src/lib/themes.ts — the registry the pickers read.
+   A file imported here but missing from that array ships CSS nothing can
+   reach.
 
-   All twelve are offered. Curate what the pickers show with `showInSelector`
-   in src/lib/themes.ts rather than by commenting out an import here: a theme
-   left imported keeps working for a visitor who saved it earlier.
+   Curate what the pickers offer with `showInSelector` in src/lib/themes.ts
+   rather than by removing an import here, so a theme a visitor saved earlier
+   keeps working.
    ============================================================================= */
 
 @import './primitives.css';


### PR DESCRIPTION
Comments in the Dockerfile, compose file, workflow, token files and the i18n test described how a defect was found rather than what the code does. The changelog carried the same at entry length.

Both now describe the code and the change.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
