### PR TITLE
Paint the body under Safari's floating toolbar

### DIFF
--- a/src/__tests__/bar-color.test.ts
+++ b/src/__tests__/bar-color.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Holds the home page's toolbar colour to one value in the two places that
+ * carry it.
+ *
+ * Safari on iOS floats a translucent toolbar over the foot of the screen and
+ * tints it from the BODY's background. The home page's hero is a dark gradient
+ * in both colour modes, so in light mode the body underneath is white and a
+ * white strip was drawn across the foot of the hero.
+ *
+ * Two copies, because each is read by something that cannot see the other:
+ *
+ *   1. `data-bar-color` on the hero, whose VALUE the theme script paints onto
+ *      the body while the hero covers the bottom edge of the screen. Read with
+ *      getAttribute rather than out of the cascade, which is not reliable for a
+ *      custom property on iOS Safari.
+ *   2. `--bar-color` in the stylesheet, which ends the hero's gradient. This is
+ *      the one the other is meant to match: the toolbar is right when it
+ *      carries the colour the hero actually finishes on.
+ *
+ * `theme-color` is not one of them — that tag does not reach this surface.
+ *
+ * Nothing else ties these two together, so this does.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf8');
+
+const HOME = 'src/components/pages/views/HomeView.astro';
+const LAYOUT = 'src/layouts/BaseLayout.astro';
+const GLOBAL_CSS = 'src/styles/global.css';
+
+/** The gradient's end stop, which the attribute is a copy of. */
+function stylesheetValue(): string {
+  const css = read(GLOBAL_CSS);
+  const block = css.match(/(?<!\.dark )\.hero-dark-gradient\s*\{([^}]*)\}/);
+  expect(block, `${GLOBAL_CSS} declares .hero-dark-gradient`).not.toBeNull();
+
+  const found = block![1].match(/--bar-color\s*:\s*([^;]+);/);
+  expect(found, '.hero-dark-gradient declares --bar-color').not.toBeNull();
+
+  return found![1].trim();
+}
+
+describe('home page toolbar colour', () => {
+  it('both hero gradients end on the named stop', () => {
+    // Guards the premise rather than the copies: if the hero stopped ending on
+    // this colour, the two values would agree with each other and disagree
+    // with the page. Both rules matter — one is the dark-mode override.
+    const css = read(GLOBAL_CSS);
+    const rules = css.match(/\.hero-dark-gradient\s*\{[^}]*background:\s*linear-gradient\([^;]*;/g);
+    expect(rules, 'the hero declares a gradient background').not.toBeNull();
+    expect(rules!.length).toBe(2);
+    for (const rule of rules!) {
+      expect(rule).toMatch(/var\(--bar-color\)\s*100%/);
+    }
+  });
+
+  it('the hero attribute carries the same value', () => {
+    const found = read(HOME).match(/data-bar-color="([^"]+)"/);
+    expect(found, `${HOME} sets data-bar-color`).not.toBeNull();
+    expect(found![1]).toBe(stylesheetValue());
+  });
+
+  it('the attribute is a value, not a bare flag', () => {
+    // A bare `data-bar-color` renders as "true", which the script would paint
+    // onto the body verbatim. It reads the attribute rather than the cascade,
+    // so nothing else would catch it.
+    expect(read(HOME)).not.toMatch(/data-bar-color(?=[\s>])/);
+  });
+
+  it('the script reads the attribute rather than the cascade', () => {
+    const layout = read(LAYOUT);
+    expect(layout).toMatch(/getAttribute\('data-bar-color'\)/);
+    expect(layout).not.toMatch(/getPropertyValue\('--bar-color'\)/);
+  });
+
+  it('the paint is cleared as well as applied', () => {
+    // The section stops covering the bottom edge as soon as the page moves. A
+    // paint that is never cleared would sit under every section below it.
+    const layout = read(LAYOUT);
+    expect(layout).toMatch(/addEventListener\('scroll', onScroll/);
+    expect(layout).toMatch(/const want = color \|\| '';/);
+  });
+});

--- a/src/components/pages/views/HomeView.astro
+++ b/src/components/pages/views/HomeView.astro
@@ -154,8 +154,16 @@ const basedInDisplay = `${city ?? 'Your City'}${country ? `, ${country}` : ''}`;
   <!-- Hero -->
   <!-- data-header-flip-anchor: the floating header keeps its over-the-hero
        look until this section is nearly out from under it. See the flip
-       threshold in Header.astro. -->
-  <Hero layout="centered" size="xl" class="hero-dark-gradient" fullHeight data-header-flip-anchor>
+       threshold in Header.astro.
+
+       data-bar-color: Safari on iOS floats a translucent toolbar over the foot
+       of the screen and tints it from the BODY's background. This hero is dark
+       in both colour modes while the body under it is white in light mode,
+       which draws a white strip across the foot of it. The theme script paints
+       the body this colour while the hero covers that edge, and clears it
+       after. Same value as --bar-color in global.css, which ends the hero's
+       gradient. See `paintBody` in BaseLayout.astro. -->
+  <Hero layout="centered" size="xl" class="hero-dark-gradient" fullHeight data-header-flip-anchor data-bar-color="#000">
     <Badge slot="badge" variant="brand" pill pulse class="dark:text-brand-200">{hero.badge}</Badge>
 
     {/* 12.6vw fills the mobile column (~95-98% at 320-390px), sized to the

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -186,7 +186,87 @@ if (commentsConfig?.enabled) {
           applyColorTheme(el);
         }
 
+        /**
+         * The bottom edge of what the reader can actually see, in the same
+         * coordinates as getBoundingClientRect.
+         *
+         * `innerHeight` is the layout viewport, and on iOS that runs behind
+         * the browser chrome. `visualViewport` is the visible figure, and it
+         * changes as the toolbar collapses under a scroll. The two are
+         * identical in a desktop browser, so nothing there shows the
+         * difference.
+         */
+        function viewportBottom() {
+          const vv = window.visualViewport;
+          if (vv && vv.height) return vv.offsetTop + vv.height;
+          return window.innerHeight || document.documentElement.clientHeight;
+        }
+
+        /**
+         * The colour an opted-in section wants under Safari's bottom toolbar,
+         * or null when none applies.
+         *
+         * Safari on iOS floats that toolbar over the page and tints it from
+         * the BODY's background. A section that is darker than the body — the
+         * home page's hero, which is a dark gradient in both colour modes —
+         * therefore gets a strip of the body's colour drawn across its foot,
+         * white in light mode.
+         *
+         * The section opts in by carrying the colour as the VALUE of
+         * `data-bar-color`. Read with getAttribute rather than resolved from
+         * the cascade: `getComputedStyle` for a custom property is reliable in
+         * Chromium and is not on iOS Safari, and a version of this that read it
+         * that way fell back to the body's colour on the device — which is the
+         * colour the strip is made of.
+         *
+         * Only while the bottom edge of the screen is inside the section.
+         * Scroll it up past that edge and what sits under the toolbar is
+         * whatever follows, so the body goes back to its own colour.
+         */
+        function sectionColor() {
+          const el = document.querySelector('[data-bar-color]');
+          if (!el) return null;
+
+          const rect = el.getBoundingClientRect();
+          const edge = viewportBottom();
+          if (!(rect.height > 0 && rect.top <= edge && rect.bottom >= edge)) return null;
+
+          return (el.getAttribute('data-bar-color') || '').trim() || null;
+        }
+
+        /**
+         * Paint the body that colour.
+         *
+         * Invisible on the page: it only applies while the section covers the
+         * bottom edge of the screen, and the section is painted over the body
+         * for every pixel the reader can see. Cleared the moment that stops
+         * being true.
+         *
+         * It has to be the body. `<meta name="theme-color">` does not reach
+         * this surface, and neither does a background on <html> or a
+         * `color-scheme` declaration — all three were tried on the device and
+         * left the strip where it was.
+         */
+        function paintBody(color) {
+          if (!document.body) return;
+          if (!document.querySelector('[data-bar-color]')) return;
+
+          const want = color || '';
+          if (document.body.style.backgroundColor !== want) {
+            document.body.style.backgroundColor = want;
+          }
+        }
+
+        function syncBar() {
+          paintBody(sectionColor());
+        }
+
         applyTheme(document.documentElement);
+        syncBar();
+
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', syncBar, { once: true });
+        }
 
         if (!window.__themeListenersInit) {
           window.__themeListenersInit = true;
@@ -205,7 +285,33 @@ if (commentsConfig?.enabled) {
           });
           document.addEventListener('astro:after-swap', function () {
             applyTheme(document.documentElement);
+            syncBar();
           });
+
+          // A section that covers the bottom edge stops covering it as soon as
+          // the page moves, so this has to follow the scroll — otherwise the
+          // body would stay painted over the page below it. One update per
+          // frame at most; the work is a querySelector and a rect.
+          //
+          // iOS collapses and expands its toolbar as you scroll, which moves
+          // the visible bottom edge without firing a window resize, so
+          // visualViewport is listened to as well.
+          let queued = false;
+          function onScroll() {
+            if (queued) return;
+            queued = true;
+            requestAnimationFrame(function () {
+              queued = false;
+              syncBar();
+            });
+          }
+          window.addEventListener('scroll', onScroll, { passive: true });
+          window.addEventListener('resize', onScroll, { passive: true });
+          window.addEventListener('orientationchange', onScroll, { passive: true });
+          if (window.visualViewport) {
+            window.visualViewport.addEventListener('resize', onScroll);
+            window.visualViewport.addEventListener('scroll', onScroll);
+          }
         }
       })();
     </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -340,13 +340,18 @@
 
   /* Hero gradient — dark mode */
   .dark .hero-dark-gradient {
-    background: linear-gradient(to bottom, var(--color-brand-500) 0%, #000 100%);
+    background: linear-gradient(to bottom, var(--color-brand-500) 0%, var(--bar-color) 100%);
   }
 
+  /* The end stop is named because it is also the colour Safari needs under the
+     toolbar it floats over the foot of the screen. One source of truth: change
+     it here and the browser chrome follows. See `paintBody` in BaseLayout, and
+     `data-bar-color` on the hero in HomeView. */
   .hero-dark-gradient {
     position: relative;
     isolation: isolate;
-    background: linear-gradient(to bottom, var(--color-brand-500) 0%, #000 100%);
+    --bar-color: #000;
+    background: linear-gradient(to bottom, var(--color-brand-500) 0%, var(--bar-color) 100%);
   }
   /* The hero panel stays dark in light mode, so its text needs the same
      hierarchy the panel has in dark mode: a near-white heading (91%


### PR DESCRIPTION
Safari on iOS floats a translucent toolbar over the foot of the screen and tints it from the body's background. The home page's hero is a dark gradient in both colour modes, and the body underneath it is white in light mode, so a white strip is drawn across the foot of the hero. In dark mode the body is near-black against the hero's black and nothing shows, which makes it look like a dark-mode-only problem when it is a light-mode one.

The hero declares the colour as the value of `data-bar-color`, and the theme script paints the body that colour while the hero covers the bottom edge of the screen, clearing it as soon as it does not. Invisible on the page: the hero is painted over the body for every pixel the reader can see.

It has to be the body. `<meta name="theme-color">` does not reach this surface, and neither does a background on <html> or a `color-scheme` declaration.

Two details that only matter on the device:

- The colour is read with getAttribute rather than resolved from the cascade. `getComputedStyle` for a custom property is reliable in Chromium and is not on iOS Safari, and a version that read it that way fell back to the body's own colour there — which is the colour the strip is made of.
- The viewport's bottom edge comes from `visualViewport`, not `innerHeight`. On iOS `innerHeight` is the layout viewport, which runs behind the chrome and does not change as the toolbar collapses under a scroll. The two are identical in a desktop browser.

The gradient's end stop is now `--bar-color`, so the stylesheet and the attribute are two copies of one colour rather than two independent values. `src/__tests__/bar-color.test.ts` fails when they drift, when the attribute is written as a bare flag (which renders as "true"), or when the script goes back to reading the cascade.

Verified in Chromium at 430x932 on the home page and /about/, in both colour modes with the theme toggle on light and on system, at the top of the page and scrolled past the hero: the body carries the hero's colour at the top of the home page in all four, is cleared at every scroll position past the hero, and is never touched on /about/.

Chromium draws no browser chrome, so the strip itself cannot appear there — those numbers show the code does what it was built to do in every mode. The behaviour it is built against was confirmed on an iPhone running Safari.

## What does this PR do?

A clear description of the change and why it was made.

Fixes # (issue number, if applicable)

## Type of change

- [ ] Bug fix
- [ ] New feature or component
- [ ] Documentation update
- [ ] Refactor or code quality improvement
- [ ] Other: ___

## Checklist

- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm check` passes with 0 errors
- [ ] `pnpm build` completes successfully
- [ ] I have tested this change in the browser
- [ ] No unnecessary files are included in this PR

## Screenshots (if relevant)

Add before/after screenshots for visual changes.
